### PR TITLE
Make intermittently failing concurrencyTests more stable.

### DIFF
--- a/tests/dat/actions/concurrent.js
+++ b/tests/dat/actions/concurrent.js
@@ -1,6 +1,8 @@
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor
 // license agreements; and to You under the Apache License, Version 2.0.
 
+const Promise = require('bluebird');
+
 let counter = 0;
 let requestCount = undefined;
 let interval = 100;
@@ -17,6 +19,10 @@ function main(args) {
             setTimeout(function() {
                 checkRequests(args, resolve, reject);
             }, interval);
+        }).finally(() => {
+            // Before leaving the container, decrement the counter again. But wait twice the interval, before decrementing it. Otherwise, the
+            // other requests might not realise, that all requests were inside the container.
+            setTimeout(() => counter--, 2 * interval);
         });
     }
 


### PR DESCRIPTION
The test `Action concurrency limits should execute activations sequentially when concurrency = 1` fails intermittently. The reason is, that 4 activations are started in parallel.
If there is a delay to one of these activations, the last activation will reuse an existing container, which has already an incremented counter.
This PR changes the action to decrement the counter before leaving the action.

This will also enhance local debugging, as the warm container can be reused.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.