### PR TITLE
Introduce configurable action blob size limit.

### DIFF
--- a/ansible/roles/controller/tasks/deploy.yml
+++ b/ansible/roles/controller/tasks/deploy.yml
@@ -190,6 +190,10 @@
       "CONFIG_whisk_timeLimit_max": "{{ limit_action_time_max | default() }}"
       "CONFIG_whisk_timeLimit_std": "{{ limit_action_time_std | default() }}"
 
+      "CONFIG_whisk_action_blobSize": "{{ limit_action_blob_size | default() }}"
+      "CONFIG_akka_http_server_parsing_maxContentLength": "{{ limit_action_blob_size | default() }}"
+      "CONFIG_akka_http_client_parsing_maxContentLength": "{{ limit_action_blob_size | default() }}"
+
       "CONFIG_whisk_activation_payload_max":
         "{{ limit_activation_payload | default() }}"
 

--- a/ansible/roles/couchdb/tasks/deploy.yml
+++ b/ansible/roles/couchdb/tasks/deploy.yml
@@ -63,6 +63,19 @@
     force_basic_auth: yes
   when: (couchdb.version|version_compare('2.0','>=')) and (db.instances|int == 1)
 
+- name: setup httpd request entity size limit for database
+  uri:
+    url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_node/couchdb@{{ ansible_host }}/_config/httpd/max_http_request_size"
+    method: PUT
+    body: >
+      "{{ limit_action_blob_size | default('50m') | human_to_bytes }}"
+    body_format: raw
+    status_code: 200
+    user: "{{ db_username }}"
+    password: "{{ db_password }}"
+    force_basic_auth: yes
+  when: (couchdb.version|version_compare('2.0','>=')) and (db.instances|int == 1)
+
 - name: enable the cluster setup mode
   uri:
     url: "{{ db_protocol }}://{{ ansible_host }}:{{ db_port }}/_cluster_setup"

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -207,6 +207,9 @@
       "CONFIG_whisk_timeLimit_min": "{{ limit_action_time_min | default() }}"
       "CONFIG_whisk_timeLimit_max": "{{ limit_action_time_max | default() }}"
       "CONFIG_whisk_timeLimit_std": "{{ limit_action_time_std | default() }}"
