### PR TITLE
Optional support for queued writes for CosmosDB

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
     compile 'io.reactivex:rxscala_2.12:0.26.5'
     compile 'io.reactivex:rxjava-reactive-streams:1.2.1'
-    compile ('com.microsoft.azure:azure-cosmosdb:2.4.2')
+    compile ('com.microsoft.azure:azure-cosmosdb:2.4.5')
 
     compile ('com.lightbend.akka:akka-stream-alpakka-s3_2.12:1.0.1') {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -281,6 +281,14 @@ whisk {
         #     }
         #   }
         # }
+
+        # Optional queued writes mode
+        # write-queue-config = {
+        #    # Size of in memory queue. If queue gets full then elements would be dropped upon addition
+        #    queue-size = 10000
+        #    # Number of concurrent connections to use to perform writes to db
+        #    concurrency = 500
+        # }
     }
 
     # transaction ID related configuration

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -82,7 +82,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   private val clusterIdValue = config.clusterId.map(JsString(_))
   private val docPersister: DocumentPersister =
     config.writeQueueConfig
-      .map(new QueuedPersister(this, _, Some(queueSizeToken.gauge)))
+      .map(new QueuedPersister(this, _, collName, Some(queueSizeToken.gauge)))
       .getOrElse(new SimplePersister(this))
 
   logging.info(

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -31,6 +31,8 @@ import pureconfig._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
+case class WriteQueueConfig(queueSize: Int, concurrency: Int)
+
 case class CosmosDBConfig(endpoint: String,
                           key: String,
                           db: String,
@@ -40,7 +42,8 @@ case class CosmosDBConfig(endpoint: String,
                           timeToLive: Option[Duration],
                           clusterId: Option[String],
                           softDeleteTTL: Option[FiniteDuration],
-                          recordUsageFrequency: Option[FiniteDuration]) {
+                          recordUsageFrequency: Option[FiniteDuration],
+                          writeQueueConfig: Option[WriteQueueConfig]) {
 
   def createClient(): AsyncDocumentClient = {
     new AsyncDocumentClient.Builder()

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
@@ -40,7 +40,7 @@ class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig,
   ec: ExecutionContext)
     extends DocumentPersister {
   private val queuedExecutor =
-    new QueuedExecutor[(JsObject, TransactionId), DocInfo](config.queueSize, config.concurrency)({
+    new QueuedExecutor[(JsObject, TransactionId), DocInfo](config.queueSize, config.concurrency, gauge)({
       case (js, tid) => store.putJsonDoc(js)(tid)
     })
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.core.database.cosmosdb
 
 import akka.Done
 import akka.stream.ActorMaterializer
+import kamon.metric.Gauge
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.entity.DocInfo
 import spray.json.JsObject
@@ -34,7 +35,7 @@ class SimplePersister(store: CosmosDBArtifactStore[_]) extends DocumentPersister
   override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = store.putJsonDoc(js)
 }
 
-class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig)(
+class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig, gauge: Option[Gauge])(
   implicit materializer: ActorMaterializer,
   ec: ExecutionContext)
     extends DocumentPersister {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import akka.Done
+import akka.stream.ActorMaterializer
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.entity.DocInfo
+import spray.json.JsObject
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait DocumentPersister {
+  def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo]
+  def close(): Future[Done] = Future.successful(Done)
+}
+
+class SimplePersister(store: CosmosDBArtifactStore[_]) extends DocumentPersister {
+  override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = store.putJsonDoc(js)
+}
+
+class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig)(
+  implicit materializer: ActorMaterializer,
+  ec: ExecutionContext)
+    extends DocumentPersister {
+  private val queuedExecutor =
+    new QueuedExecutor[(JsObject, TransactionId), DocInfo](config.queueSize, config.concurrency)({
+      case (js, tid) => store.putJsonDoc(js)(tid)
+    })
+
+  override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = queuedExecutor.put((js, transid))
+
+  override def close(): Future[Done] = queuedExecutor.close()
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/DocumentPersister.scala
@@ -19,10 +19,13 @@ package org.apache.openwhisk.core.database.cosmosdb
 
 import akka.Done
 import akka.stream.ActorMaterializer
-import kamon.metric.Gauge
-import org.apache.openwhisk.common.TransactionId
+import kamon.metric.{Gauge, MeasurementUnit}
+import org.apache.openwhisk.common.LoggingMarkers.start
+import org.apache.openwhisk.common.{LogMarkerToken, Logging, TransactionId}
+import org.apache.openwhisk.core.database.StoreUtils.reportFailure
+import org.apache.openwhisk.core.database.cosmosdb.CosmosDBUtil.{_id, _rev}
 import org.apache.openwhisk.core.entity.DocInfo
-import spray.json.JsObject
+import spray.json.{DefaultJsonProtocol, JsObject}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -35,16 +38,31 @@ class SimplePersister(store: CosmosDBArtifactStore[_]) extends DocumentPersister
   override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = store.putJsonDoc(js)
 }
 
-class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig, gauge: Option[Gauge])(
+class QueuedPersister(store: CosmosDBArtifactStore[_], config: WriteQueueConfig, collName: String, gauge: Option[Gauge])(
   implicit materializer: ActorMaterializer,
-  ec: ExecutionContext)
-    extends DocumentPersister {
+  ec: ExecutionContext,
+  logging: Logging)
+    extends DocumentPersister
+    with DefaultJsonProtocol {
+  private val enqueueDoc =
+    LogMarkerToken("database", "enqueueDocument", start)(MeasurementUnit.time.milliseconds)
   private val queuedExecutor =
     new QueuedExecutor[(JsObject, TransactionId), DocInfo](config.queueSize, config.concurrency, gauge)({
       case (js, tid) => store.putJsonDoc(js)(tid)
     })
 
-  override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = queuedExecutor.put((js, transid))
+  override def put(js: JsObject)(implicit transid: TransactionId): Future[DocInfo] = {
+    val id = js.fields(_id).convertTo[String]
+    val rev = js.fields.get(_rev).map(_.convertTo[String]).getOrElse("")
+    val docinfoStr = s"id: $id, rev: $rev"
+    val start = transid.started(this, enqueueDoc, s"[PUT] '$collName' saving document: '$docinfoStr'")
+    val f = queuedExecutor.put((js, transid))
+    reportFailure(
+      f,
+      start,
+      failure => s"[PUT] '$collName' internal error for $docinfoStr, failure: '${failure.getMessage}'")
+    f
+  }
 
   override def close(): Future[Done] = queuedExecutor.close()
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import akka.Done
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult}
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
+
+class QueuedExecutor[T, R](queueSize: Int, concurrency: Int)(operation: T => Future[R])(
+  implicit materializer: ActorMaterializer,
+  ec: ExecutionContext) {
+  //TODO Track queue size
+  private val (docQueue, queueFinish) = Source
+    .queue[(T, Promise[R])](queueSize, OverflowStrategy.dropNew)
+    .mapAsyncUnordered(concurrency) {
+      case (d, p) =>
+        val f = operation(d)
+        f.onComplete {
+          case Success(result) => p.success(result)
+          case Failure(e)      => p.failure(e)
+        }
+        // Recover Future to not abort stream in case of a failure
+        f.recover { case _ => () }
+    }
+    .toMat(Sink.ignore)(Keep.both)
+    .run()
+
+  /**
+   * Queues an element to be written later
+   *
+   * @param el the element to process
+   * @return a future containing the response of the database for this specific element
+   */
+  def put(el: T): Future[R] = {
+    val promise = Promise[R]()
+    docQueue.offer(el -> promise).flatMap {
+      case QueueOfferResult.Enqueued    => promise.future
+      case QueueOfferResult.Dropped     => Future.failed(new Exception("DB request queue is full."))
+      case QueueOfferResult.QueueClosed => Future.failed(new Exception("DB request queue was closed."))
+      case QueueOfferResult.Failure(f)  => Future.failed(f)
+    }
+    promise.future
+  }
+
+  def close(): Future[Done] = {
+    docQueue.complete()
+    docQueue.watchCompletion().flatMap(_ => queueFinish)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
@@ -63,7 +63,6 @@ class QueuedExecutor[T, R](queueSize: Int, concurrency: Int, gauge: Option[Gauge
       case QueueOfferResult.QueueClosed => Future.failed(new Exception("DB request queue was closed."))
       case QueueOfferResult.Failure(f)  => Future.failed(f)
     }
-    promise.future
   }
 
   def close(): Future[Done] = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutor.scala
@@ -25,7 +25,7 @@ import kamon.metric.Gauge
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-class QueuedExecutor[T, R](queueSize: Int, concurrency: Int, gauge: Option[Gauge] = None)(operation: T => Future[R])(
+class QueuedExecutor[T, R](queueSize: Int, concurrency: Int, gauge: Option[Gauge])(operation: T => Future[R])(
   implicit materializer: ActorMaterializer,
   ec: ExecutionContext) {
   private val (queue, queueFinish) = Source

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBQueuedWriteTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBQueuedWriteTests.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.database.DocumentSerializer
+import org.apache.openwhisk.core.database.memory.MemoryAttachmentStoreProvider
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+@RunWith(classOf[JUnitRunner])
+class CosmosDBQueuedWriteTests extends FlatSpec with CosmosDBStoreBehaviorBase {
+  override def storeType = "CosmosDB_QueuedWrites"
+
+  override protected def getAttachmentStore[D <: DocumentSerializer: ClassTag]() =
+    Some(MemoryAttachmentStoreProvider.makeStore[D]())
+
+  override def adaptCosmosDBConfig(config: CosmosDBConfig): CosmosDBConfig =
+    config.copy(writeQueueConfig = Some(WriteQueueConfig(1000, 2)))
+
+  it should "write multiple documents" in {
+    implicit val tid: TransactionId = transid()
+
+    val insertCount = 10
+    val ns = newNS()
+    val activations = (1 to insertCount).map(newActivation(ns.asString, "testact", _))
+    val f = Future.sequence(activations.map(activationStore.put(_)))
+
+    implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 2.minutes)
+    f.futureValue.size shouldBe insertCount
+
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutorTests.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import akka.Done
+import akka.stream.ActorMaterializer
+import common.{LoggedFunction, WskActorSystem}
+import org.apache.openwhisk.utils.retry
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
+
+@RunWith(classOf[JUnitRunner])
+class QueuedExecutorTests extends FlatSpec with Matchers with WskActorSystem with ScalaFutures {
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  val promiseDelay = 100.milliseconds
+  def resolveDelayed(p: Promise[Unit], delay: FiniteDuration = promiseDelay) =
+    akka.pattern.after(delay, actorSystem.scheduler) {
+      p.success(())
+      Future.successful(())
+    }
+
+  behavior of "QueuedExecutor"
+
+  it should "complete queued values with the thrown exception" in {
+    val executor = new QueuedExecutor[Int, Int](2, 1)(_ => Future.failed(new Exception))
+
+    val r1 = executor.put(1)
+    val r2 = executor.put(2)
+
+    r1.failed.futureValue shouldBe an[Exception]
+    r2.failed.futureValue shouldBe an[Exception]
+
+    // the executor is still intact
+    val r3 = executor.put(3)
+    val r4 = executor.put(4)
+
+    r3.failed.futureValue shouldBe an[Exception]
+    r4.failed.futureValue shouldBe an[Exception]
+  }
+
+  it should "wait for executions to finish on close" in {
+    val count = 5
+
+    val ps = Seq.fill(count)(Promise[Unit]())
+    val queuedPromises = mutable.Queue(ps: _*)
+
+    val queuedOperation = LoggedFunction((i: Int) => {
+      queuedPromises.dequeue().future.map(_ => i + 1)
+    })
+
+    val executor = new QueuedExecutor[Int, Int](100, 1)(queuedOperation)
+
+    val values = 1 to count
+    val results = values.map(executor.put)
+
+    // First entry
+    retry(queuedOperation.calls should have size 1)
+    executor.size shouldBe count
+
+    ps.head.success(())
+    retry(queuedOperation.calls should have size 2)
+
+    //Trigger close
+    val closeF = executor.close()
+
+    //Let each operation complete now
+    ps.foreach(_.trySuccess(()))
+
+    //Wait for executor to close
+    closeF.futureValue shouldBe Done
+
+    queuedOperation.calls should have size count
+    Future.sequence(results).futureValue.sum shouldBe values.map(_ + 1).sum
+    executor.size shouldBe 0
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/QueuedExecutorTests.scala
@@ -45,7 +45,7 @@ class QueuedExecutorTests extends FlatSpec with Matchers with WskActorSystem wit
   behavior of "QueuedExecutor"
 
   it should "complete queued values with the thrown exception" in {
-    val executor = new QueuedExecutor[Int, Int](2, 1)(_ => Future.failed(new Exception))
+    val executor = new QueuedExecutor[Int, Int](2, 1, None)(_ => Future.failed(new Exception))
 
     val r1 = executor.put(1)
     val r2 = executor.put(2)


### PR DESCRIPTION
For activations in case of high volume we are seeing connection pool related error. This PR adds an optional support for having queued writes

## Description

In case of high volume of writes on Invoker we are seeing errors like 

```
[2019-06-11T00:37:10.196Z] [ERROR] Network failureio.reactivex.netty.client.PoolExhaustedException: null    
    at io.reactivex.netty.client.ConnectionPoolImpl.performAquire(ConnectionPoolImpl.java:177)  
    at io.reactivex.netty.client.ConnectionPoolImpl.access$300(ConnectionPoolImpl.java:45)  
    at io.reactivex.netty.client.ConnectionPoolImpl$1.call(ConnectionPoolImpl.java:139) 
    at io.reactivex.netty.client.ConnectionPoolImpl$1.call(ConnectionPoolImpl.java:124) 
    at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)  
    at rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)  
```

This was observed with a pool size of 1000.  To prevent such cases it would be better to have a more controlled way of writing documents to db. Earlier for CouchDB similar thing was done via #2812 where batched writes were used. Currently CosmosDB does not provide an easy way to perform batched writes (Azure/azure-cosmosdb-java#182). 

### Design

To enable controlled writes this PR introduces a `QueuedExecutor` (similar in spirit to existing `Batcher` implementation) which ensures that writes are queued and then prcessed in a controlled way. Key points

* The queue size is tracked as a gauge metric
* Implementation ensures that upon close any existing entry in queue should get persisted
* Proper [backpressure is not possible][1]. So in case of very excessive writes entries would be dropped. Other option is to set a higher queue size but that can result in out of memory scenario. 

### Usage

```
  cosmosdb {
    collections {
      WhiskActivation {
        write-queue-config = {
          # Size of in memory queue. If queue gets full then put calls would be rejected
          queue-size = 100000

          # Number of concurrent connections to use to perform writes to db
          concurrency = 500
        }
      }
    }
  }
```

### Future Enhancement

We can possibly optimize the write throughput by implementing the bulk write logic as used in [CosmosDB Bulk Importer](https://chapsas.com/how-the-cosmosdb-bulk-executor-works-under-the-hood/). This would require us to batch the inserts and then sort by partition and send the calls to respective partition.

Another possible option to reduce heap pressure would be to store the object in byte array form in queue and deserialize before passing to `ArtifactStore`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://github.com/apache/incubator-openwhisk/pull/2812#discussion_r142941162

