### PR TITLE
Invoker backpressure

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -91,6 +91,9 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
     }
     compile ('com.amazonaws:aws-java-sdk-cloudfront:1.11.517')
+    compile 'com.lightbend.akka.management:akka-management-cluster-bootstrap_2.12:0.11.0'
+    compile 'com.lightbend.akka.discovery:akka-discovery-kubernetes-api_2.12:0.11.0'
+    compile 'com.lightbend.akka.discovery:akka-discovery-marathon-api_2.12:0.11.0'
     scoverage gradle.scoverage.deps
 
     //Following constraints ensure that akka related transitive dependencies match the

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -392,6 +392,7 @@ object LoggingMarkers {
   def LOADBALANCER_INVOKER_STATUS_CHANGE(state: String) =
     LogMarkerToken(loadbalancer, "invokerState", counter, Some(state), Map("state" -> state))(MeasurementUnit.none)
   val LOADBALANCER_ACTIVATION_START = LogMarkerToken(loadbalancer, "activations", counter)(MeasurementUnit.none)
+  val LOADBALANCER_SYSTEM_ERRORS = LogMarkerToken(loadbalancer, "systemErrors", counter)(MeasurementUnit.none)
 
   def LOADBALANCER_ACTIVATIONS_INFLIGHT(controllerInstance: ControllerInstanceId) = {
     if (TransactionId.metricsKamonTags)

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -451,6 +451,8 @@ object LoggingMarkers {
     LogMarkerToken(containerPool, "resourceError", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_RESCHEDULED_ACTIVATION =
     LogMarkerToken(containerPool, "rescheduledActivation", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_RUNBUFFER_COUNT =
+    LogMarkerToken(containerPool, "runBufferCount", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_RUNBUFFER_SIZE =
     LogMarkerToken(containerPool, "runBufferSize", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_ACTIVE_COUNT =

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -459,6 +459,10 @@ object LoggingMarkers {
     LogMarkerToken(containerPool, "activeCount", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_ACTIVE_SIZE =
     LogMarkerToken(containerPool, "activeSize", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_PREWARM_COUNT =
+    LogMarkerToken(containerPool, "prewarmCount", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_PREWARM_SIZE =
+    LogMarkerToken(containerPool, "prewarmSize", counter)(MeasurementUnit.none)
   val CLUSTER_RESOURCES_IDLES_COUNT =
     LogMarkerToken(clusterResourceManager, "idlesCount", counter)(MeasurementUnit.none)
   val CLUSTER_RESOURCES_IDLES_SIZE =

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -350,6 +350,8 @@ object LoggingMarkers {
   private val kafka = "kafka"
   private val loadbalancer = "loadbalancer"
   private val containerClient = "containerClient"
+  private val containerPool = "containerPool"
+  private val clusterResourceManager = "clusterResources"
 
   /*
    * Controller related markers
@@ -445,6 +447,16 @@ object LoggingMarkers {
       MeasurementUnit.none)
   val CONTAINER_CLIENT_RETRIES =
     LogMarkerToken(containerClient, "retries", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_RESOURCE_ERROR =
+    LogMarkerToken(containerPool, "resourceError", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_RESCHEDULED_ACTIVATION =
+    LogMarkerToken(containerPool, "rescheduledActivation", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_TOTAL_MEM =
+    LogMarkerToken(clusterResourceManager, "totalMemory", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_MAX_MEM =
+    LogMarkerToken(clusterResourceManager, "maxMemory", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_NODE_COUNT =
+    LogMarkerToken(clusterResourceManager, "nodes", counter)(MeasurementUnit.none)
 
   val INVOKER_TOTALMEM_BLACKBOX = LogMarkerToken(loadbalancer, "totalCapacityBlackBox", counter)(MeasurementUnit.none)
   val INVOKER_TOTALMEM_MANAGED = LogMarkerToken(loadbalancer, "totalCapacityManaged", counter)(MeasurementUnit.none)

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -451,6 +451,21 @@ object LoggingMarkers {
     LogMarkerToken(containerPool, "resourceError", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_RESCHEDULED_ACTIVATION =
     LogMarkerToken(containerPool, "rescheduledActivation", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_RUNBUFFER_SIZE =
+    LogMarkerToken(containerPool, "runBufferSize", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_ACTIVE_COUNT =
+    LogMarkerToken(containerPool, "activeCount", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_ACTIVE_SIZE =
+    LogMarkerToken(containerPool, "activeSize", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_IDLES_COUNT =
+    LogMarkerToken(clusterResourceManager, "idlesCount", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_IDLES_SIZE =
+    LogMarkerToken(clusterResourceManager, "idlesSize", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_RESERVED_COUNT =
+    LogMarkerToken(clusterResourceManager, "reservedCount", counter)(MeasurementUnit.none)
+  val CLUSTER_RESOURCES_RESERVED_SIZE =
+    LogMarkerToken(clusterResourceManager, "reservedSize", counter)(MeasurementUnit.none)
+
   val CLUSTER_RESOURCES_TOTAL_MEM =
     LogMarkerToken(clusterResourceManager, "totalMemory", counter)(MeasurementUnit.none)
   val CLUSTER_RESOURCES_MAX_MEM =

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -71,7 +71,7 @@ trait Container {
 
   implicit protected val as: ActorSystem
   protected val id: ContainerId
-  protected val addr: ContainerAddress
+  protected[core] val addr: ContainerAddress
   protected implicit val logging: Logging
   protected implicit val ec: ExecutionContext
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -246,6 +246,9 @@ case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
 /** Indicates an error while initializing a container */
 case class InitializationError(interval: Interval, response: ActivationResponse) extends Exception(response.toString)
 
+/** Indicates a resource availability error */
+case class ClusterResourceError(required: ByteSize, available: ByteSize) extends ContainerError("inadequate resources")
+
 case class Interval(start: Instant, end: Instant) {
   def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -23,7 +23,6 @@ import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstanceId}
 import org.apache.openwhisk.spi.Spi
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 import scala.math.max
 
 case class ContainerArgsConfig(network: String,
@@ -32,16 +31,12 @@ case class ContainerArgsConfig(network: String,
                                dnsOptions: Seq[String] = Seq.empty,
                                extraArgs: Map[String, Set[String]] = Map.empty)
 
-case class ClusterManagedCapacityMonitor(idlePruneUseRatio: Double,
-                                         idleTimeout: FiniteDuration,
-                                         idleRemoveSize: ByteSize)
-
 case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
                                clusterManagedResources: Boolean,
-                               clusterManagedResourceMaxStarts: Int,
-                               clusterManagedCapacityMonitor: ClusterManagedCapacityMonitor) {
+                               useClusterBootstrap: Boolean,
+                               clusterManagedResourceMaxStarts: Int) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -32,7 +32,10 @@ case class ContainerArgsConfig(network: String,
                                dnsOptions: Seq[String] = Seq.empty,
                                extraArgs: Map[String, Set[String]] = Map.empty)
 
-case class ContainerPoolConfig(userMemory: ByteSize, concurrentPeekFactor: Double, akkaClient: Boolean) {
+case class ContainerPoolConfig(userMemory: ByteSize,
+                               concurrentPeekFactor: Double,
+                               akkaClient: Boolean,
+                               clusterManagedResources: Boolean) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -35,7 +35,8 @@ case class ContainerArgsConfig(network: String,
 case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
-                               clusterManagedResources: Boolean) {
+                               clusterManagedResources: Boolean,
+                               clusterManagedResourceMaxStarts: Int) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -22,8 +22,8 @@ import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstanceId}
 import org.apache.openwhisk.spi.Spi
-
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.math.max
 
 case class ContainerArgsConfig(network: String,
@@ -32,11 +32,16 @@ case class ContainerArgsConfig(network: String,
                                dnsOptions: Seq[String] = Seq.empty,
                                extraArgs: Map[String, Set[String]] = Map.empty)
 
+case class ClusterManagedCapacityMonitor(idlePruneUseRatio: Double,
+                                         idleTimeout: FiniteDuration,
+                                         idleRemoveSize: ByteSize)
+
 case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
                                clusterManagedResources: Boolean,
-                               clusterManagedResourceMaxStarts: Int) {
+                               clusterManagedResourceMaxStarts: Int,
+                               clusterManagedCapacityMonitor: ClusterManagedCapacityMonitor) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -23,6 +23,7 @@ import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstanceId}
 import org.apache.openwhisk.spi.Spi
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.math.max
 
 case class ContainerArgsConfig(network: String,
@@ -36,7 +37,8 @@ case class ContainerPoolConfig(userMemory: ByteSize,
                                akkaClient: Boolean,
                                clusterManagedResources: Boolean,
                                useClusterBootstrap: Boolean,
-                               clusterManagedResourceMaxStarts: Int) {
+                               clusterManagedResourceMaxStarts: Int,
+                               clusterManagedIdleGrace: FiniteDuration) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Size.scala
@@ -30,22 +30,33 @@ object SizeUnits extends Enumeration {
     def toBytes(n: Long): Long
     def toKBytes(n: Long): Long
     def toMBytes(n: Long): Long
+    def toGBytes(n: Long): Long
   }
 
   case object BYTE extends Unit {
     def toBytes(n: Long): Long = n
     def toKBytes(n: Long): Long = n / 1024
     def toMBytes(n: Long): Long = n / 1024 / 1024
+    def toGBytes(n: Long): Long = n / 1024 / 1024 / 1024
   }
   case object KB extends Unit {
     def toBytes(n: Long): Long = n * 1024
     def toKBytes(n: Long): Long = n
     def toMBytes(n: Long): Long = n / 1024
+    def toGBytes(n: Long): Long = n / 1024 / 1024
+
   }
   case object MB extends Unit {
     def toBytes(n: Long): Long = n * 1024 * 1024
     def toKBytes(n: Long): Long = n * 1024
     def toMBytes(n: Long): Long = n
+    def toGBytes(n: Long): Long = n / 1024
+  }
+  case object GB extends Unit {
+    def toBytes(n: Long): Long = n * 1024 * 1024 * 1024
+    def toKBytes(n: Long): Long = n * 1024 * 1024
+    def toMBytes(n: Long): Long = n * 1024
+    def toGBytes(n: Long): Long = n
   }
 }
 
@@ -98,13 +109,14 @@ case class ByteSize(size: Long, unit: SizeUnits.Unit) extends Ordered[ByteSize] 
       case SizeUnits.BYTE => s"$size B"
       case SizeUnits.KB   => s"$size KB"
       case SizeUnits.MB   => s"$size MB"
+      case SizeUnits.GB   => s"$size GB"
     }
   }
 }
 
 object ByteSize {
-  private val regex = """(?i)\s?(\d+)\s?(MB|KB|B|M|K)\s?""".r.pattern
-  protected[entity] val formatError = """Size Unit not supported. Only "B", "K[B]" and "M[B]" are supported."""
+  private val regex = """(?i)\s?(\d+)\s?(GB|MB|KB|B|G|M|K)\s?""".r.pattern
+  protected[entity] val formatError = """Size Unit not supported. Only "B", "K[B]", "M[B]" and "G[B]" are supported."""
 
   def fromString(sizeString: String): ByteSize = {
     val matcher = regex.matcher(sizeString)
@@ -114,6 +126,7 @@ object ByteSize {
         case 'B' => SizeUnits.BYTE
         case 'K' => SizeUnits.KB
         case 'M' => SizeUnits.MB
+        case 'G' => SizeUnits.GB
       }
 
       ByteSize(size, unit)
@@ -163,9 +176,11 @@ trait SizeConversion {
   def B = sizeIn(SizeUnits.BYTE)
   def KB = sizeIn(SizeUnits.KB)
   def MB = sizeIn(SizeUnits.MB)
+  def GB: ByteSize = sizeIn(SizeUnits.GB)
   def bytes = B
   def kilobytes = KB
   def megabytes = MB
+  def gigabytes: ByteSize = GB
 
   def sizeInBytes = sizeIn(SizeUnits.BYTE)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
@@ -188,7 +188,7 @@ object JsonFormatters extends DefaultJsonProtocol {
 }
 
 class MesosTask(override protected val id: ContainerId,
-                override protected val addr: ContainerAddress,
+                override protected[core] val addr: ContainerAddress,
                 override protected implicit val ec: ExecutionContext,
                 override protected implicit val logging: Logging,
                 override protected val as: ActorSystem,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
@@ -43,7 +43,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * (external log collection and retrieval must be enabled via LogStore SPI to expose logs to wsk cli)
  */
 class YARNTask(override protected val id: ContainerId,
-               override protected val addr: ContainerAddress,
+               override protected[core] val addr: ContainerAddress,
                override protected val ec: ExecutionContext,
                override protected val logging: Logging,
                override protected val as: ActorSystem,

--- a/common/scala/src/main/scala/org/apache/openwhisk/utils/Events.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/utils/Events.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.utils
+
+/** NodeStats captures resource potential availability within a cluster. */
+case class NodeStats(mem: Double, cpu: Double, ports: Int)
+case class NodeStatsUpdate(stats: Map[String, NodeStats])

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -39,9 +39,6 @@ repositories {
 
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
-    compile 'com.lightbend.akka.management:akka-management-cluster-bootstrap_2.12:0.11.0'
-    compile 'com.lightbend.akka.discovery:akka-discovery-kubernetes-api_2.12:0.11.0'
-    compile 'com.lightbend.akka.discovery:akka-discovery-marathon-api_2.12:0.11.0'
     compile project(':common:scala')
     compile project(':core:invoker')
     scoverage gradle.scoverage.deps

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -257,6 +257,12 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
         }
 
         logging.info(this, s"${if (!forced) "received" else "forced"} completion ack for '$aid'")(tid)
+
+        //track overall count of system errors
+        if (isSystemError) {
+          MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_SYSTEM_ERRORS)
+        }
+
         // Active acks that are received here are strictly from user actions - health actions are not part of
         // the load balancer's activation map. Inform the invoker pool supervisor of the user action completion.
         // guard this

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -63,6 +63,7 @@ whisk {
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
     cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
     use-cluster-bootstrap: false # if true, use akka boostrap to discover cluster nodes
+    cluster-managed-idle-grace: 5 minutes # time container is allowed to idle before being eligible for removal during ReleaseFree cycle
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -63,9 +63,10 @@ whisk {
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
     cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
     cluster-managed-capacity-monitor { //config to cause accelerated pruning of idles once cluster capacity ratio is reached
-      idle-prune-use-ratio=0.75 //begin freeing idles when we see less than this ratio of hosts (compared to max number of hosts ever seen)
+      idle-prune-use-ratio = 0.75 //begin freeing idles when we see less than this ratio of hosts (compared to max number of hosts ever seen)
       idle-timeout = 10 seconds //only remove idles > 10s unused
       idle-remove-size = 4096 M //remove 4GB at a time
+    }
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -62,6 +62,10 @@ whisk {
     akka-client:  false # If true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
     cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
+    cluster-managed-capacity-monitor { //config to cause accelerated pruning of idles once cluster capacity ratio is reached
+      idle-prune-use-ratio=0.75 //begin freeing idles when we see less than this ratio of hosts (compared to max number of hosts ever seen)
+      idle-timeout = 10 seconds //only remove idles > 10s unused
+      idle-remove-size = 4096 M //remove 4GB at a time
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -62,11 +62,7 @@ whisk {
     akka-client:  false # If true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
     cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
-    cluster-managed-capacity-monitor { //config to cause accelerated pruning of idles once cluster capacity ratio is reached
-      idle-prune-use-ratio = 0.75 //begin freeing idles when we see less than this ratio of hosts (compared to max number of hosts ever seen)
-      idle-timeout = 10 seconds //only remove idles > 10s unused
-      idle-remove-size = 4096 M //remove 4GB at a time
-    }
+    useClusterBootstrap: false # if true, use akka boostrap to discover cluster nodes
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -61,6 +61,7 @@ whisk {
     concurrent-peek-factor: 0.5 # Factor used to limit message peeking: 0 < factor <= 1.0 - larger number improves concurrent processing, but increases risk of message loss during invoker crash
     akka-client:  false # If true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
+    cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -58,8 +58,9 @@ whisk {
 
   container-pool {
     user-memory: 1024 m
-    concurrent-peek-factor: 0.5 #factor used to limit message peeking: 0 < factor <= 1.0 - larger number improves concurrent processing, but increases risk of message loss during invoker crash
-    akka-client:  false # if true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
+    concurrent-peek-factor: 0.5 # Factor used to limit message peeking: 0 < factor <= 1.0 - larger number improves concurrent processing, but increases risk of message loss during invoker crash
+    akka-client:  false # If true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
+    cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
   }
 
   kubernetes {

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -62,7 +62,7 @@ whisk {
     akka-client:  false # If true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
     cluster-managed-resources: false # If false, container-pool.user-memory is used to determine pool capacity to launch containers, otherwise, ContainerPool.clusterCanLaunch() is used
     cluster-managed-resource-max-starts: 20 # In cluster managed resource case, limit the number of concurrent container starts to this value.
-    useClusterBootstrap: false # if true, use akka boostrap to discover cluster nodes
+    use-cluster-bootstrap: false # if true, use akka boostrap to discover cluster nodes
   }
 
   kubernetes {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -257,10 +257,8 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
         MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
         MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_IDLES_COUNT, localUnused.size)
         val unusedSize = localUnused.map(_._2.memoryLimit.toMB).sum
-        logging.debug(this, s"metrics invoker ${myId} (self) has ${lastUnused.size} unused (${unusedSize}MB)")
-        logging.debug(
-          this,
-          s"metrics invoker ${myId} (self) has ${localReservations.size} reserved (${reservedSize}MB)")
+        logging.info(this, s"metrics invoker ${myId} (self) has ${localUnused.size} unused (${unusedSize}MB)")
+        logging.info(this, s"metrics invoker ${myId} (self) has ${localReservations.size} reserved (${reservedSize}MB)")
         MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_IDLES_SIZE, unusedSize)
         MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_RESERVED_COUNT, localReservations.size)
         MetricEmitter.emitGaugeMetric(

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -125,6 +125,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
       val localRes = localReservations.values.map(_.size) //active local reservations
       val remoteRes = remoteReservations.values.toList.flatten.map(_.size) //remote/stale reservations
 
+      //TODO: consider potential to fit each reservation, then required memory for this action.
       val allRes = localRes ++ remoteRes
       //make sure there is at least one node with unreserved mem > memory
       val canLaunch = clusterHasPotentialMemoryCapacity(memory.toMB, allRes) //consider all reservations blocking till they are removed during NodeStatsUpdate

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -266,7 +266,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
         }
         MetricEmitter.emitHistogramMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
 
-        if (!prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers
+        if (stats.nonEmpty && !prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers
           prewarmsInitialized = true
           logging.info(this, "initializing prewarmpool after stats recevied")
           //        initPrewarms()

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -190,14 +190,14 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
     val mediator = DistributedPubSub(system).mediator
     val replicator = DistributedData(system).replicator
 
-    mediator ! Put(clusterPoolData) //allow point to point messaging based on the actor name: use Send(/user/<myname>) to send messages to me in the cluster
+    mediator ! Put(self) //allow point to point messaging based on the actor name: use Send(/user/<myname>) to send messages to me in the cluster
     //subscribe to invoker ids changes (need to setup additional keys based on each invoker arriving)
-    replicator ! Subscribe(InvokerIdsKey, clusterPoolData)
+    replicator ! Subscribe(InvokerIdsKey, self)
     //add this invoker to ids list
     replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ + (myId))
 
     logging.info(this, "subscribing to NodeStats updates")
-    system.eventStream.subscribe(clusterPoolData, classOf[NodeStatsUpdate])
+    system.eventStream.subscribe(self, classOf[NodeStatsUpdate])
 
     //track the recent updates, so that we only send updates after changes (since this is done periodically, not on each data change)
     var lastUnused: List[RemoteContainerRef] = List.empty

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -262,7 +262,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
         MetricEmitter.emitHistogramMetric(
           LoggingMarkers.CLUSTER_RESOURCES_MAX_MEM,
           stats.values.maxBy(_.mem).mem.toLong)
-        MetricEmitter.emitCounterMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
+        MetricEmitter.emitHistogramMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
 
         if (!prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers
           prewarmsInitialized = true

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -186,7 +186,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
     localReservations
       .count({ case (_, state) => state.size.toMB > 0 }) < config.clusterManagedResourceMaxStarts //only positive reservations affect ability to start
 
-  class ContainerPoolClusterData(instanceId: InvokerInstanceId, pool: ActorRef) extends Actor {
+  class ContainerPoolClusterData(instanceId: InvokerInstanceId, containerPool: ActorRef) extends Actor {
     implicit val cluster = Cluster(system)
     implicit val ec = context.dispatcher
     val mediator = DistributedPubSub(system).mediator
@@ -247,7 +247,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
         logging.error(this, s"failed to update replicated data: $f")
       case RequestReleaseFree(id, refs) =>
         val remotePath = s"/user/${ContainerPoolClusterData.clusterPoolActorName(id)}"
-        logging.info(this, s"notifying invoker ${remotePath}")
+        logging.info(this, s"notifying invoker ${id} to free ${refs.size} containers")
         mediator ! Send(path = remotePath, msg = ReleaseFree(refs), localAffinity = false)
       case NodeStatsUpdate(stats) =>
         logging.info(
@@ -268,19 +268,19 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
           prewarmsInitialized = true
           logging.info(this, "initializing prewarmpool after stats recevied")
           //        initPrewarms()
-          pool ! InitPrewarms
+          containerPool ! InitPrewarms
         }
 
         //only signal updates (to pool or replicator) in case things have changed
         if (lastStats != stats) {
           lastStats = stats
-          pool ! ResourceUpdate
+          containerPool ! ResourceUpdate
         }
 
       case r: ReleaseFree =>
         logging.info(this, s"got releasefree from ${sender()}")
         //forward to the pool
-        pool.forward(r)
+        containerPool.forward(r)
       case c @ Changed(LWWRegisterKey(idStr)) =>
         val resRegex = "reservation(\\d+)".r
         val unusedRegex = "unused(\\d+)".r

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.ddata.DistributedData
+import akka.cluster.ddata.LWWRegister
+import akka.cluster.ddata.LWWRegisterKey
+import akka.cluster.ddata.ORSet
+import akka.cluster.ddata.ORSetKey
+import akka.cluster.ddata.Replicator.Changed
+import akka.cluster.ddata.Replicator.Subscribe
+import akka.cluster.ddata.Replicator.Unsubscribe
+import akka.cluster.ddata.Replicator.Update
+import akka.cluster.ddata.Replicator.WriteLocal
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator.Put
+import akka.cluster.pubsub.DistributedPubSubMediator.Send
+import java.time.Instant
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.entity.ByteSize
+import org.apache.openwhisk.core.entity.InvokerInstanceId
+import org.apache.openwhisk.core.entity.size._
+import org.apache.openwhisk.utils.NodeStats
+import org.apache.openwhisk.utils.NodeStatsUpdate
+import scala.collection.immutable
+import scala.collection.mutable.ListBuffer
+import scala.util.Try
+
+class AkkaClusterContainerResourceManager(system: ActorSystem,
+                                          instanceId: InvokerInstanceId,
+                                          poolActor: ActorRef,
+                                          poolConfig: ContainerPoolConfig)(implicit logging: Logging)
+    extends ContainerResourceManager {
+
+  /** cluster state tracking */
+  private var clusterReservations: Map[ActorRef, Reservation] = Map.empty //this pool's own reservations
+  private var remoteReservations: Map[Int, List[Reservation]] = Map.empty //other pool's reservations
+  private var unused: Map[ActorRef, ContainerData] = Map.empty // this pool's unused containers
+  var clusterActionHostStats = Map.empty[String, NodeStats] //track the most recent node stats per action host (host that is able to run action containers)
+  var clusterActionHostsCount = 0
+  var prewarmsInitialized = false
+  val clusterPoolData: ActorRef =
+    system.actorOf(
+      Props(new ContainerPoolClusterData(instanceId, poolActor)),
+      ContainerPoolClusterData.clusterPoolActorName(instanceId.toInt))
+  implicit val cluster = Cluster(system)
+  val mediator = DistributedPubSub(system).mediator
+  val replicator = DistributedData(system).replicator
+
+  mediator ! Put(clusterPoolData) //allow point to point messaging based on the actor name: use Send(/user/<myname>) to send messages to me in the cluster
+
+  //invoker keys
+  val InvokerIdsKey = ORSetKey[Int]("invokerIds")
+  //my keys
+  val myId = instanceId.toInt
+  val myKey = LWWRegisterKey[List[Reservation]]("reservation" + myId)
+  val myUnusedKey = LWWRegisterKey[List[RemoteContainerRef]]("unused" + myId)
+  //remote keys
+  var reservationKeys: immutable.Map[Int, LWWRegisterKey[List[Reservation]]] = Map.empty
+  var unusedKeys: immutable.Map[Int, LWWRegisterKey[List[RemoteContainerRef]]] = Map.empty
+
+  //cachedValues
+  var unusedPool: Map[Int, List[RemoteContainerRef]] = Map.empty //invoker akka address -> List[RemoteContainerRef]
+  var idMap: immutable.Set[Int] = Set.empty
+  //subscribe to invoker ids changes (need to setup additional keys based on each invoker arriving)
+  replicator ! Subscribe(InvokerIdsKey, clusterPoolData)
+  //add this invoker to ids list
+  replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ + (myId))
+
+  logging.info(this, "subscribing to NodeStats updates")
+  system.eventStream.subscribe(clusterPoolData, classOf[NodeStatsUpdate])
+
+  def activationStartLogMessage(): String =
+    s"node stats ${clusterActionHostStats} reserved ${clusterReservations.size} (of max ${poolConfig.clusterManagedResourceMaxStarts}) containers ${reservedSize}MB " +
+      s"${reservedStartCount} pending starts ${reservedStopCount} pending stops " +
+      s"${scheduledStartCount} scheduled starts ${scheduledStopCount} scheduled stops"
+
+  def rescheduleLogMessage() = {
+    s"reservations: ${clusterReservations.size}"
+  }
+
+  def requestSpace(size: ByteSize) = {
+    val bufferedSize = size + 4096.MB
+    logging.info(this, s"signalling cluster release of idle resources up to ${bufferedSize.toMB}MB")
+    //find idles up to this size
+    val removable = unusedPool.map(u => u._2.map(u._1 -> _)).flatten.to[ListBuffer]
+    val removed = remove(removable, bufferedSize) //add some buffer so that any accumulating activations will have better chance
+    val removing = removed.groupBy(_._1).map(k => k._1 -> k._2.map(_._2)) //group the removables by invoker, will send single message per invoker
+    logging.info(this, s"requesting removal of ${removed.size} eligible idle containers ${removing}")
+    removing.foreach { r =>
+      //        val addrOpt = idMap.find(_.id == r._1).map(_.address)
+
+      val remotePath = s"/user/${ContainerPoolClusterData.clusterPoolActorName(r._1)}"
+      logging.info(this, s"notifying invoker ${remotePath}")
+      mediator ! Send(path = remotePath, msg = ReleaseFree(r._2), localAffinity = false)
+
+      //update unusedPool (we won't ask them to be removed twice)
+      unusedPool = unusedPool + (r._1 -> unusedPool(r._1).filterNot(r._2.toSet))
+
+    }
+  }
+
+  def reservedSize = clusterReservations.values.map(_.size.toMB).sum
+  def reservedStartCount = clusterReservations.values.count {
+    case p: Reservation => p.size.toMB >= 0
+    case _              => false
+  }
+  def reservedStopCount = clusterReservations.values.count {
+    case p: Reservation => p.size.toMB < 0
+    case _              => false
+  }
+  def scheduledStartCount = clusterReservations.values.count {
+    case p: Reservation => p.size.toMB >= 0
+    case _              => false
+  }
+  def scheduledStopCount = clusterReservations.values.count {
+    case p: Reservation => p.size.toMB < 0
+    case _              => false
+  }
+  private var clusterResourcesAvailable
+    : Boolean = false //track to log whenever there is a switch from cluster resources being available to not being available
+
+  def canLaunch(memory: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean = {
+
+    val localReservations = clusterReservations.values.map(_.size) //active local reservations
+    val remoteRes = remoteReservations.values.toList.flatten.map(_.size) //remote/stale reservations
+
+    val allRes = localReservations ++ remoteRes
+    //make sure there is at least one node with unreserved mem > memory
+    val canLaunch = clusterHasPotentialMemoryCapacity(memory.toMB, allRes) //consider all reservations blocking till they are removed during NodeStatsUpdate
+    //log only when changing value
+    if (canLaunch != clusterResourcesAvailable) {
+      if (canLaunch) {
+        logging.info(this, s"cluster can launch action with ${memory.toMB}MB reserved:${reservedSize}")
+      } else {
+        logging.warn(this, s"cluster cannot launch action with ${memory.toMB}MB reserved:${reservedSize}")
+      }
+    }
+    clusterResourcesAvailable = canLaunch
+    canLaunch
+  }
+
+  /** Return true to indicate there is expectation that there is "room" to launch a task with these memory/cpu/ports specs */
+  def clusterHasPotentialMemoryCapacity(memory: Double, reserve: Iterable[ByteSize]): Boolean = {
+    //copy AgentStats, then deduct pending tasks
+    var availableResources = clusterActionHostStats.toList.sortBy(_._2.mem).toMap //sort by mem to match lowest value
+    val inNeedReserved = ListBuffer.empty ++ reserve
+
+    var unmatched = 0
+
+    inNeedReserved.foreach { p =>
+      //for each pending find an available offer that fits
+      availableResources.find(_._2.mem > p.toMB) match {
+        case Some(o) =>
+          availableResources = availableResources + (o._1 -> o._2.copy(mem = o._2.mem - p.toMB))
+          inNeedReserved -= p
+        case None => unmatched += 1
+      }
+    }
+    unmatched == 0 && availableResources.exists(_._2.mem > memory)
+  }
+
+  /** reservation adjustments */
+  def addReservation(ref: ActorRef, size: ByteSize): Unit = {
+    clusterReservations = clusterReservations + (ref -> Reservation(size))
+  }
+  def releaseReservation(ref: ActorRef): Unit = {
+    clusterReservations = clusterReservations - ref
+  }
+  def allowMoreStarts(config: ContainerPoolConfig): Boolean =
+    clusterReservations
+      .count({ case (_, state) => state.size.toMB > 0 }) < config.clusterManagedResourceMaxStarts //only positive reservations affect ability to start
+
+  class ContainerPoolClusterData(instanceId: InvokerInstanceId, pool: ActorRef) extends Actor {
+
+    var lastUnused: List[RemoteContainerRef] = List.empty
+    var lastReservations: List[Reservation] = List.empty
+    var lastStats: Map[String, NodeStats] = Map.empty
+    def updateRemoteReservations(id: Int, reservations: List[Reservation]) = {
+      remoteReservations = remoteReservations + (id -> reservations)
+    }
+
+    override def postStop(): Unit = {
+      //remove this invoker from ids list
+      replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ - myId)
+    }
+    override def receive: Receive = {
+      case NodeStatsUpdate(stats) =>
+        logging.info(
+          this,
+          s"received node stats ${stats} reserved/scheduled ${clusterReservations.size} containers ${reservedSize}MB")
+        clusterActionHostStats = stats
+        if (!prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers
+          prewarmsInitialized = true
+          logging.info(this, "initializing prewarmpool after stats recevied")
+          //        initPrewarms()
+          pool ! InitPrewarms
+        }
+
+        //only signal updates (to pool or replicator) in case things have changed
+        if (lastStats != stats) {
+          lastStats = stats
+          pool ! ResourceUpdate
+        }
+
+        //update this invokers reservations seen by other invokers
+        val reservations = clusterReservations.values.toList
+        if (lastReservations != reservations) {
+          lastReservations = reservations
+          logging.info(
+            this,
+            s"invoker ${myId} now has ${reservations.size} reservations (${reservations.map(_.size.toMB).sum}MB)")
+          replicator ! Update(myKey, LWWRegister[List[Reservation]](List.empty), WriteLocal)(reg =>
+            reg.withValue(reservations))
+        }
+        //update this invokers idles seen by other invokers
+        val idles = unused.map(f => RemoteContainerRef(f._2.memoryLimit, f._2.lastUsed)).toList
+        if (lastUnused != idles) {
+          lastUnused = idles
+          logging.info(this, s"invoker ${myId} now has ${idles.size} idles (${idles.map(_.size.toMB).sum}MB)")
+          replicator ! Update(myUnusedKey, LWWRegister[List[RemoteContainerRef]](List.empty), WriteLocal)(reg =>
+            reg.withValue(idles))
+        }
+
+      case r: ReleaseFree =>
+        logging.info(this, s"got releasefree from ${sender()}")
+        //forward to the pool
+        pool.forward(r)
+      case c @ Changed(LWWRegisterKey(idStr)) =>
+        val resRegex = "reservation(\\d+)".r
+        val unusedRegex = "unused(\\d+)".r
+        val (id, res) = idStr match {
+          case resRegex(remoteId)    => remoteId.toInt -> true
+          case unusedRegex(remoteId) => remoteId.toInt -> false
+        }
+        if (id != myId) {
+
+          if (res) {
+            val idKey = LWWRegisterKey[List[Reservation]]("reservation" + id)
+            val newValue = c.get(idKey).value
+            updateRemoteReservations(id, newValue)
+          } else {
+            val unusedKey = LWWRegisterKey[List[RemoteContainerRef]]("unused" + id)
+            val newValue = c.get(unusedKey).value
+            println(s"updating unused pool ${newValue}")
+            unusedPool = unusedPool + (id -> newValue)
+          }
+        }
+      case c @ Changed(InvokerIdsKey) =>
+        val newValue = c.get(InvokerIdsKey).elements
+        if (reservationKeys.keySet != newValue) {
+          val deleted = reservationKeys.keySet.diff(newValue)
+          val added = newValue.diff(reservationKeys.keySet)
+          added.foreach { id =>
+            println(s"adding id ${id}")
+            val idKey = LWWRegisterKey[List[Reservation]]("reservation" + id)
+            if (id != myId) { //skip my own id
+              val unusedKey = LWWRegisterKey[List[RemoteContainerRef]]("unused" + id)
+              reservationKeys = reservationKeys + (id -> idKey)
+              unusedKeys = unusedKeys + (id -> unusedKey)
+              replicator ! Subscribe(idKey, self)
+              replicator ! Subscribe(unusedKey, self)
+            }
+
+          }
+          deleted.foreach { id =>
+            println(s"removing id ${id}")
+            val idKey = LWWRegisterKey[List[Reservation]]("reservation" + id)
+            val unusedKey = LWWRegisterKey[List[RemoteContainerRef]]("unused" + id)
+            reservationKeys = reservationKeys - id
+            unusedKeys = unusedKeys - id
+            replicator ! Unsubscribe(idKey, self)
+            replicator ! Unsubscribe(unusedKey, self)
+            updateRemoteReservations(id, List.empty)
+          }
+        }
+    }
+  }
+  def updateUnused(newUnused: Map[ActorRef, ContainerData]): Unit = {
+
+    unused = newUnused
+  }
+  def remove[A](pool: ListBuffer[(A, RemoteContainerRef)], memory: ByteSize): List[(A, RemoteContainerRef)] = {
+
+    if (pool.isEmpty) {
+      List.empty
+    } else {
+
+      val oldest = pool.minBy(_._2.lastUsed)
+      if (memory > 0.B) { //&& memoryConsumptionOf(pool) >= memory.toMB //remove any amount possible
+        // Remove the oldest container if:
+        // - there is more memory required
+        // - there are still containers that can be removed
+        // - there are enough free containers that can be removed
+        //val (ref, data) = freeContainers.minBy(_._2.lastUsed)
+        // Catch exception if remaining memory will be negative
+        val remainingMemory = Try(memory - oldest._2.size).getOrElse(0.B)
+        List(oldest._1 -> oldest._2) ++ remove(pool - oldest, remainingMemory)
+      } else {
+        // If this is the first call: All containers are in use currently, or there is more memory needed than
+        // containers can be removed.
+        // Or, if this is one of the recursions: Enough containers are found to get the memory, that is
+        // necessary. -> Abort recursion
+        List.empty
+      }
+    }
+  }
+}
+
+/**
+ * Reservation indicates resources allocated to container, but possibly not launched yet. May be negative for container stop.
+ * Pending: Allocated from this point of view, but not yet started/stopped by cluster manager.
+ * Scheduled: Started/Stopped by cluster manager, but not yet reflected in NodeStats, so must still be considered when allocating resources.
+ * */
+case class Reservation(size: ByteSize)
+case class RemoteContainerRef(size: ByteSize, lastUsed: Instant)
+case class ReleaseFree(remoteContainerRefs: List[RemoteContainerRef])
+
+object ContainerPoolClusterData {
+  def clusterPoolActorName(instanceId: Int): String = "containerPoolCluster" + instanceId.toInt
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -256,12 +256,14 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
             .map(_._2.size)
             .sum} (${remoteReservedSize}MB)")
         clusterActionHostStats = stats
-        MetricEmitter.emitHistogramMetric(
-          LoggingMarkers.CLUSTER_RESOURCES_TOTAL_MEM,
-          stats.values.map(_.mem).sum.toLong)
-        MetricEmitter.emitHistogramMetric(
-          LoggingMarkers.CLUSTER_RESOURCES_MAX_MEM,
-          stats.values.maxBy(_.mem).mem.toLong)
+        if (stats.nonEmpty) {
+          MetricEmitter.emitHistogramMetric(
+            LoggingMarkers.CLUSTER_RESOURCES_TOTAL_MEM,
+            stats.values.map(_.mem).sum.toLong)
+          MetricEmitter.emitHistogramMetric(
+            LoggingMarkers.CLUSTER_RESOURCES_MAX_MEM,
+            stats.values.maxBy(_.mem).mem.toLong)
+        }
         MetricEmitter.emitHistogramMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
 
         if (!prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -40,6 +40,8 @@ import akka.cluster.pubsub.DistributedPubSubMediator.Put
 import akka.cluster.pubsub.DistributedPubSubMediator.Send
 import java.time.Instant
 import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.common.LoggingMarkers
+import org.apache.openwhisk.common.MetricEmitter
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.InvokerInstanceId
 import org.apache.openwhisk.core.entity.size._
@@ -254,6 +256,14 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
             .map(_._2.size)
             .sum} (${remoteReservedSize}MB)")
         clusterActionHostStats = stats
+        MetricEmitter.emitHistogramMetric(
+          LoggingMarkers.CLUSTER_RESOURCES_TOTAL_MEM,
+          stats.values.map(_.mem).sum.toLong)
+        MetricEmitter.emitHistogramMetric(
+          LoggingMarkers.CLUSTER_RESOURCES_MAX_MEM,
+          stats.values.maxBy(_.mem).mem.toLong)
+        MetricEmitter.emitCounterMetric(LoggingMarkers.CLUSTER_RESOURCES_NODE_COUNT, stats.size)
+
         if (!prewarmsInitialized) { //we assume that when stats are received, we should startup prewarm containers
           prewarmsInitialized = true
           logging.info(this, "initializing prewarmpool after stats recevied")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaClusterContainerResourceManager.scala
@@ -186,12 +186,13 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
     implicit val ec = context.dispatcher
     val mediator = DistributedPubSub(system).mediator
     val replicator = DistributedData(system).replicator
+    implicit val myAddress = DistributedData(system).selfUniqueAddress
 
     mediator ! Put(self) //allow point to point messaging based on the actor name: use Send(/user/<myname>) to send messages to me in the cluster
     //subscribe to invoker ids changes (need to setup additional keys based on each invoker arriving)
     replicator ! Subscribe(InvokerIdsKey, self)
     //add this invoker to ids list
-    replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ + (myId))
+    replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ :+ (myId))
 
     logging.info(this, "subscribing to NodeStats updates")
     system.eventStream.subscribe(self, classOf[NodeStatsUpdate])
@@ -212,7 +213,7 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
     private def cleanup() = {
       //remove this invoker from ids list
       logging.info(this, s"stopping invoker ${myId}")
-      replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_ - myId)
+      replicator ! Update(InvokerIdsKey, ORSet.empty[Int], WriteLocal)(_.remove(myId))
 
     }
     override def receive: Receive = {
@@ -224,8 +225,8 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
           logging.info(
             this,
             s"invoker ${myId} (self) has ${reservations.size} reservations (${reservations.map(_.size.toMB).sum}MB)")
-          replicator ! Update(myReservationsKey, LWWRegister[List[Reservation]](List.empty), WriteLocal)(reg =>
-            reg.withValue(reservations))
+          replicator ! Update(myReservationsKey, LWWRegister[List[Reservation]](myAddress, List.empty), WriteLocal)(
+            reg => reg.withValueOf(reservations))
         }
         //update this invokers idles seen by other invokers; including only idles past the idleGrace period
         val idleGraceInstant = Instant.now().minusSeconds(poolConfig.clusterManagedIdleGrace.toSeconds)
@@ -238,8 +239,8 @@ class AkkaClusterContainerResourceManager(system: ActorSystem,
           logging.info(
             this,
             s"invoker ${myId} (self) has ${lastUnused.size} unused (${lastUnused.map(_.size.toMB).sum}MB)")
-          replicator ! Update(myUnusedKey, LWWRegister[List[RemoteContainerRef]](List.empty), WriteLocal)(reg =>
-            reg.withValue(idles))
+          replicator ! Update(myUnusedKey, LWWRegister[List[RemoteContainerRef]](myAddress, List.empty), WriteLocal)(
+            reg => reg.withValueOf(idles))
         }
       case UpdateSuccess => //nothing (normal behavior)
       case f: UpdateFailure[_] => //log the failure

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -67,7 +67,12 @@ class ContainerPool(instanceId: InvokerInstanceId,
 
   implicit val logging = new AkkaLogging(context.system.log)
 
-  val resourceManager = new AkkaClusterContainerResourceManager(context.system, instanceId, self, poolConfig)
+  val resourceManager = if (poolConfig.clusterManagedResources) {
+    new AkkaClusterContainerResourceManager(context.system, instanceId, self, poolConfig)
+  } else {
+    self ! InitPrewarms
+    new LocalContainerResourceManager()
+  }
   var freePool = immutable.Map.empty[ActorRef, ContainerData]
   var busyPool = immutable.Map.empty[ActorRef, ContainerData]
   var prewarmedPool = immutable.Map.empty[ActorRef, ContainerData]
@@ -75,6 +80,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
   // buffered here to keep order of computation.
   // Otherwise actions with small memory-limits could block actions with large memory limits.
   var runBuffer = immutable.Queue.empty[Run]
+  var resent = immutable.Set.empty[ActivationId]
   val logMessageInterval = 10.seconds
 
   var prewarmsInitialized = false
@@ -111,6 +117,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
     // fail for example, or a container has aged and was destroying itself when a new request was assigned)
     case r: Run =>
       implicit val tid: TransactionId = r.msg.transid
+      resent = resent - r.msg.activationId
       // Check if the message is resent from the buffer. Only the first message on the buffer can be resent.
       val isResentFromBuffer = runBuffer.nonEmpty && runBuffer.dequeueOption.exists(_._1.msg == r.msg)
       // Only process request, if there are no other requests waiting for free slots, or if the current request is the
@@ -200,7 +207,11 @@ class ContainerPool(instanceId: InvokerInstanceId,
               // from the buffer
               val (_, newBuffer) = runBuffer.dequeue
               runBuffer = newBuffer
-              runBuffer.dequeueOption.foreach { case (run, _) => self ! run }
+              runBuffer.dequeueOption.foreach {
+                case (run, _) =>
+                  resent = resent + run.msg.activationId
+                  self ! run
+              }
             }
             actor ! r // forwards the run request to the container
             logContainerStart(r, containerState, newData.activeActivationCount, container)
@@ -332,9 +343,14 @@ class ContainerPool(instanceId: InvokerInstanceId,
    * */
   def processBuffer() = {
     if (poolConfig.clusterManagedResources) {
+      //if next runbuffer item has not already been resent, send it
       runBuffer.dequeueOption match {
-        case Some((run, _)) => //run the first from buffer
-          self ! run
+        case Some((run, newQueue)) => //run the first from buffer
+          //avoid sending dupes
+          if (!resent.contains(run.msg.activationId)) {
+            resent = resent + run.msg.activationId
+            self ! run
+          }
         case None => //feed me!
           feed ! MessageFeed.Processed
       }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -159,11 +159,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
                     } else {
                       r.action.limits.memory.megabytes.MB
                     })
-                  .map { a =>
-                    //decrease the reserved (not yet stopped container) memory tracker
-                    //resourceManager.addReservation(a._1, (-r.action.limits.memory.megabytes).MB)
-                    removeContainer(a._1)
-                  }
+                  .map(a => removeContainer(a._1))
                   // If the list had at least one entry, enough containers were removed to start the new container. After
                   // removing the containers, we are not interested anymore in the containers that have been removed.
                   .headOption
@@ -288,7 +284,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
 
     // Container got removed
     case ContainerRemoved =>
-      //stop tracking via reserved
+      //stop tracking via reserved (should already be removed, except in case of failure)
       resourceManager.releaseReservation(sender())
 
       // if container was in free pool, it may have been processing (but under capacity),

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -237,7 +237,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
             }
             if (!isResentFromBuffer) {
               // Add this request to the buffer, as it is not there yet.
-              runBuffer = runBuffer.enqueue(r)
+              runBuffer = runBuffer.enqueue(Run(r.action, r.msg, retryLogDeadline))
             }
         }
       } else {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -153,7 +153,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
                     })
                   .map { a =>
                     //decrease the reserved (not yet stopped container) memory tracker
-                    resourceManager.addReservation(a._1, (-r.action.limits.memory.megabytes).MB)
+                    //resourceManager.addReservation(a._1, (-r.action.limits.memory.megabytes).MB)
                     removeContainer(a._1)
                   }
                   // If the list had at least one entry, enough containers were removed to start the new container. After
@@ -418,7 +418,6 @@ class ContainerPool(instanceId: InvokerInstanceId,
 
   def updateUnused() = {
     val unused = freePool.filter(_._2.activeActivationCount == 0)
-    logging.info(this, s"pool has ${unused.size} unused")
     resourceManager.updateUnused(unused)
   }
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -259,7 +259,8 @@ class ContainerPool(instanceId: InvokerInstanceId,
     // Container is free to take more work
     case NeedWork(warmData: WarmedData) =>
       val oldData = freePool.get(sender()).getOrElse(busyPool(sender()))
-      val newData = warmData.copy(activeActivationCount = oldData.activeActivationCount - 1)
+      val newData =
+        warmData.copy(lastUsed = oldData.lastUsed, activeActivationCount = oldData.activeActivationCount - 1)
       if (newData.activeActivationCount < 0) {
         logging.error(this, s"invalid activation count after warming < 1 ${newData}")
       }
@@ -456,6 +457,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
   }
 
   def updateUnused() = {
+    //TODO: exclude those not past idle grace
     val unused = freePool.filter(_._2.activeActivationCount == 0)
     resourceManager.updateUnused(unused)
   }
@@ -567,6 +569,12 @@ object ContainerPool {
     // and has not been used since the removal was requested
     // and has not been used past the idle grace period
     val idleGraceInstant = Instant.now().minusSeconds(idleGrace.toSeconds)
+
+    freePool.foreach { c =>
+      println(s"c  ${c._2.getContainer}  ${c._2.lastUsed}  ${idleGraceInstant} ${c._2.lastUsed
+        .isBefore(idleGraceInstant)} ${c._2.activeActivationCount}")
+    }
+
     val toRemove = freePool
     //FILTER MATCHING MEMORY USAGE WITH LAST USE BEFORE IDLE GRACE INSTANT
       .filter { f =>
@@ -578,7 +586,10 @@ object ContainerPool {
           r.size == f._2.memoryLimit && r.lastUsed == f._2.lastUsed && r.containerAddress == f._2.getContainer.get.addr
         }
       }
-    toRemove.foreach(i => logging.info(this, s"removing idle container ${i._2.getContainer.get}"))
+    toRemove.foreach(i =>
+      logging.info(
+        this,
+        s"removing idle container ${i._2.getContainer.get} with last use ${i._2.lastUsed} before idle grace at ${idleGraceInstant}"))
     toRemove.keySet
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -418,7 +418,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
 
   def updateUnused() = {
     val unused = freePool.filter(_._2.activeActivationCount == 0)
-    logging.info(this, s"we have ${unused.size} unused")
+    logging.info(this, s"pool has ${unused.size} unused")
     resourceManager.updateUnused(unused)
   }
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -113,7 +113,6 @@ class ContainerPool(instanceId: InvokerInstanceId,
       implicit val tid: TransactionId = r.msg.transid
       // Check if the message is resent from the buffer. Only the first message on the buffer can be resent.
       val isResentFromBuffer = runBuffer.nonEmpty && runBuffer.dequeueOption.exists(_._1.msg == r.msg)
-//      println(s"is resent ${isResentFromBuffer}")
       // Only process request, if there are no other requests waiting for free slots, or if the current request is the
       // next request to process
       // It is guaranteed, that only the first message on the buffer is resent.
@@ -230,7 +229,6 @@ class ContainerPool(instanceId: InvokerInstanceId,
             }
             if (!isResentFromBuffer) {
               // Add this request to the buffer, as it is not there yet.
-//              println(s"enqueue1 ${r.msg.activationId}")
               runBuffer = runBuffer.enqueue(r)
             }
             if (!poolConfig.clusterManagedResources) {
@@ -241,7 +239,6 @@ class ContainerPool(instanceId: InvokerInstanceId,
       } else {
         // There are currently actions waiting to be executed before this action gets executed.
         // These waiting actions were not able to free up enough memory.
-//        println(s"enqueue2 ${r.msg.activationId}")
         runBuffer = runBuffer.enqueue(r)
       }
 
@@ -318,7 +315,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
       //so preemptively request more
       resourceManager.requestSpace(size)
     case ReleaseFree(refs) =>
-      logging.info(this, s"pool is trying to release ${refs.size} containers by request of ${sender()}")
+      logging.info(this, s"pool is trying to release ${refs.size} containers by request of invoker")
       //remove each ref, IFF it is still not in use, and has not been used since the removal was requested
       refs.foreach(r =>
         freePool
@@ -421,7 +418,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
 
   def updateUnused() = {
     val unused = freePool.filter(_._2.activeActivationCount == 0)
-    println(s"now we have ${unused.size} unused")
+    logging.info(this, s"we have ${unused.size} unused")
     resourceManager.updateUnused(unused)
   }
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -297,6 +297,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
         if (f.activeActivationCount > 0) {
           processBuffer()
         }
+        updateUnused()
         sender()
       }
       // container was busy (busy indicates at full capacity), so there is capacity to accept another job request
@@ -320,7 +321,7 @@ class ContainerPool(instanceId: InvokerInstanceId,
       resourceManager.releaseReservation(sender())
       freePool = freePool - sender()
       busyPool = busyPool - sender()
-
+      updateUnused()
     case InitPrewarms =>
       initPrewarms()
     case ResourceUpdate => //we may have more resources - either process the buffer or request another feed message

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -163,7 +163,8 @@ class ContainerPool(instanceId: InvokerInstanceId,
                       Math.min(r.action.limits.memory.megabytes, memoryConsumptionOf(freePool)).MB
                     } else {
                       r.action.limits.memory.megabytes.MB
-                    })
+                    },
+                    Instant.now().minusSeconds(poolConfig.clusterManagedIdleGrace.toSeconds))
                   .map(a => removeContainer(a._1))
                   // If the list had at least one entry, enough containers were removed to start the new container. After
                   // removing the containers, we are not interested anymore in the containers that have been removed.
@@ -525,7 +526,7 @@ object ContainerPool {
   @tailrec
   protected[containerpool] def remove[A](pool: Map[A, ContainerData],
                                          memory: ByteSize,
-                                         lastUsedMax: Instant = Instant.now(),
+                                         lastUsedMax: Instant,
                                          anyAmount: Boolean = false,
                                          toRemove: Map[A, ByteSize] = Map.empty[A, ByteSize]): Map[A, ByteSize] = {
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -339,11 +339,12 @@ class ContainerPool(instanceId: InvokerInstanceId,
       //remove each ref, IFF it is still not in use, and has not been used since the removal was requested
       ContainerPool.findIdlesToRemove(freePool, refs).foreach(removeContainer)
     case EmitMetrics =>
-      MetricEmitter.emitHistogramMetric(LoggingMarkers.CONTAINER_POOL_RUNBUFFER_SIZE, runBuffer.size)
-      MetricEmitter.emitHistogramMetric(LoggingMarkers.CLUSTER_RESOURCES_IDLES_COUNT, inUse.size)
-      MetricEmitter.emitHistogramMetric(
-        LoggingMarkers.CLUSTER_RESOURCES_IDLES_SIZE,
-        inUse.map(_._2.memoryLimit.toMB).sum)
+      MetricEmitter.emitGaugeMetric(LoggingMarkers.CONTAINER_POOL_RUNBUFFER_COUNT, runBuffer.size)
+      MetricEmitter.emitGaugeMetric(
+        LoggingMarkers.CONTAINER_POOL_RUNBUFFER_SIZE,
+        runBuffer.map(_.action.limits.memory.megabytes).sum)
+      MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_IDLES_COUNT, inUse.size)
+      MetricEmitter.emitGaugeMetric(LoggingMarkers.CLUSTER_RESOURCES_IDLES_SIZE, inUse.map(_._2.memoryLimit.toMB).sum)
   }
 
   /** Buffer processing in cluster managed resources means to send the first item in runBuffer;

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -137,7 +137,7 @@ case class WarmingData(override val container: Container,
     extends ContainerStarted(container, lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warming"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 /** type representing a cold (not yet running) container that is being initialized (for a specific action + invocation namespace) */
@@ -148,7 +148,7 @@ case class WarmingColdData(invocationNamespace: EntityName,
     extends ContainerNotStarted(lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warmingCold"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 /** type representing a warm container that has already been in use (for a specific action + invocation namespace) */
@@ -160,7 +160,7 @@ case class WarmedData(override val container: Container,
     extends ContainerStarted(container, lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warmed"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 // Events received by the actor

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -176,6 +176,7 @@ case object RescheduleJob // job is sent back to parent and could not be process
 case class PreWarmCompleted(data: PreWarmedData)
 case class InitCompleted(data: WarmedData)
 case object RunCompleted
+case object ContainerStarted
 
 /**
  * A proxy that wraps a Container. It is used to keep track of the lifecycle
@@ -334,7 +335,9 @@ class ContainerProxy(
   when(Running) {
     // Intermediate state, we were able to start a container
     // and we keep it in case we need to destroy it.
-    case Event(completed: PreWarmCompleted, _) => stay using completed.data
+    case Event(completed: PreWarmCompleted, _) =>
+      context.parent ! ContainerStarted
+      stay using completed.data
 
     // Init was successful
     case Event(completed: InitCompleted, _: PreWarmedData) =>

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+import akka.actor.ActorRef
+import org.apache.openwhisk.core.entity.ByteSize
+
+trait ContainerResourceManager {
+  def activationStartLogMessage(): String
+  def rescheduleLogMessage(): String
+
+  def updateUnused(unused: Map[ActorRef, ContainerData])
+  def allowMoreStarts(config: ContainerPoolConfig): Boolean
+  def addReservation(ref: ActorRef, byteSize: ByteSize): Unit
+  def releaseReservation(ref: ActorRef): Unit
+  def requestSpace(size: ByteSize): Unit
+  def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
@@ -20,13 +20,14 @@ import akka.actor.ActorRef
 import org.apache.openwhisk.core.entity.ByteSize
 
 trait ContainerResourceManager {
-  def activationStartLogMessage(): String
-  def rescheduleLogMessage(): String
+  def activationStartLogMessage(): String = ""
+  def rescheduleLogMessage(): String = ""
 
-  def updateUnused(unused: Map[ActorRef, ContainerData])
-  def allowMoreStarts(config: ContainerPoolConfig): Boolean
-  def addReservation(ref: ActorRef, byteSize: ByteSize): Unit
-  def releaseReservation(ref: ActorRef): Unit
-  def requestSpace(size: ByteSize): Unit
+  val autoStartPrewarming: Boolean = true
+  def updateUnused(unused: Map[ActorRef, ContainerData]) = {}
+  def allowMoreStarts(config: ContainerPoolConfig): Boolean = true
+  def addReservation(ref: ActorRef, byteSize: ByteSize): Unit = {}
+  def releaseReservation(ref: ActorRef): Unit = {}
+  def requestSpace(size: ByteSize): Unit = {}
   def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerResourceManager.scala
@@ -23,11 +23,9 @@ trait ContainerResourceManager {
   def activationStartLogMessage(): String = ""
   def rescheduleLogMessage(): String = ""
 
-  val autoStartPrewarming: Boolean = true
   def updateUnused(unused: Map[ActorRef, ContainerData]) = {}
-  def allowMoreStarts(config: ContainerPoolConfig): Boolean = true
   def addReservation(ref: ActorRef, byteSize: ByteSize): Unit = {}
   def releaseReservation(ref: ActorRef): Unit = {}
   def requestSpace(size: ByteSize): Unit = {}
-  def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean
+  def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig, prewarm: Boolean = false): Boolean
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
@@ -16,19 +16,10 @@
  */
 
 package org.apache.openwhisk.core.containerpool
-import akka.actor.ActorRef
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.entity.ByteSize
 
 class LocalContainerResourceManager(implicit logging: Logging) extends ContainerResourceManager {
-
-  override def activationStartLogMessage(): String = ""
-  override def rescheduleLogMessage(): String = ""
-  override def updateUnused(unused: Map[ActorRef, ContainerData]): Unit = {}
-  override def allowMoreStarts(config: ContainerPoolConfig): Boolean = true
-  override def addReservation(ref: ActorRef, byteSize: ByteSize): Unit = {}
-  override def releaseReservation(ref: ActorRef): Unit = {}
-  override def requestSpace(size: ByteSize): Unit = {}
   override def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean =
     poolMemory + size.toMB <= poolConfig.userMemory.toMB
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
@@ -16,10 +16,16 @@
  */
 
 package org.apache.openwhisk.core.containerpool
+import akka.actor.ActorRef
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.entity.ByteSize
 
-class LocalContainerResourceManager(implicit logging: Logging) extends ContainerResourceManager {
-  override def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean =
-    poolMemory + size.toMB <= poolConfig.userMemory.toMB
+class LocalContainerResourceManager(pool: ActorRef)(implicit logging: Logging) extends ContainerResourceManager {
+  pool ! InitPrewarms //init prewarms immediately
+  override def canLaunch(size: ByteSize,
+                         poolMemory: Long,
+                         poolConfig: ContainerPoolConfig,
+                         prewarm: Boolean): Boolean = {
+    prewarm || poolMemory + size.toMB <= poolConfig.userMemory.toMB //in this impl we do not restrict starting of prewarm based on pool capacity
+  }
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+import akka.actor.ActorRef
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.entity.ByteSize
+
+class LocalContainerResourceManager(implicit logging: Logging, tid: TransactionId) extends ContainerResourceManager {
+
+  override def activationStartLogMessage(): String = ""
+  override def rescheduleLogMessage(): String = ""
+  override def updateUnused(unused: Map[ActorRef, ContainerData]): Unit = {}
+  override def allowMoreStarts(config: ContainerPoolConfig): Boolean = true
+  override def addReservation(ref: ActorRef, byteSize: ByteSize): Unit = {}
+  override def releaseReservation(ref: ActorRef): Unit = {}
+  override def requestSpace(size: ByteSize): Unit = {}
+  override def canLaunch(size: ByteSize, poolMemory: Long, poolConfig: ContainerPoolConfig): Boolean =
+    poolMemory + size.toMB <= poolConfig.userMemory.toMB
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/LocalContainerResourceManager.scala
@@ -18,10 +18,9 @@
 package org.apache.openwhisk.core.containerpool
 import akka.actor.ActorRef
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.entity.ByteSize
 
-class LocalContainerResourceManager(implicit logging: Logging, tid: TransactionId) extends ContainerResourceManager {
+class LocalContainerResourceManager(implicit logging: Logging) extends ContainerResourceManager {
 
   override def activationStartLogMessage(): String = ""
   override def rescheduleLogMessage(): String = ""

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -162,7 +162,7 @@ object DockerContainer {
  * @param addr the ip of the container
  */
 class DockerContainer(protected val id: ContainerId,
-                      protected val addr: ContainerAddress,
+                      protected[core] val addr: ContainerAddress,
                       protected val useRunc: Boolean)(implicit docker: DockerApiWithFileAccess,
                                                       runc: RuncApi,
                                                       override protected val as: ActorSystem,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -208,7 +208,7 @@ class InvokerReactive(
   }
 
   private val pool =
-    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs))
+    actorSystem.actorOf(ContainerPool.props(instance, childFactory, poolConfig, activationFeed, prewarmingConfigs))
 
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -81,7 +81,7 @@ class MesosContainerFactoryTest
   }
 
   // 80 slots, each 265MB
-  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false)
+  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, false)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -81,7 +81,7 @@ class MesosContainerFactoryTest
   }
 
   // 80 slots, each 265MB
-  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, false)
+  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, false, 10)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -49,6 +49,7 @@ import scala.concurrent.duration._
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.WhiskConfig._
+import org.apache.openwhisk.core.containerpool.ClusterManagedCapacityMonitor
 import org.apache.openwhisk.core.containerpool.ContainerArgsConfig
 import org.apache.openwhisk.core.containerpool.ContainerPoolConfig
 import org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStore
@@ -81,7 +82,8 @@ class MesosContainerFactoryTest
   }
 
   // 80 slots, each 265MB
-  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, false, 10)
+  val poolConfig =
+    ContainerPoolConfig(21200.MB, 0.5, false, false, 10, ClusterManagedCapacityMonitor(0.5, 10.seconds, 1024.B))
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -82,7 +82,7 @@ class MesosContainerFactoryTest
 
   // 80 slots, each 265MB
   val poolConfig =
-    ContainerPoolConfig(21200.MB, 0.5, false, false, false, 10)
+    ContainerPoolConfig(21200.MB, 0.5, false, false, false, 10, 10.seconds)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -49,7 +49,6 @@ import scala.concurrent.duration._
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.WhiskConfig._
-import org.apache.openwhisk.core.containerpool.ClusterManagedCapacityMonitor
 import org.apache.openwhisk.core.containerpool.ContainerArgsConfig
 import org.apache.openwhisk.core.containerpool.ContainerPoolConfig
 import org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStore
@@ -83,7 +82,7 @@ class MesosContainerFactoryTest
 
   // 80 slots, each 265MB
   val poolConfig =
-    ContainerPoolConfig(21200.MB, 0.5, false, false, 10, ClusterManagedCapacityMonitor(0.5, 10.seconds, 1024.B))
+    ContainerPoolConfig(21200.MB, 0.5, false, false, false, 10)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -125,7 +125,7 @@ class ContainerPoolTests
     (containers, factory)
   }
 
-  def poolConfig(userMemory: ByteSize) = ContainerPoolConfig(userMemory, 0.5, false, false)
+  def poolConfig(userMemory: ByteSize) = ContainerPoolConfig(userMemory, 0.5, false, false, 10)
 
   behavior of "ContainerPool"
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -125,7 +125,7 @@ class ContainerPoolTests
     (containers, factory)
   }
 
-  def poolConfig(userMemory: ByteSize) = ContainerPoolConfig(userMemory, 0.5, false)
+  def poolConfig(userMemory: ByteSize) = ContainerPoolConfig(userMemory, 0.5, false, false)
 
   behavior of "ContainerPool"
 
@@ -809,4 +809,5 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     pool = pool - 'first
     ContainerPool.remove(pool, MemoryLimit.stdMemory) shouldBe List('second)
   }
+
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -42,7 +42,6 @@ import org.apache.openwhisk.core.entity.ExecManifest.RuntimeManifest
 import org.apache.openwhisk.core.entity.ExecManifest.ImageName
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.connector.MessageFeed
-import org.apache.openwhisk.core.containerpool.ClusterManagedCapacityMonitor
 
 /**
  * Behavior tests for the ContainerPool
@@ -127,7 +126,7 @@ class ContainerPoolTests
   }
 
   def poolConfig(userMemory: ByteSize) =
-    ContainerPoolConfig(userMemory, 0.5, false, false, 10, ClusterManagedCapacityMonitor(0.5, 10.seconds, 1024.B))
+    ContainerPoolConfig(userMemory, 0.5, false, false, false, 10)
 
   val instanceId = InvokerInstanceId(0, userMemory = 1024.MB)
   behavior of "ContainerPool"

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.containerpool.test
 
 import java.time.Instant
-
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor.{ActorRef, ActorSystem, FSM}
 import akka.stream.scaladsl.Source
@@ -26,7 +25,6 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.ByteString
 import common.{LoggedFunction, StreamLogging, SynchronizedLoggedFunction, WhiskProperties}
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
@@ -34,6 +32,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.connector.ActivationMessage
+import org.apache.openwhisk.core.containerpool.ClusterManagedCapacityMonitor
 import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.containerpool.logging.LogCollectingException
 import org.apache.openwhisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
@@ -201,7 +200,8 @@ class ContainerProxyTests
     (transid: TransactionId, activation: WhiskActivation, context: UserContext) =>
       Future.successful(())
   }
-  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, false, 10)
+  val poolConfig =
+    ContainerPoolConfig(2.MB, 0.5, false, false, 10, ClusterManagedCapacityMonitor(0.5, 10.seconds, 1024.B))
 
   behavior of "ContainerProxy"
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -200,7 +200,7 @@ class ContainerProxyTests
       Future.successful(())
   }
   val poolConfig =
-    ContainerPoolConfig(2.MB, 0.5, false, false, false, 10)
+    ContainerPoolConfig(2.MB, 0.5, false, false, false, 10, 10.seconds)
 
   behavior of "ContainerProxy"
 
@@ -1126,7 +1126,7 @@ class ContainerProxyTests
                       apiKeyMustBePresent: Boolean = true)
       extends Container {
     protected[core] val id = ContainerId("testcontainer")
-    protected val addr = ContainerAddress("0.0.0.0")
+    override protected[core] val addr = ContainerAddress("0.0.0.0")
     protected implicit val logging: Logging = log
     protected implicit val ec: ExecutionContext = system.dispatcher
     override implicit protected val as: ActorSystem = system

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -201,7 +201,7 @@ class ContainerProxyTests
     (transid: TransactionId, activation: WhiskActivation, context: UserContext) =>
       Future.successful(())
   }
-  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, false)
+  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, false, 10)
 
   behavior of "ContainerProxy"
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -134,6 +134,9 @@ class ContainerProxyTests
   def run(machine: ActorRef, currentState: ContainerState) = {
     machine ! Run(action, message)
     expectMsg(Transition(machine, currentState, Running))
+    if (currentState == Uninitialized) {
+      expectMsg(ContainerStarted)
+    }
     expectWarmed(invocationNamespace.name, action)
     expectMsg(Transition(machine, Running, Ready))
   }
@@ -198,7 +201,7 @@ class ContainerProxyTests
     (transid: TransactionId, activation: WhiskActivation, context: UserContext) =>
       Future.successful(())
   }
-  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false)
+  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, false)
 
   behavior of "ContainerProxy"
 
@@ -450,6 +453,7 @@ class ContainerProxyTests
 
     machine ! Run(noLogsAction, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
     expectWarmed(invocationNamespace.name, noLogsAction)
     expectMsg(Transition(machine, Running, Ready))
 
@@ -731,6 +735,7 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -779,6 +784,7 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -817,6 +823,7 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -854,6 +861,7 @@ class ContainerProxyTests
     registerCallback(machine)
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
     expectMsg(ContainerRemoved) // The message is sent as soon as the container decides to destroy itself
     expectMsg(Transition(machine, Running, Removing))
 
@@ -985,6 +993,7 @@ class ContainerProxyTests
     // Start running the action
     machine ! Run(action, message)
     expectMsg(Transition(machine, Uninitialized, Running))
+    expectMsg(ContainerStarted)
 
     // Schedule the container to be removed
     machine ! Remove

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -32,7 +32,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.connector.ActivationMessage
-import org.apache.openwhisk.core.containerpool.ClusterManagedCapacityMonitor
 import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.containerpool.logging.LogCollectingException
 import org.apache.openwhisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
@@ -201,7 +200,7 @@ class ContainerProxyTests
       Future.successful(())
   }
   val poolConfig =
-    ContainerPoolConfig(2.MB, 0.5, false, false, 10, ClusterManagedCapacityMonitor(0.5, 10.seconds, 1024.B))
+    ContainerPoolConfig(2.MB, 0.5, false, false, false, 10)
 
   behavior of "ContainerProxy"
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Invoker use of cluster managed resources should allow dynamic cluster resizing.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Currently, invoker has a static config `whisk.container-pool.user-memory` that affects:
* controller sharding across invokers
* invoker's concept of ability to launch containers

This does not work well in an environment that may scale up in hosts to accommodate the ability to launch more containers. Making that config "dynamic" is also not the best solution since the invoker really has no say in ability to launch a container (in this case of cluster managed action containers, at least), and therefore relying on it at either controller or invoker layer is problematic.

This PR introduces:
* config flag to enable cluster managed resources - this is separate from ContainerFactory, and introduces some addition logic to ContainerPool
* NodeStats - collected at ContainerPool from akka system event stream, and used to determine (which respect to latest snapshot of data) whether a container is launchable
* Reservations - tracked at ContainerPool to accommodate timing delays between cluster manager container starts/stops, and updates to NodeStats

See proposal on apache wiki here: 
https://cwiki.apache.org/confluence/display/OPENWHISK/Cluster+Manager+Resources+in+Invoker  



## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

