### PR TITLE
Add reason parameter for wskadmin tool

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
@@ -218,13 +218,16 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
           "--firesPerMinute",
           "2",
           "--concurrentInvocations",
-          "3"))
+          "3",
+          "--reason",
+          "WskAdminTests: adjust throttles for namespace"))
       // check correctly set
       val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
-      lines should have size 3
+      lines should have size 4
       lines(0) shouldBe "invocationsPerMinute = 1"
       lines(1) shouldBe "firesPerMinute = 2"
       lines(2) shouldBe "concurrentInvocations = 3"
+      lines(3) shouldBe "reason = WskAdminTests: adjust throttles for namespace"
     } finally {
       wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
     }

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -147,6 +147,7 @@ def parseArgs():
     subcmd.add_argument('--concurrentInvocations', help='concurrent invocations allowed for this namespace', type=int)
     subcmd.add_argument('--allowedKinds', help='list of runtime kinds allowed in this namespace', nargs='+', type=str)
     subcmd.add_argument('--storeActivations', help='enable or disable storing of activations to datastore for this namespace', default=None, type=str_to_bool)
+    subcmd.add_argument('--reason', help='reason for set limits for a given namespace', type=str)
 
     subcmd = subparser.add_parser('get', help='get limits for a given namespace (if none exist, system defaults apply)')
     subcmd.add_argument('namespace', help='the namespace to get limits for')
@@ -552,6 +553,11 @@ def setLimitsCmd(args, props):
         toSet = givenLimit if givenLimit != None else doc.get(limit)
         if toSet != None:
             doc[limit] = toSet
+    # setting reason
+    givenReason = argsDict.get('reason')
+    toSet = givenReason if givenReason != None else doc.get('reason')
+    if toSet != None:
+        doc['reason'] = toSet
 
     res = insertIntoDatabase(props, doc, args.verbose)
     if res.status in [201, 202]:
@@ -570,6 +576,10 @@ def getLimitsCmd(args, props):
             givenLimit = dbDoc.get(limit)
             if givenLimit != None:
                 print('%s = %s' % (limit, givenLimit))
+        # get reason
+        givenReason = dbDoc.get('reason')
+        if givenReason != None:
+            print('%s = %s' % ('reason', givenReason))
     else:
         error = json.loads(res.read())
         if error['reason'] == 'missing' or error['reason'] == 'deleted':

--- a/tools/admin/wskadmin
+++ b/tools/admin/wskadmin
@@ -555,7 +555,7 @@ def setLimitsCmd(args, props):
             doc[limit] = toSet
     # setting reason
     givenReason = argsDict.get('reason')
-    toSet = givenReason if givenReason != None else doc.get('reason')
+    toSet = givenReason[:256] if givenReason != None else doc.get('reason')
     if toSet != None:
         doc['reason'] = toSet
 


### PR DESCRIPTION
For auditability reasons it would be beneficial to also specify a reason for the set limits command (why was a certain namespace throttled on a given limit).

This PR adds a reason parameter to the `wskadmin` tool. It is the most simple implementation where the reason value would be overwritten by each new set limits command. 

```
{
  "_id": "<namespace>/limits",
  "firesPerMinute": 100,
  "invocationsPerMinute": 200,
  "reason": "throttle namespace on invocations per minute because of .."
}
```

In order to have a kind of audit trail/log available the history of changes on the `/limits` documents needs to be stored. Please find below a sample of the `/limits` document containing an audit log. However this PR does not implement an audit log but only adds a single reason parameter to the `/limits` document as described above.

```
{
  "_id": "<namespace>/limits",
  "firesPerMinute": 100,
  "invocationsPerMinute": 200,
  "reasons": [
    {
      "reason": "throttle namespace on fires per minute because of ..",
      "time": "1562317956422",
      "limits": {
        "firesPerMinute": 100
      }
    },
    {
      "reason": "throttle namespace on invocations per minute because of ..",
      "time": "1562318956422",
      "limits": {
        "invocationsPerMinute": 200
      }
    }
  ]
}
```

## Description
This code change add an additional reason parameter to the wskadmin tool to store in addition the reason for the set limits command for auditability reasons..

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

