### PR TITLE
Remove configureOSSpecificOpts in standalone and move the config options to standalone.conf

### DIFF
--- a/core/standalone/src/main/resources/standalone.conf
+++ b/core/standalone/src/main/resources/standalone.conf
@@ -32,6 +32,10 @@ whisk {
     ArtifactStoreProvider = "org.apache.openwhisk.core.database.memory.MemoryArtifactStoreProvider"
     MessagingProvider = "org.apache.openwhisk.connector.lean.LeanMessagingProvider"
     LoadBalancerProvider = "org.apache.openwhisk.core.loadBalancer.LeanBalancer"
+    # Use cli based log store for all setups as its more stable to use
+    # and does not require root user access
+    LogStoreProvider = "org.apache.openwhisk.core.containerpool.docker.DockerCliLogStoreProvider"
+    ContainerFactoryProvider = "org.apache.openwhisk.core.containerpool.docker.StandaloneDockerContainerFactoryProvider"
   }
 
   info {
@@ -66,6 +70,11 @@ whisk {
     standalone.container-factory {
       #If enabled then pull would also be attempted for standard OpenWhisk images under`openwhisk` prefix
       pull-standard-images: true
+    }
+
+    container-factory {
+      # Disable runc by default to keep things stable
+      use-runc: false
     }
   }
   swagger-ui {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -123,7 +123,6 @@ object StandaloneOpenWhisk extends SLF4JLogging {
   def initialize(conf: Conf): Unit = {
     configureBuildInfo()
     configureServerPort(conf)
-    configureOSSpecificOpts()
     initConfigLocation(conf)
     configureRuntimeManifest(conf)
     loadWhiskConfig()
@@ -194,19 +193,6 @@ object StandaloneOpenWhisk extends SLF4JLogging {
         Await.ready(admin.executeCommand(), 60.seconds)
         logging.info(this, s"Created user [$subject]")
     }
-  }
-
-  private def configureOSSpecificOpts(): Unit = {
-    setSysProp(
-      "whisk.spi.ContainerFactoryProvider",
-      "org.apache.openwhisk.core.containerpool.docker.StandaloneDockerContainerFactoryProvider")
-
-    //Disable runc by default to keep things stable
-    setSysProp("whisk.docker.container-factory.use-runc", "False")
-
-    //Use cli based log store for all setups as its more stable to use
-    // and does not require root user access
-    setSysProp("whisk.spi.LogStoreProvider", "org.apache.openwhisk.core.containerpool.docker.DockerCliLogStoreProvider")
   }
 
   private def localHostName = {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
The setSysOps are override the standalone.conf since standalone.conf
is evaluated first. The will prevent us from using a custom config files
on these parameters. Moving these options from code into
standalone.conf, so a custom config files can potentially override them.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