+      "CONFIG_whisk_action_blobSize": "{{ limit_action_blob_size | default() }}"
+      "CONFIG_akka_http_server_parsing_maxContentLength": "{{ limit_action_blob_size | default() }}"
+      "CONFIG_akka_http_client_parsing_maxContentLength": "{{ limit_action_blob_size | default() }}"
       "CONFIG_whisk_activation_payload_max": "{{ limit_activation_payload | default() }}"
       "CONFIG_whisk_transactions_header": "{{ transactions.header }}"
 

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -10,7 +10,7 @@ events {
 
 http {
 {# allow large uploads, need to thread proper limit into here #}
-    client_max_body_size 50M;
+    client_max_body_size {{ limit_action_blob_size | default('50m') | upper }};
 
     rewrite_log on;
 {# change log format to display the upstream information #}

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -6,8 +6,15 @@ include "logging"
 
 akka.http {
     client {
-        parsing.illegal-header-warnings = off
-        parsing.max-chunk-size = 50m
+        request-timeout = 65s
+
+        idle-timeout = 70s
+
+        parsing {
+            illegal-header-warnings = off
+            max-chunk-size = 50m
+            max-content-length = 50m
+        }
     }
 
     host-connection-pool {
@@ -166,6 +173,11 @@ whisk {
         min = 128 m
         max = 512 m
         std = 256 m
+    }
+
+    # action blob size limit configuration
+    action {
+        blob-size = 48 m
     }
 
     # action log-limit configuration

--- a/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/whisk/core/WhiskConfig.scala
@@ -218,6 +218,7 @@ object ConfigKeys {
   val memory = "whisk.memory"
   val timeLimit = "whisk.time-limit"
   val logLimit = "whisk.log-limit"
+  val actionBlobSize = "whisk.action.blob-size"
   val activation = "whisk.activation"
   val activationPayload = s"$activation.payload"
   val userEvents = "whisk.user-events"

--- a/common/scala/src/main/scala/whisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/whisk/core/entity/Exec.scala
@@ -19,7 +19,6 @@ package whisk.core.entity
 
 import java.nio.charset.StandardCharsets
 
-import scala.language.postfixOps
 import scala.util.matching.Regex
 
 import spray.json._
@@ -29,6 +28,8 @@ import whisk.core.entity.ExecManifest._
 import whisk.core.entity.size.SizeInt
 import whisk.core.entity.size.SizeOptionString
 import whisk.core.entity.size.SizeString
+import whisk.core.ConfigKeys
+import pureconfig.loadConfigOrThrow
 
 /**
  * Exec encodes the executable details of an action. For black
@@ -212,7 +213,9 @@ protected[core] case class SequenceExecMetaData(components: Vector[FullyQualifie
 
 protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
 
-  val sizeLimit = 48 MB
+  import whisk.core.entity.size.pureconfigReader
+
+  val sizeLimit = loadConfigOrThrow[ByteSize](ConfigKeys.actionBlobSize)
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic
@@ -342,7 +345,7 @@ protected[core] object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol
 
 protected[core] object ExecMetaDataBase extends ArgNormalizer[ExecMetaDataBase] with DefaultJsonProtocol {
 
-  val sizeLimit = 48 MB
+  val sizeLimit = Exec.sizeLimit
 
   // The possible values of the JSON 'kind' field for certain runtimes:
   // - Sequence because it is an intrinsic

--- a/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -18,6 +18,7 @@
 package whisk.core.containerpool.docker
 
 import akka.actor.ActorSystem
+
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -30,11 +31,14 @@ import whisk.core.containerpool.ContainerFactoryProvider
 import whisk.core.entity.ByteSize
 import whisk.core.entity.ExecManifest
 import whisk.core.entity.InstanceId
+
 import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
+
 import pureconfig._
 import whisk.core.ConfigKeys
 import whisk.core.containerpool.ContainerArgsConfig
+import whisk.core.entity.Exec.sizeLimit
 
 case class DockerContainerFactoryConfig(useRunc: Boolean)
 
@@ -70,7 +74,7 @@ class DockerContainerFactory(instance: InstanceId,
       userProvidedImage = userProvidedImage,
       memory = memory,
       cpuShares = cpuShares,
-      environment = Map("__OW_API_HOST" -> config.wskApiHost),
+      environment = Map("__OW_API_HOST" -> config.wskApiHost, "__OW_ACTION_BLOB_SIZE" -> s"${sizeLimit.toMB}"),
       network = containerArgsConfig.network,
       dnsServers = containerArgsConfig.dnsServers,
       name = Some(name),

--- a/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/whisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -30,6 +30,7 @@ import whisk.common.TransactionId
 import whisk.core.containerpool.Container
 import whisk.core.containerpool.ContainerFactory
 import whisk.core.containerpool.ContainerFactoryProvider
+import whisk.core.entity.Exec.sizeLimit
 import whisk.core.entity.ByteSize
 import whisk.core.entity.ExecManifest.ImageName
 import whisk.core.entity.InstanceId
@@ -78,7 +79,7 @@ class KubernetesContainerFactory(label: String, config: WhiskConfig)(implicit ac
       image,
       userProvidedImage,
       memory,
-      environment = Map("__OW_API_HOST" -> config.wskApiHost),
+      environment = Map("__OW_API_HOST" -> config.wskApiHost, "__OW_ACTION_BLOB_SIZE" -> s"${sizeLimit.toMB}"),
       labels = Map("invoker" -> label))
   }
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,3 +57,30 @@ Using docker-runc obtains significantly better performance, but requires that th
 2017-09-29T20:15:54.551Z] [ERROR] [#sid_102] [RuncClient] code: 1, stdout: , stderr: json: cannot unmarshal object into Go value of type []string [marker:invoker_runc.pause_error:6830148:259]
 ```
 When a docker-runc operations results in an error, the container will be killed by the invoker.  This results in missed opportunities for container reuse and poor performance.  Setting INVOKER_USE_RUNC to false can be used as a workaround until proper usage of docker-runc can be configured for the deployment.
+
+# System configuration for large size actions.
+
+Notice that current OpenWhisk implementation is still not suitable to deal with large size action. The recommended way is to refactor applications into smaller granularities.
+
+To create a large size action, you have to build the system with large size tolerable limits.
+
+## Size limit
+
+Set `limit_action_code_size` for nginx, controller, invoker and database (only support couchdb, currently).
+
+## Timeout limit
+
+The timeout depends on how large the system resource is. Therefore, several timeout limits will be configured manually and separately. Here's some config you might need to set:
+
+* Internal http timeout: `akka.http.[client/server].[request-timeout/idle-timeout]`.
+* Database query timeout: i.e. `query_server_config.os_process_limit` in couchdb.
+* Nginx: `proxy_read_timeout`.
+* [Aaction invocation timeout](./reference.md#per-action-timeout-ms-default-60s)
+
+## System tunning
+
+Finally, you have to make sure the system have enough resources, including:
+
+* JVM heap size: `controller_heap` and `invoker_heap`.
+* If you are running OpenWhisk in sandboxed environment (i.e. VMs or Docker for mac), make sure the resource is allocate sufficiently.
+* [Action memory limit](./reference.md#per-action-memory-mb-default-256mb)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -465,7 +465,7 @@ The following table lists the default limits for actions.
 | logs | a container is not allowed to write more than N MB to stdout | per action | MB | 10 |
 | concurrent | no more than N activations may be submitted per namespace either executing or queued for execution | per namespace | number | 100 |
 | minuteRate | no more than N activations may be submitted per namespace per minute | per namespace | number | 120 |
-| codeSize | the maximum size of the actioncode | not configurable, limit per action | MB | 48 |
+| codeSize | the maximum size of the actioncode | configurable during deployment, limit per action | MB | 48 |
 | parameters | the maximum size of the parameters that can be attached | not configurable, limit per action/package/trigger | MB | 1 |
 | result | the maximum size of the action result | not configurable, limit per action | MB | 1 |
 
@@ -484,8 +484,8 @@ The following table lists the default limits for actions.
 * A user can change the limit when creating or updating the action.
 * Logs that exceed the set limit are truncated and a warning is added as the last output of the activation to indicate that the activation exceeded the set log limit.
 
-### Per action artifact (MB) (Fixed: 48MB)
-* The maximum code size for the action is 48MB.
+### Per action artifact (MB) (Default: 48MB)
+* The maximum code size for the action is fixed on deployment.
 * It is recommended for a JavaScript action to use a tool to concatenate all source code including dependencies into a single bundled file.
 
 ### Per activation payload size (MB) (Fixed: 1MB)

--- a/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
+++ b/tests/src/test/scala/whisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
@@ -42,6 +42,7 @@ import whisk.core.containerpool.docker.RuncApi
 import whisk.core.entity.ExecManifest
 import whisk.core.entity.InstanceId
 import whisk.core.entity.size._
+import whisk.core.entity.Exec.sizeLimit
 
 @RunWith(classOf[JUnitRunner])
 class DockerContainerFactoryTests
@@ -81,6 +82,8 @@ class DockerContainerFactoryTests
           "net1",
           "-e",
           "__OW_API_HOST=://:",
+          "-e",
+          s"__OW_ACTION_BLOB_SIZE=${sizeLimit.toMB}",
           "--dns",
           "dns1",
           "--dns",


### PR DESCRIPTION
I think this pr still needs some improvements, but I need some feedback on current implementation.

This pr makes the action blob size configurable with some docs for deployment and system tuning.

I’ve tested for 200MB zip file for execution,

Required changes contain two kind of limitations:
1. Size limit.
2. Timeout limit.

Size limit:

1. Nginx: `http.client_max_body_size`
2. Akka: `http.[client/server].parsing.max-content-length`
3. Internal size limitation passed by pure config. (remove hardcoded limit)
4. Database: only support on couchdb currently, -> `httpd.max_http_request_size`

All these can be done with same config —> `limit_action_blob_size`

Timeout:
1. Akka: http.[client/server].[request-timeout/idle-timeout]
2. Couchdb: query_server_config.os_process_limit (in sec)
3. Action invocation timeout.

### Discussion:

1. To make the size limit configurable, requires some changes in runtimes. [sample-change-in-node](https://github.com/tz70s/incubator-openwhisk-runtime-nodejs/commit/4f1f562c5de9827fd296521972928a228a5d436d). Invoker will pass the size limit as environment variables to it, same as `__OW_API_HOST`. Is this appropriate?

2. I didn't add any timeout related variables passed from ansible. There might be still some efforts for user to configure correctly. But the behavior of timeout depends on system resources, to avoid potential risk, using ad-hoc configuration currently.

3. Due to same config passed into `akka.http.[client/server].xxx`, I think that would be nice to raise them to upper level -> i.e. `akka.http.parsing.max-content-length`. User can override it on either server or client config, but I'm not sure whether there's any risk or not?

4. See the system tuning section: to test with large action blob size, needs lots of changes for system tuning in current travis build. Therefore, no additional tests are provided now.

5. After testing, I think the large action size is still not a recommended way, seems current implementation of OpenWhisk requires lots of optimization to support it. Therefore, I've mentioned this into doc.

6. There's another way to config database's `request-size-limit` via controller side by using remote (http) APIs, might be better by using same abstraction for all artifact store.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] Opened issue to propose and discuss this change (#3712)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.