### PR TITLE
Parameterize Invocations per Minute limit

### DIFF
--- a/tools/travis/runSystemTests.sh
+++ b/tools/travis/runSystemTests.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+SCRIPTDIR=$(cd "$(dirname "$0")" && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 
 cd $ROOTDIR/tools/travis
@@ -27,10 +27,10 @@ cd $ROOTDIR/tools/travis
 export ORG_GRADLE_PROJECT_testSetName="REQUIRE_SYSTEM"
 export GRADLE_COVERAGE=true
 
-./setupPrereq.sh /ansible/files/runtimes-nodeonly.json
+./setupPrereq.sh /ansible/files/runtimes-nodeonly.json 240
 
 ./distDocker.sh
 
-./setupSystem.sh /ansible/files/runtimes-nodeonly.json
+./setupSystem.sh /ansible/files/runtimes-nodeonly.json 240
 
 ./runTests.sh

--- a/tools/travis/setupPrereq.sh
+++ b/tools/travis/setupPrereq.sh
@@ -20,9 +20,10 @@ set -e
 
 # Build script for Travis-CI.
 SECONDS=0
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 ROOTDIR="$SCRIPTDIR/../.."
 RUNTIMES_MANIFEST=${1:-"/ansible/files/runtimes.json"}
+LIMIT_IPM=${2:-60}
 
 cd $ROOTDIR/ansible
 
@@ -32,5 +33,8 @@ $ANSIBLE_CMD couchdb.yml
 $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD wipe.yml
 
-$ANSIBLE_CMD properties.yml -e manifest_file="$RUNTIMES_MANIFEST"
+$ANSIBLE_CMD properties.yml \
+  -e "{ \"manifest_file\": \"$RUNTIMES_MANIFEST\",
+      \"invoker_use_runc\": false,
+      \"limit_invocations_per_minute\": $LIMIT_IPM }"
 echo "Time taken for ${0##*/} is $SECONDS secs"

--- a/tools/travis/setupSystem.sh
+++ b/tools/travis/setupSystem.sh
@@ -20,13 +20,17 @@ set -e
 
 # Build script for Travis-CI.
 SECONDS=0
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+SCRIPTDIR=$(cd "$(dirname "$0")" && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 RUNTIMES_MANIFEST=${1:-"/ansible/files/runtimes.json"}
+LIMIT_IPM=${2:-60}
 
 cd $ROOTDIR/ansible
 
-$ANSIBLE_CMD openwhisk.yml -e manifest_file="$RUNTIMES_MANIFEST"
+$ANSIBLE_CMD openwhisk.yml \
+  -e "{ \"manifest_file\": \"$RUNTIMES_MANIFEST\",
+      \"invoker_use_runc\": false,
+      \"limit_invocations_per_minute\": $LIMIT_IPM }"
 $ANSIBLE_CMD apigateway.yml
 $ANSIBLE_CMD routemgmt.yml
 


### PR DESCRIPTION
On faster Travis machines, the System Test fails because it runs into the Invoker's Invocations Per Minute limit.  While this is a Good Thing in general, it's quite frustrating during a system test.  This PR adds parameterization of the Invocations Per Minute limit to the test scripts so that the system test can raise that limit and avoid spurious failures.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [X] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

