### PR TITLE
Use ‘docker.host’ java property as a way to set Docker access for Runtime unit tests

### DIFF
--- a/tests/src/test/scala/actionContainers/ActionContainer.scala
+++ b/tests/src/test/scala/actionContainers/ActionContainer.scala
@@ -109,7 +109,7 @@ object ActionContainer {
     // Test here that this actually works, otherwise throw a somewhat understandable error message
     proc(s"$dockerCmdString info").onComplete {
       case Success((v, _, _)) if (v != 0) =>
-        throw new RuntimeException("""Unable to connect to docker host using '$d' as command string.
+        throw new RuntimeException(s"""Unable to connect to docker host using $dockerCmdString as command string.
           |The docker host is determined using the Java property 'docker.host' or
           |the envirnoment variable 'DOCKER_HOST'. Please verify that one or the
           |other is set for your build/test process.""".stripMargin)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
These changes allow new scripts using docker-gradle-plugin to use Java properties to pass Docker URL information to the test, rather than inferring it based on whisk. properties.  If the ‘docker.host’ java property is not set, the original ‘whisk.properties’ logic is used as a fallback.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

