### PR TITLE
Fix NullPointerException in ActivationFinisher.

### DIFF
--- a/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/whisk/core/controller/actions/PrimitiveActions.scala
@@ -276,7 +276,7 @@ protected[actions] object ActivationFinisher {
       logging.debug(this, "finisher shutdown")
       preemptiveMsgs.foreach(_.cancel())
       preemptiveMsgs = Vector.empty
-      Option(context).foreach(_.stop(poller))
+      context.stop(poller)
     }
   }
 


### PR DESCRIPTION
The ActivationFinisher's code is racy. If shutdown and postStop are called concurrently a NullPointerException is possible.

Stopping the actor itself should call `postStop` and thus the logic there seems redundant.