### PR TITLE
graduation: remove more incubator- references

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ information shown below.
 If you are reporting an enhancement request, please include information on what you are trying to achieve and why that enhancement would help you.
 
 For more information about reporting issues, see
-https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md#raising-issues
+https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#raising-issues
 
 Use the commands below to provide key information from your environment:
 You do not have to include this information if this is a feature request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,8 @@
 ## Checklist:
 <!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->
 
-- [ ] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
-- [ ] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
+- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
+- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
 - [ ] I added tests to cover my changes.
 - [ ] My changes require further changes to the documentation.
 - [ ] I updated the documentation where necessary.

--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -87,4 +87,4 @@ The following repositories were included in the donation:
 
 
                           The Apache OpenWhisk Community
-                       http://openwhisk.incubator.apache.org/
+                           http://openwhisk.apache.org/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [![codecov](https://codecov.io/gh/apache/openwhisk/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/openwhisk)
 [![Twitter](https://img.shields.io/twitter/follow/openwhisk.svg?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=openwhisk)
 
-OpenWhisk is a cloud-first distributed event-based programming service. It provides a programming model to upload event handlers to a cloud service, and register the handlers to respond to various events. Learn more at [http://openwhisk.incubator.apache.org](http://openwhisk.incubator.apache.org).
+OpenWhisk is a cloud-first distributed event-based programming service. It provides a programming model to upload event handlers to a cloud service, and register the handlers to respond to various events. Learn more at [http://openwhisk.apache.org](http://openwhisk.apache.org).
 
 
 * [Quick Start](#quick-start) (Docker-Compose)
@@ -124,4 +124,4 @@ Report bugs, ask questions and request features [here on GitHub](../../issues).
 
 ### Slack
 
-You can also join the OpenWhisk Team on Slack [https://openwhisk-team.slack.com](https://openwhisk-team.slack.com) and chat with developers. To get access to our public slack team, request an invite [https://openwhisk.incubator.apache.org/slack.html](https://openwhisk.incubator.apache.org/slack.html).
+You can also join the OpenWhisk Team on Slack [https://openwhisk-team.slack.com](https://openwhisk-team.slack.com) and chat with developers. To get access to our public slack team, request an invite [https://openwhisk.apache.org/slack.html](https://openwhisk.apache.org/slack.html).

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 # OpenWhisk
 
-[![Build Status](https://travis-ci.org/apache/incubator-openwhisk.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk)
+[![Build Status](https://travis-ci.org/apache/openwhisk.svg?branch=master)](https://travis-ci.org/apache/openwhisk)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Join Slack](https://img.shields.io/badge/join-slack-9B69A0.svg)](http://slack.openwhisk.org/)
-[![codecov](https://codecov.io/gh/apache/incubator-openwhisk/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-openwhisk)
+[![codecov](https://codecov.io/gh/apache/openwhisk/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/openwhisk)
 [![Twitter](https://img.shields.io/twitter/follow/openwhisk.svg?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=openwhisk)
 
 OpenWhisk is a cloud-first distributed event-based programming service. It provides a programming model to upload event handlers to a cloud service, and register the handlers to respond to various events. Learn more at [http://openwhisk.incubator.apache.org](http://openwhisk.incubator.apache.org).
@@ -40,22 +40,22 @@ OpenWhisk is a cloud-first distributed event-based programming service. It provi
 The easiest way to start using OpenWhisk is to get Docker installed on Mac, Windows or Linux. The [Docker website](https://docs.docker.com/install/) has detailed instructions on getting the tools installed. This does not give you a production deployment but gives you enough of the pieces to start writing functions and seeing them run.
 
 ```
-git clone https://github.com/apache/incubator-openwhisk-devtools.git
-cd incubator-openwhisk-devtools/docker-compose
+git clone https://github.com/apache/openwhisk-devtools.git
+cd openwhisk-devtools/docker-compose
 make quick-start
 ```
 
-For more detailed instructions or if you encounter problems see the [OpenWhisk-dev tools](https://github.com/apache/incubator-openwhisk-devtools/blob/master/docker-compose/README.md) project.
+For more detailed instructions or if you encounter problems see the [OpenWhisk-dev tools](https://github.com/apache/openwhisk-devtools/blob/master/docker-compose/README.md) project.
 
 ### Kubernetes Setup
 
 Another path to quickly starting to use OpenWhisk is to install it on a Kubernetes cluster.  On a Mac, you can use the Kubernetes support built into Docker 18.06 (or higher). You can also deploy OpenWhisk on Minikube, on a managed Kubernetes cluster provisioned from a public cloud provider, or on a Kubernetes cluster you manage yourself. To get started,
 
 ```
-git clone https://github.com/apache/incubator-openwhisk-deploy-kube.git
+git clone https://github.com/apache/openwhisk-deploy-kube.git
 ```
 
-Then follow the instructions in the [OpenWhisk on Kubernetes README.md](https://github.com/apache/incubator-openwhisk-deploy-kube/blob/master/README.md).
+Then follow the instructions in the [OpenWhisk on Kubernetes README.md](https://github.com/apache/openwhisk-deploy-kube/blob/master/README.md).
 
 ### Vagrant Setup
 A [Vagrant](http://vagrantup.com) machine is also available to run OpenWhisk on Mac, Windows PC or GNU/Linux but isn't used by as much of the dev team so sometimes lags behind.
@@ -66,7 +66,7 @@ Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and
 Follow these step to run your first OpenWhisk Action:
 ```
 # Clone openwhisk
-git clone --depth=1 https://github.com/apache/incubator-openwhisk.git openwhisk
+git clone --depth=1 https://github.com/apache/openwhisk.git openwhisk
 
 # Change directory to tools/vagrant
 cd openwhisk/tools/vagrant

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -202,25 +202,25 @@ There are two installation modes to install `wsk` CLI: remote and local.
 The mode "remote" means to download the `wsk` binaries from available web links.
 By default, OpenWhisk sets the installation mode to remote and downloads the
 binaries from the CLI
-[release page](https://github.com/apache/incubator-openwhisk-cli/releases),
+[release page](https://github.com/apache/openwhisk-cli/releases),
 where OpenWhisk publishes the official `wsk` binaries.
 
 The mode "local" means to build and install the `wsk` binaries from local CLI
 project. You can download the source code of OpenWhisk CLI
-[here](https://github.com/apache/incubator-openwhisk-cli).
+[here](https://github.com/apache/openwhisk-cli).
 Let's assume your OpenWhisk CLI home directory is
-`$OPENWHISK_HOME/../incubator-openwhisk-cli` and you've already `export`ed
+`$OPENWHISK_HOME/../openwhisk-cli` and you've already `export`ed
 `OPENWHISK_HOME` to be the root directory of this project. After you download
 the CLI repository, use the gradle command to build the binaries (you can omit
 the `-PnativeBuild` if you want to cross-compile for all supported platforms):
 
 ```
-cd "$OPENWHISK_HOME/../incubator-openwhisk-cli"
+cd "$OPENWHISK_HOME/../openwhisk-cli"
 ./gradlew releaseBinaries -PnativeBuild
 ```
 
 The binaries are generated and put into a tarball in the folder
-`../incubator-openwhisk-cli/release`.  Then, use the following Ansible command
+`../openwhisk-cli/release`.  Then, use the following Ansible command
 to (re-)configure the CLI installation:
 
 ```
@@ -228,13 +228,13 @@ export OPENWHISK_ENVIRONMENT=local  # ... or whatever
 ansible-playbook -i environments/$OPENWHISK_ENVIRONMENT edge.yml -e mode=clean
 ansible-playbook -i environments/$OPENWHISK_ENVIRONMENT edge.yml \
     -e cli_installation_mode=local \
-    -e openwhisk_cli_home="$OPENWHISK_HOME/../incubator-openwhisk-cli"
+    -e openwhisk_cli_home="$OPENWHISK_HOME/../openwhisk-cli"
 ```
 
 The parameter `cli_installation_mode` specifies the CLI installation mode and
 the parameter `openwhisk_cli_home` specifies the home directory of your local
 OpenWhisk CLI.  (_n.b._ `openwhisk_cli_home` defaults to
-`$OPENWHISK_HOME/../incubator-openwhisk-cli`.)
+`$OPENWHISK_HOME/../openwhisk-cli`.)
 
 Once the CLI is installed, you can [use it to work with Whisk](../docs/cli.md).
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -19,7 +19,7 @@ mode: deploy
 lean: false
 prompt_user: true
 openwhisk_home: "{{ lookup('env', 'OPENWHISK_HOME') | default(playbook_dir ~ '/..', true) }}"
-openwhisk_cli_home: "{{ lookup('env', 'OPENWHISK_CLI') | default(openwhisk_home ~ '/../incubator-openwhisk-cli', true) }}"
+openwhisk_cli_home: "{{ lookup('env', 'OPENWHISK_CLI') | default(openwhisk_home ~ '/../openwhisk-cli', true) }}"
 exclude_logs_from: []
 
 # This whisk_api_localhost_name_default is used to configure nginx to permit vanity URLs for web actions
@@ -339,7 +339,7 @@ catalog_auth_key: "{{ playbook_dir }}/files/auth.whisk.system"
 #
 catalog_repos:
   openwhisk-catalog:
-    url: https://github.com/apache/incubator-openwhisk-catalog.git
+    url: https://github.com/apache/openwhisk-catalog.git
     # Set the local location as the same level as openwhisk home, but it can be changed.
     location: "{{ openwhisk_home }}/../openwhisk-catalog"
     version: "HEAD"
@@ -369,7 +369,7 @@ openwhisk_cli:
   local:
     location: "{{ openwhisk_cli_home }}/build"
   remote:
-    location: "https://github.com/apache/incubator-openwhisk-cli/releases/download/{{ openwhisk_cli_tag }}"
+    location: "https://github.com/apache/openwhisk-cli/releases/download/{{ openwhisk_cli_tag }}"
 
 # Controls access to log directories
 logs:

--- a/ansible/roles/nginx/templates/nginx.conf.j2
+++ b/ansible/roles/nginx/templates/nginx.conf.j2
@@ -138,11 +138,11 @@ http {
         }
 
         location /blackbox.tar.gz {
-            return 301 https://github.com/apache/incubator-openwhisk-runtime-docker/releases/download/sdk%400.1.0/blackbox-0.1.0.tar.gz;
+            return 301 https://github.com/apache/openwhisk-runtime-docker/releases/download/sdk%400.1.0/blackbox-0.1.0.tar.gz;
         }
 
         location /OpenWhiskIOSStarterApp.zip {
-            return 301 https://github.com/apache/incubator-openwhisk-client-swift/releases/download/0.3.0/starterapp-0.3.0.zip;
+            return 301 https://github.com/apache/openwhisk-client-swift/releases/download/0.3.0/starterapp-0.3.0.zip;
         }
 
         location /cli {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -443,7 +443,7 @@ whisk {
 
     feature-flags {
         # Enables support for `provide-api-key` annotation.
-        # See https://github.com/apache/incubator-openwhisk/pull/4284
+        # See https://github.com/apache/openwhisk/pull/4284
         # for details
         require-api-key-annotation = true
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -190,7 +190,7 @@ object Controller {
     JsObject(
       "description" -> "OpenWhisk".toJson,
       "support" -> JsObject(
-        "github" -> "https://github.com/apache/incubator-openwhisk/issues".toJson,
+        "github" -> "https://github.com/apache/openwhisk/issues".toJson,
         "slack" -> "http://slack.openwhisk.org".toJson),
       "api_paths" -> apis.toJson,
       "limits" -> JsObject(

--- a/core/cosmosdb/cache-invalidator/README.md
+++ b/core/cosmosdb/cache-invalidator/README.md
@@ -62,5 +62,5 @@ event is generated:
 
 [1]: https://docs.microsoft.com/en-us/azure/cosmos-db/change-feed
 [2]: https://github.com/Azure/azure-documentdb-changefeedprocessor-java
-[3]: https://github.com/apache/incubator-openwhisk-devtools/tree/master/docker-compose
+[3]: https://github.com/apache/openwhisk-devtools/tree/master/docker-compose
 [4]: https://github.com/Landoop/kafka-topics-ui

--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -189,5 +189,5 @@ whisk {
 
 Then pass this config file via `-c` option.
 
-[1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md
-[2]: https://github.com/apache/incubator-openwhisk/blob/master/docs/samples.md
+[1]: https://github.com/apache/openwhisk/blob/master/docs/cli.md
+[2]: https://github.com/apache/openwhisk/blob/master/docs/samples.md

--- a/docs/about.md
+++ b/docs/about.md
@@ -40,7 +40,7 @@ Being an open-source project, OpenWhisk stands on the shoulders of giants, inclu
 
 ## Creating the action
 
-To give the explanation a little bit of context, let’s create an action in the system first. We will use that action to explain the concepts later on while tracing through the system. The following commands assume that the [OpenWhisk CLI is setup properly](https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md).
+To give the explanation a little bit of context, let’s create an action in the system first. We will use that action to explain the concepts later on while tracing through the system. The following commands assume that the [OpenWhisk CLI is setup properly](https://github.com/apache/openwhisk/blob/master/docs/cli.md).
 
 First, we’ll create a file *action.js* containing the following code which will print “Hello World” to stdout and return a JSON object containing “world” under the key “hello”.
 ```

--- a/docs/actions-actionloop.md
+++ b/docs/actions-actionloop.md
@@ -19,17 +19,17 @@
 
 # Developing a new Runtime with the ActionLoop proxy
 
-The [OpenWhisk runtime specification](actions-new.md) defines the expected behavior of an OpenWhisk runtime; you can choose to implement a new runtime from scratch by just following this specification. However, the fastest way to develop a new, compliant runtime is by reusing the *[ActionLoop proxy](https://github.com/apache/incubator-openwhisk-runtime-go#actionloop-runtime)* which already implements most of the specification and requires you to write code for just a few hooks to get a fully functional (and *fast*) runtime in a few hours or less.
+The [OpenWhisk runtime specification](actions-new.md) defines the expected behavior of an OpenWhisk runtime; you can choose to implement a new runtime from scratch by just following this specification. However, the fastest way to develop a new, compliant runtime is by reusing the *[ActionLoop proxy](https://github.com/apache/openwhisk-runtime-go#actionloop-runtime)* which already implements most of the specification and requires you to write code for just a few hooks to get a fully functional (and *fast*) runtime in a few hours or less.
 
 ## What is the ActionLoop proxy
 
-The `ActionLoop proxy` is a runtime "engine", written in the [Go programming language](https://golang.org/), originally developed specifically to support the [OpenWhisk Go language runtime](https://github.com/apache/incubator-openwhisk-runtime-go). However, it was written in a  generic way such that it has since been adopted to implement OpenWhisk runtimes for Swift, PHP, Python, Rust, Java, Ruby and Crystal. Even though it was developed with compiled languages in mind it works equally well with scripting languages.
+The `ActionLoop proxy` is a runtime "engine", written in the [Go programming language](https://golang.org/), originally developed specifically to support the [OpenWhisk Go language runtime](https://github.com/apache/openwhisk-runtime-go). However, it was written in a  generic way such that it has since been adopted to implement OpenWhisk runtimes for Swift, PHP, Python, Rust, Java, Ruby and Crystal. Even though it was developed with compiled languages in mind it works equally well with scripting languages.
 
 Using it, you can develop a new runtime in a fraction of the time needed for authoring a full-fledged runtime from scratch. This is due to the fact that you have only to write a command line protocol and not a fully-featured web server (with a small amount of corner cases to consider). The results should also produce a runtime that is fairly fast and responsive.  In fact, the ActionLoop proxy has also been adopted to improve the performance of existing runtimes like Python, Ruby, PHP, and Java where performance has improved by a factor between 2x to 20x.
 
 ### Precompilation of OpenWhisk Actions
 
-In addition to being the basis for new runtime development,  ActionLoop runtimes can also support offline "precompilation" of OpenWhisk Action source files into a ZIP file that contains only the compiled binaries which are very fast to start once deployed. More information on this approach can be found here: [Precompiling Go Sources Offline](https://github.com/apache/incubator-openwhisk-runtime-go/blob/master/docs/DEPLOY.md#precompile) which describes how to do this for the Go language, but the approach applies to any language supported by ActionLoop.
+In addition to being the basis for new runtime development,  ActionLoop runtimes can also support offline "precompilation" of OpenWhisk Action source files into a ZIP file that contains only the compiled binaries which are very fast to start once deployed. More information on this approach can be found here: [Precompiling Go Sources Offline](https://github.com/apache/openwhisk-runtime-go/blob/master/docs/DEPLOY.md#precompile) which describes how to do this for the Go language, but the approach applies to any language supported by ActionLoop.
 
 # Tutorial - How to write a new runtime with the ActionLoop Proxy
 
@@ -46,11 +46,11 @@ The general procedure for authoring a runtime with the `ActionLoop proxy` requir
 
 ## ActionLoop Starter Kit
 
-To facilitate the process, there is an `actionloop-starter-kit` in the [openwhisk-devtools](https://github.com/apache/incubator-openwhisk-devtools/tree/master/actionloop-starter-kit) GitHub repository, that implements a fully working runtime for Python.  It contains a stripped-down version of the real Python runtime (with some advanced features removed) along with guided, step-by-step instructions on how to translate it to a different target runtime language using Ruby as an example.
+To facilitate the process, there is an `actionloop-starter-kit` in the [openwhisk-devtools](https://github.com/apache/openwhisk-devtools/tree/master/actionloop-starter-kit) GitHub repository, that implements a fully working runtime for Python.  It contains a stripped-down version of the real Python runtime (with some advanced features removed) along with guided, step-by-step instructions on how to translate it to a different target runtime language using Ruby as an example.
 
 In short, the starter kit provides templates you can adapt in creating an ActionLoop runtime for each of the steps listed above, these include :
 
--checking out  the `actionloop-starter-kit` from the `incubator-openwhisk-devtools` repository
+-checking out  the `actionloop-starter-kit` from the `openwhisk-devtools` repository
 -editing the `Dockerfile` to create the target environment for your target language.
 -converting (rewrite) the `launcher.py` script to an equivalent for script for your target language.
 -editing the `compile` script to compile your action in your target language.
@@ -88,8 +88,8 @@ $ docker ps
 So let's start to create our own `actionloop-demo-ruby-2.6` runtime. First, check out the `devtools` repository to access the starter kit, then move it in your home directory to work on it.
 
 ```bash
-$ git clone https://github.com/apache/incubator-openwhisk-devtools
-$ mv incubator-openwhisk-devtools/actionloop-starter-kit ~/actionloop-demo-ruby-v2.6
+$ git clone https://github.com/apache/openwhisk-devtools
+$ mv openwhisk-devtools/actionloop-starter-kit ~/actionloop-demo-ruby-v2.6
 ```
 
 Now, take the directory `python3.7` and rename it to `ruby2.6` and use `sed` to fix the directory name references in the Gradle build files.
@@ -770,7 +770,7 @@ Rename to `tests/src/test/scala/runtime/actionContainers/ActionLoopRubyBasicTest
 - `testEntryPointOtherThanMain`
 - `testLargeInput`
 
-You should convert Python code to Ruby code. We do not do go into the details of each test, as they are pretty simple and obvious. You can check the source code for the real test [here](https://github.com/apache/incubator-openwhisk-runtime-ruby/blob/master/tests/src/test/scala/actionContainers/Ruby26ActionLoopContainerTests.scala).
+You should convert Python code to Ruby code. We do not do go into the details of each test, as they are pretty simple and obvious. You can check the source code for the real test [here](https://github.com/apache/openwhisk-runtime-ruby/blob/master/tests/src/test/scala/actionContainers/Ruby26ActionLoopContainerTests.scala).
 
 You can verify tests are running properly with:
 

--- a/docs/actions-docker.md
+++ b/docs/actions-docker.md
@@ -25,7 +25,7 @@ Building custom runtime images is a common solution to the issue of having exter
 
 ### Usage
 
-The [Apache OpenWhisk CLI](https://github.com/apache/incubator-openwhisk-cli) has a `--docker` configuration parameter to set a custom runtime for an action.
+The [Apache OpenWhisk CLI](https://github.com/apache/openwhisk-cli) has a `--docker` configuration parameter to set a custom runtime for an action.
 
 ```
 wsk action create <ACTION_NAME> --docker <IMAGE> source.js
@@ -43,7 +43,7 @@ In this scenario, action source code will not be injected into the runtime durin
 
 ### Restrictions
 
-- Custom runtime images must implement the [Action interface](https://github.com/apache/incubator-openwhisk/blob/master/docs/actions-new.md#runtime-general-requirements). This is the [protocol used by the platform](https://github.com/apache/incubator-openwhisk/blob/master/docs/actions-new.md#action-interface) to pass invocation requests to the runtime containers. Containers are expected to expose a HTTP server (running on port 8080) with `/init` and `/run` endpoints.
+- Custom runtime images must implement the [Action interface](https://github.com/apache/openwhisk/blob/master/docs/actions-new.md#runtime-general-requirements). This is the [protocol used by the platform](https://github.com/apache/openwhisk/blob/master/docs/actions-new.md#action-interface) to pass invocation requests to the runtime containers. Containers are expected to expose a HTTP server (running on port 8080) with `/init` and `/run` endpoints.
 - Custom runtime images must be available on [Docker Hub](https://hub.docker.com/search?q=&type=image). Docker Hub is the only container registry currently supported. This means all custom runtime images will need to be publicly available.
 - Custom runtime images will be pulled from Docker Hub into the local platform registry upon the first invocation. This can lead to longer cold-start times on the first invocation with a new or updated image. Once images have been pulled down, they are cached locally.
 
@@ -61,12 +61,12 @@ Apache OpenWhisk publishes all the [existing runtime images](https://hub.docker.
 
 Here are some of the more common runtime images...
 
-- `openwhisk/action-nodejs-v10` - [Node.js 10](https://hub.docker.com/r/openwhisk/action-nodejs-v10) ([Source](https://github.com/apache/incubator-openwhisk-runtime-nodejs/blob/master/core/nodejs10Action/Dockerfile))
-- `openwhisk/python3action` - [Python 3](https://hub.docker.com/r/openwhisk/python3action) ([Source](https://github.com/apache/incubator-openwhisk-runtime-python/blob/master/core/pythonAction/Dockerfile))
-- `openwhisk/java8action` - [Java 8](https://hub.docker.com/r/openwhisk/java8action) ([Source](https://github.com/apache/incubator-openwhisk-runtime-java/blob/master/core/java8/Dockerfile))
-- `openwhisk/action-swift-v4.2` - [Swift 4.2](https://hub.docker.com/r/openwhisk/action-swift-v4.2) ([Source](https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile))
-- `openwhisk/action-php-v7.3` - [PHP 7.3](https://hub.docker.com/r/openwhisk/action-php-v7.3) ([Source](https://github.com/apache/incubator-openwhisk-runtime-php/blob/master/core/php7.3Action/Dockerfile))
-- `openwhisk/action-ruby-v2.5` - [Ruby 2.5](https://hub.docker.com/r/openwhisk/action-ruby-v2.5) ([Source](https://github.com/apache/incubator-openwhisk-runtime-ruby/blob/master/core/ruby2.5Action/Dockerfile))
+- `openwhisk/action-nodejs-v10` - [Node.js 10](https://hub.docker.com/r/openwhisk/action-nodejs-v10) ([Source](https://github.com/apache/openwhisk-runtime-nodejs/blob/master/core/nodejs10Action/Dockerfile))
+- `openwhisk/python3action` - [Python 3](https://hub.docker.com/r/openwhisk/python3action) ([Source](https://github.com/apache/openwhisk-runtime-python/blob/master/core/pythonAction/Dockerfile))
+- `openwhisk/java8action` - [Java 8](https://hub.docker.com/r/openwhisk/java8action) ([Source](https://github.com/apache/openwhisk-runtime-java/blob/master/core/java8/Dockerfile))
+- `openwhisk/action-swift-v4.2` - [Swift 4.2](https://hub.docker.com/r/openwhisk/action-swift-v4.2) ([Source](https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift42Action/Dockerfile))
+- `openwhisk/action-php-v7.3` - [PHP 7.3](https://hub.docker.com/r/openwhisk/action-php-v7.3) ([Source](https://github.com/apache/openwhisk-runtime-php/blob/master/core/php7.3Action/Dockerfile))
+- `openwhisk/action-ruby-v2.5` - [Ruby 2.5](https://hub.docker.com/r/openwhisk/action-ruby-v2.5) ([Source](https://github.com/apache/openwhisk-runtime-ruby/blob/master/core/ruby2.5Action/Dockerfile))
 
 ## Extending Existing Runtimes
 
@@ -147,7 +147,7 @@ wsk action invoke tfjs --result
 
 Python is a popular language for machine learning and data science due to availability of libraries like [numpy](http://www.numpy.org/).
 
-Python libraries can be [imported into the Python runtime](https://github.com/apache/incubator-openwhisk/blob/master/docs/actions-python.md#packaging-python-actions-with-a-virtual-environment-in-zip-files) in Apache OpenWhisk by including a `virtualenv` folder in the deployment archive. This approach does not work when the deployment archive would be larger than the action size limit (48MB).
+Python libraries can be [imported into the Python runtime](https://github.com/apache/openwhisk/blob/master/docs/actions-python.md#packaging-python-actions-with-a-virtual-environment-in-zip-files) in Apache OpenWhisk by including a `virtualenv` folder in the deployment archive. This approach does not work when the deployment archive would be larger than the action size limit (48MB).
 
 Instead, we can build a custom runtime which extends the project's Python runtime image and runs `pip install` during the container build process. These libraries will then be pre-installed into the runtime and can be excluded from the deployment archive.
 
@@ -207,7 +207,7 @@ wsk action invoke ml-libs --result
 
 ## Creating native actions
 
-Docker support can also be used to run any executable file (from static binaries to shell scripts) on the platform. Executable files need to use the `openwhisk/dockerskeleton` [runtime image](https://github.com/apache/incubator-openwhisk-runtime-docker). Native actions can be created using the `--native` CLI flag, rather than explicitly specifying `dockerskeleton` as the runtime image name.
+Docker support can also be used to run any executable file (from static binaries to shell scripts) on the platform. Executable files need to use the `openwhisk/dockerskeleton` [runtime image](https://github.com/apache/openwhisk-runtime-docker). Native actions can be created using the `--native` CLI flag, rather than explicitly specifying `dockerskeleton` as the runtime image name.
 
 ### Usage
 
@@ -218,7 +218,7 @@ wsk action create my-action --native archive.zip
 
 Executables can either be text or binary files. Text-based executable files (e.g. shell scripts) are passed directly as the action source files. Binary files (e.g. C programs) must be named `exec` and packaged into a zip archive.
 
-Native action source files must be executable within the  `openwhisk/dockerskeleton` [runtime image](https://github.com/apache/incubator-openwhisk-runtime-docker). This means being compiled for the correct platform architecture, linking to the correct dynamic libraries  and using pre-installed external dependencies.
+Native action source files must be executable within the  `openwhisk/dockerskeleton` [runtime image](https://github.com/apache/openwhisk-runtime-docker). This means being compiled for the correct platform architecture, linking to the correct dynamic libraries  and using pre-installed external dependencies.
 
 When an invocation request is received by the runtime container, the native action file will be executed until the process exits. Action invocation parameters will be passed as a JSON string to `stdin`.
 

--- a/docs/actions-go.md
+++ b/docs/actions-go.md
@@ -116,7 +116,7 @@ cd ..
 wsk action create hellozip hello.zip --kind go:1.11
 ```
 
-Check the example [golang-main-package](https://github.com/apache/incubator-openwhisk-runtime-go/tree/master/examples/golang-main-package) and the associated `Makefile`.
+Check the example [golang-main-package](https://github.com/apache/openwhisk-runtime-go/tree/master/examples/golang-main-package) and the associated `Makefile`.
 
 ### Using vendor folders
 
@@ -155,7 +155,7 @@ golang-hello-vendor
             - golang.org/...
 ```
 
-Check the example [golang-hello-vendor](https://github.com/apache/incubator-openwhisk-runtime-go/tree/master/examples/golang-hello-vendor)
+Check the example [golang-hello-vendor](https://github.com/apache/openwhisk-runtime-go/tree/master/examples/golang-hello-vendor)
 
 Note you do not need to store the `vendor` folder in the version control system as it can be regenerated, you only the manifest files. However, you need to include the entire vendor folder when you deploy the action in source format for compilation by the runtime.
 
@@ -185,7 +185,7 @@ docker run openwhisk/actionloop-golang-v1.11 -compile main <src.zip >exec.zip
 
 Note that the output is always a zip file in  Linux AMD64 format so the executable can be run only inside a Docker Linux container.
 
-Here a `Makefile` is helpful. Check the [examples](https://github.com/apache/incubator-openwhisk-runtime-go/tree/master/examples) for a collection of tested Makefiles. The  generated executable is suitable to be deployed in OpenWhisk, so you can do:
+Here a `Makefile` is helpful. Check the [examples](https://github.com/apache/openwhisk-runtime-go/tree/master/examples) for a collection of tested Makefiles. The  generated executable is suitable to be deployed in OpenWhisk, so you can do:
 
 `wsk action create my-action exec.zip --kind go:1.11`
 

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -103,7 +103,7 @@ The runtime repository should follow the canonical structure used by other runti
         └── ...          # ... which extend canonical interface plus additional runtime specific tests
 ```
 
-The [Docker skeleton repository](https://github.com/apache/incubator-openwhisk-runtime-docker)
+The [Docker skeleton repository](https://github.com/apache/openwhisk-runtime-docker)
 is an example starting point to fork and modify for your new runtime.
 
 ### The test action
@@ -232,7 +232,7 @@ will destroy the container.
 
 The proxy must flush all the logs produced during initialization and execution and add a frame marker
 to denote the end of the log stream for an activation. This is done by emitting the token
-[`XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX`](https://github.com/apache/incubator-openwhisk/blob/59abfccf91b58ee39f184030374203f1bf372f2d/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala#L51)
+[`XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX`](https://github.com/apache/openwhisk/blob/59abfccf91b58ee39f184030374203f1bf372f2d/core/invoker/src/main/scala/whisk/core/containerpool/docker/DockerContainer.scala#L51)
 as the last log line for the `stdout` _and_ `stderr` streams. Failure to emit this marker will cause delayed
 or truncated activation logs.
 

--- a/docs/actions-php.md
+++ b/docs/actions-php.md
@@ -24,7 +24,7 @@ The following sections guide you through creating and invoking a single PHP acti
 and demonstrate how to bundle multiple PHP files and third party dependencies.
 
 PHP actions are executed using PHP 7.3. The specific
-version of PHP is listed in the CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
+version of PHP is listed in the CHANGELOG files in the [PHP runtime repository](https://github.com/apache/openwhisk-runtime-php).
 
 To use a PHP runtime, specify the `wsk` CLI parameter `--kind` when creating or
 updating an action. The available PHP kinds are:
@@ -108,7 +108,7 @@ then the runtime will include one for you with the following Composer packages:
 - ramsey/uuid
 
 The specific versions of these packages depends on the PHP runtime in use and is listed in the
-CHANGELOG files in the [PHP runtime repository](https://github.com/apache/incubator-openwhisk-runtime-php).
+CHANGELOG files in the [PHP runtime repository](https://github.com/apache/openwhisk-runtime-php).
 
 
 ## Built-in PHP extensions

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -27,7 +27,7 @@ observable output.
 An action may be created from a function programmed using a number of [supported languages and runtimes](#languages-and-runtimes),
 or from a binary-compatible executable, or even executables packaged as Docker containers.
 
-* The OpenWhisk CLI [`wsk`](https://github.com/apache/incubator-openwhisk-cli/releases)
+* The OpenWhisk CLI [`wsk`](https://github.com/apache/openwhisk-cli/releases)
 makes it easy to create and invoke actions. Instructions for configuring the CLI are available [here](cli.md).
 * You can also use the [REST API](rest_api.md).
 

--- a/docs/apigateway.md
+++ b/docs/apigateway.md
@@ -21,7 +21,7 @@
 OpenWhisk actions can benefit from being managed by API management.
 
 The API Gateway can act as a proxy to [Web Actions](webactions.md) and provides them with additional features including HTTP method routing , client id/secrets, rate limiting and CORS.
-For more information on API Gateway feature you can read the [api management documentation](https://github.com/apache/incubator-openwhisk-apigateway/blob/master/doc/v2/management_interface_v2.md)
+For more information on API Gateway feature you can read the [api management documentation](https://github.com/apache/openwhisk-apigateway/blob/master/doc/v2/management_interface_v2.md)
 
 
 ## Create APIs from OpenWhisk web actions using the CLI
@@ -215,7 +215,7 @@ ok: deleted API /club
 ```
 ### Changing the configuration
 
-You can edit the configuration file to configure API Gateway extensions such as disabling or enabling CORS, for more info on the format of the configuration file refer to the API Gateway [docs](https://github.com/apache/incubator-openwhisk-apigateway/blob/master/doc/v2/management_interface_v2.md#gateway-specific-extensions).
+You can edit the configuration file to configure API Gateway extensions such as disabling or enabling CORS, for more info on the format of the configuration file refer to the API Gateway [docs](https://github.com/apache/openwhisk-apigateway/blob/master/doc/v2/management_interface_v2.md#gateway-specific-extensions).
 
 ### Importing the configuration
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -27,23 +27,23 @@ The catalog is available as packages in the `/whisk.system` namespace. See [Brow
 
 | Package | Description |
 | --- | --- |
-| [/whisk.system/alarms](https://github.com/apache/incubator-openwhisk-package-alarms/blob/master/README.md) | Package to create periodic triggers |
-| [/whisk.system/cloudant](https://github.com/apache/incubator-openwhisk-package-cloudant/blob/master/README.md) | Package to work with [Cloudant NoSQL DB](https://console.ng.bluemix.net/docs/services/Cloudant/index.html) service |
-| [/whisk.system/github](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/github/README.md) | Package to create webhook triggers for [GitHub](https://developer.github.com/) |
-| [/whisk.system/messaging](https://github.com/apache/incubator-openwhisk-package-kafka/blob/master/README.md) | Package to work with [Message Hub](https://console.ng.bluemix.net/docs/services/MessageHub/index.html) service |
-| [/whisk.system/pushnotifications](https://github.com/apache/incubator-openwhisk-package-pushnotifications/blob/master/README.md) | Package to work with [Push Notification](https://console.ng.bluemix.net/docs/services/mobilepush/index.html) service |
-| [/whisk.system/slack](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/slack/README.md) | Package to post to the [Slack APIs](https://api.slack.com/) |
-| [/whisk.system/watson-translator](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/watson-translator/README.md) | Package for [text translation and language identification](https://www.ibm.com/watson/developercloud/language-translator.html) |
-| [/whisk.system/watson-speechToText](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/watson-speechToText/README.md) | Package to convert [speech into text](https://www.ibm.com/watson/developercloud/speech-to-text.html) |
-| [/whisk.system/watson-textToSpeech](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/watson-textToSpeech/README.md) | Package to convert [text into speech](https://www.ibm.com/watson/developercloud/text-to-speech.html) |
-| [/whisk.system/weather](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/weather/README.md) | Package to work with [Weather Company Data](https://console.ng.bluemix.net/docs/services/Weather/index.html) service |
-| [/whisk.system/websocket](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/websocket/README.md) | Package to work with a [Web Socket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) server |
+| [/whisk.system/alarms](https://github.com/apache/openwhisk-package-alarms/blob/master/README.md) | Package to create periodic triggers |
+| [/whisk.system/cloudant](https://github.com/apache/openwhisk-package-cloudant/blob/master/README.md) | Package to work with [Cloudant NoSQL DB](https://console.ng.bluemix.net/docs/services/Cloudant/index.html) service |
+| [/whisk.system/github](https://github.com/apache/openwhisk-catalog/blob/master/packages/github/README.md) | Package to create webhook triggers for [GitHub](https://developer.github.com/) |
+| [/whisk.system/messaging](https://github.com/apache/openwhisk-package-kafka/blob/master/README.md) | Package to work with [Message Hub](https://console.ng.bluemix.net/docs/services/MessageHub/index.html) service |
+| [/whisk.system/pushnotifications](https://github.com/apache/openwhisk-package-pushnotifications/blob/master/README.md) | Package to work with [Push Notification](https://console.ng.bluemix.net/docs/services/mobilepush/index.html) service |
+| [/whisk.system/slack](https://github.com/apache/openwhisk-catalog/blob/master/packages/slack/README.md) | Package to post to the [Slack APIs](https://api.slack.com/) |
+| [/whisk.system/watson-translator](https://github.com/apache/openwhisk-catalog/blob/master/packages/watson-translator/README.md) | Package for [text translation and language identification](https://www.ibm.com/watson/developercloud/language-translator.html) |
+| [/whisk.system/watson-speechToText](https://github.com/apache/openwhisk-catalog/blob/master/packages/watson-speechToText/README.md) | Package to convert [speech into text](https://www.ibm.com/watson/developercloud/speech-to-text.html) |
+| [/whisk.system/watson-textToSpeech](https://github.com/apache/openwhisk-catalog/blob/master/packages/watson-textToSpeech/README.md) | Package to convert [text into speech](https://www.ibm.com/watson/developercloud/text-to-speech.html) |
+| [/whisk.system/weather](https://github.com/apache/openwhisk-catalog/blob/master/packages/weather/README.md) | Package to work with [Weather Company Data](https://console.ng.bluemix.net/docs/services/Weather/index.html) service |
+| [/whisk.system/websocket](https://github.com/apache/openwhisk-catalog/blob/master/packages/websocket/README.md) | Package to work with a [Web Socket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) server |
 
 <!--
 TODO: place holder until we have a README for samples
-| [/whisk.system/samples](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/samples/README.md) | offers sample actions in different languages |
+| [/whisk.system/samples](https://github.com/apache/openwhisk-catalog/blob/master/packages/samples/README.md) | offers sample actions in different languages |
 -->
 <!--
 TODO: place holder until we have a README for utils
-| [/whisk.system/utils](https://github.com/apache/incubator-openwhisk-catalog/blob/master/packages/utils/README.md) | offers utilities actions such as cat, echo, and etc. |
+| [/whisk.system/utils](https://github.com/apache/openwhisk-catalog/blob/master/packages/utils/README.md) | offers utilities actions such as cat, echo, and etc. |
 -->

--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -28,62 +28,61 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk](https://github.com/apache/incubator-openwhisk) | Apache OpenWhisk is a serverless event-based programming service and an Apache top-level project. | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk) |
-| [incubator-openwhisk-apigateway](https://github.com/apache/incubator-openwhisk-apigateway) | Apache OpenWhisk API Gateway service for exposing actions as REST interfaces. | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-apigateway.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-apigateway) |
-| [incubator-openwhisk-catalog](https://github.com/apache/incubator-openwhisk-catalog) | Curated catalog of Apache OpenWhisk packages to interface with event producers and consumers | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-catalog.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-catalog) |
-| [incubator-openwhisk-cli](https://github.com/apache/incubator-openwhisk-cli) | Apache OpenWhisk Command Line Interface (CLI) | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-cli.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-cli) |
-| [incubator-openwhisk-composer](https://github.com/apache/incubator-openwhisk-composer) | Composer is a new programming model for composing cloud functions built on Apache OpenWhisk.  | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-composer.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-composer) |
-| [incubator-openwhisk-wskdeploy](https://github.com/apache/incubator-openwhisk-wskdeploy) | Apache OpenWhisk utility for deploying and managing OpenWhisk projects and packages | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-wskdeploy.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-wskdeploy) |
+| [openwhisk-apigateway](https://github.com/apache/openwhisk-apigateway) | Apache OpenWhisk API Gateway service for exposing actions as REST interfaces. | [![Build Status](https://travis-ci.org/apache/openwhisk-apigateway.svg?branch=master)](https://travis-ci.org/apache/openwhisk-apigateway) |
+| [openwhisk-catalog](https://github.com/apache/openwhisk-catalog) | Curated catalog of Apache OpenWhisk packages to interface with event producers and consumers | [![Build Status](https://travis-ci.org/apache/openwhisk-catalog.svg?branch=master)](https://travis-ci.org/apache/openwhisk-catalog) |
+| [openwhisk-cli](https://github.com/apache/openwhisk-cli) | Apache OpenWhisk Command Line Interface (CLI) | [![Build Status](https://travis-ci.org/apache/openwhisk-cli.svg?branch=master)](https://travis-ci.org/apache/openwhisk-cli) |
+| [openwhisk-composer](https://github.com/apache/openwhisk-composer) | Composer is a new programming model for composing cloud functions built on Apache OpenWhisk.  | [![Build Status](https://travis-ci.org/apache/openwhisk-composer.svg?branch=master)](https://travis-ci.org/apache/openwhisk-composer) |
+| [openwhisk-wskdeploy](https://github.com/apache/openwhisk-wskdeploy) | Apache OpenWhisk utility for deploying and managing OpenWhisk projects and packages | [![Build Status](https://travis-ci.org/apache/openwhisk-wskdeploy.svg?branch=master)](https://travis-ci.org/apache/openwhisk-wskdeploy) |
 
 
 ## Clients
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-client-go](https://github.com/apache/incubator-openwhisk-client-go) | Apache OpenWhisk Go client API library | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-go.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-go) |
-| [incubator-openwhisk-client-js](https://github.com/apache/incubator-openwhisk-client-js) | JavaScript client library for the OpenWhisk platform | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-js) |
 | [incubator-openwhisk-client-python](https://github.com/apache/incubator-openwhisk-client-python) | REST API of OpenWhisk can be used directly from Python | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-python.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-python) |
 | [incubator-openwhisk-client-swift](https://github.com/apache/incubator-openwhisk-client-swift) | openwhisk-client-swift is a Swift client SDK for OpenWhisk with support for iOS, WatchOS2, and Darwin CLI apps | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-swift.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-swift) |
+| [openwhisk-client-go](https://github.com/apache/openwhisk-client-go) | Apache OpenWhisk Go client API library | [![Build Status](https://travis-ci.org/apache/openwhisk-client-go.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-go) |
+| [openwhisk-client-js](https://github.com/apache/openwhisk-client-js) | JavaScript client library for the OpenWhisk platform | [![Build Status](https://travis-ci.org/apache/openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-js) |
 
 
 ## Runtimes
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-runtime-ballerina](https://github.com/apache/incubator-openwhisk-runtime-ballerina) | Apache OpenWhisk Ballerina runtime. Learn more at https://openwhisk.apache.org.  | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-ballerina.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-ballerina) |
-| [incubator-openwhisk-runtime-docker](https://github.com/apache/incubator-openwhisk-runtime-docker) | Apache OpenWhisk SDK for building Docker “blackbox" runtimes. https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-docker.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-docker) |
-| [incubator-openwhisk-runtime-dotnet](https://github.com/apache/incubator-openwhisk-runtime-dotnet) | Apache OpenWhisk Runtime for .Net | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-dotnet.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-dotnet) |
-| [incubator-openwhisk-runtime-go](https://github.com/apache/incubator-openwhisk-runtime-go) | Apache openwhisk runtime for go actions | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-go.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-go) |
-| [incubator-openwhisk-runtime-java](https://github.com/apache/incubator-openwhisk-runtime-java) | Apache OpenWhisk runtime for Java language functions.  https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-java.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-java) |
-| [incubator-openwhisk-runtime-nodejs](https://github.com/apache/incubator-openwhisk-runtime-nodejs) | Apache OpenWhisk runtime for Node.js JavaScript language functions. https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-nodejs.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-nodejs) |
-| [incubator-openwhisk-runtime-php](https://github.com/apache/incubator-openwhisk-runtime-php) | Apache OpenWhisk runtime for PHP language functions.  https://openwhisk.apache.org/  | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-php.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-php) |
-| [incubator-openwhisk-runtime-python](https://github.com/apache/incubator-openwhisk-runtime-python) | Apache OpenWhisk runtime for Python language functions.  https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-python.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-python) |
-| [incubator-openwhisk-runtime-ruby](https://github.com/apache/incubator-openwhisk-runtime-ruby) | Apache OpenWhisk Ruby runtime | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-ruby.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-ruby) |
-| [incubator-openwhisk-runtime-rust](https://github.com/apache/incubator-openwhisk-runtime-rust) | Apache OpenWhisk runtime for Rust functions. | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-rust.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-rust) |
-| [incubator-openwhisk-runtime-swift](https://github.com/apache/incubator-openwhisk-runtime-swift) | Apache openwhisk swift runtime | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-runtime-swift.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-runtime-swift) |
+| [openwhisk-runtime-ballerina](https://github.com/apache/openwhisk-runtime-ballerina) | Apache OpenWhisk Ballerina runtime. Learn more at https://openwhisk.apache.org.  | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-ballerina.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-ballerina) |
+| [openwhisk-runtime-docker](https://github.com/apache/openwhisk-runtime-docker) | Apache OpenWhisk SDK for building Docker “blackbox" runtimes. https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-docker.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-docker) |
+| [openwhisk-runtime-dotnet](https://github.com/apache/openwhisk-runtime-dotnet) | Apache OpenWhisk Runtime for .Net | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-dotnet.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-dotnet) |
+| [openwhisk-runtime-go](https://github.com/apache/openwhisk-runtime-go) | Apache openwhisk runtime for go actions | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-go.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-go) |
+| [openwhisk-runtime-java](https://github.com/apache/openwhisk-runtime-java) | Apache OpenWhisk runtime for Java language functions.  https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-java.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-java) |
+| [openwhisk-runtime-nodejs](https://github.com/apache/openwhisk-runtime-nodejs) | Apache OpenWhisk runtime for Node.js JavaScript language functions. https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-nodejs.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-nodejs) |
+| [openwhisk-runtime-php](https://github.com/apache/openwhisk-runtime-php) | Apache OpenWhisk runtime for PHP language functions.  https://openwhisk.apache.org/  | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-php.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-php) |
+| [openwhisk-runtime-python](https://github.com/apache/openwhisk-runtime-python) | Apache OpenWhisk runtime for Python language functions.  https://openwhisk.apache.org/ | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-python.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-python) |
+| [openwhisk-runtime-ruby](https://github.com/apache/openwhisk-runtime-ruby) | Apache OpenWhisk Ruby runtime | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-ruby.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-ruby) |
+| [openwhisk-runtime-rust](https://github.com/apache/openwhisk-runtime-rust) | Apache OpenWhisk runtime for Rust functions. | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-rust.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-rust) |
+| [openwhisk-runtime-swift](https://github.com/apache/openwhisk-runtime-swift) | Apache openwhisk swift runtime | [![Build Status](https://travis-ci.org/apache/openwhisk-runtime-swift.svg?branch=master)](https://travis-ci.org/apache/openwhisk-runtime-swift) |
 
 
 ## Deployments
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-deploy-kube](https://github.com/apache/incubator-openwhisk-deploy-kube) | This project can be used to deploy Apache OpenWhisk to a Kubernetes cluster | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-deploy-kube.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-deploy-kube) |
 | [incubator-openwhisk-deploy-mesos](https://github.com/apache/incubator-openwhisk-deploy-mesos) | Apache OpenWhisk deployment scripts and configuration files for running under Apache Mesos. | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-deploy-mesos.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-deploy-mesos) |
 | [incubator-openwhisk-deploy-openshift](https://github.com/apache/incubator-openwhisk-deploy-openshift) | This project can be used to deploy Apache OpenWhisk to the OpenShift platform | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-deploy-openshift.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-deploy-openshift) |
+| [openwhisk-deploy-kube](https://github.com/apache/openwhisk-deploy-kube) | This project can be used to deploy Apache OpenWhisk to a Kubernetes cluster | [![Build Status](https://travis-ci.org/apache/openwhisk-deploy-kube.svg?branch=master)](https://travis-ci.org/apache/openwhisk-deploy-kube) |
 
 
 ## Packages
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-package-alarms](https://github.com/apache/incubator-openwhisk-package-alarms) | Apache OpenWhisk package that can be used to create periodic, time-based alarms | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-alarms.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-alarms) |
-| [incubator-openwhisk-package-cloudant](https://github.com/apache/incubator-openwhisk-package-cloudant) | The /whisk.system/cloudant package enables you to work with a Cloudant database | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-cloudant.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-cloudant) |
 | [incubator-openwhisk-package-deploy](https://github.com/apache/incubator-openwhisk-package-deploy) | Apache openwhisk | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-deploy.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-deploy) |
 | [incubator-openwhisk-package-jira](https://github.com/apache/incubator-openwhisk-package-jira) | Interact with JIRA software software development tool used for issue tracking, and project management functions | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-jira.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-jira) |
-| [incubator-openwhisk-package-kafka](https://github.com/apache/incubator-openwhisk-package-kafka) | Apache OpenWhisk package for communicating with Kafka or Message Hub | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-kafka.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-kafka) |
 | [incubator-openwhisk-package-pushnotifications](https://github.com/apache/incubator-openwhisk-package-pushnotifications) | OpenWhisk Package for Bluemix Push Notifications Service | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-pushnotifications.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-pushnotifications) |
 | [incubator-openwhisk-package-rss](https://github.com/apache/incubator-openwhisk-package-rss) | RSS feed package | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-rss.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-rss) |
 | [incubator-openwhisk-package-template](https://github.com/apache/incubator-openwhisk-package-template) | This is a template to be use when creating new packages for OpenWhisk | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-template.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-template) |
+| [openwhisk-package-alarms](https://github.com/apache/openwhisk-package-alarms) | Apache OpenWhisk package that can be used to create periodic, time-based alarms | [![Build Status](https://travis-ci.org/apache/openwhisk-package-alarms.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-alarms) |
+| [openwhisk-package-cloudant](https://github.com/apache/openwhisk-package-cloudant) | The /whisk.system/cloudant package enables you to work with a Cloudant database | [![Build Status](https://travis-ci.org/apache/openwhisk-package-cloudant.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-cloudant) |
+| [openwhisk-package-kafka](https://github.com/apache/openwhisk-package-kafka) | Apache OpenWhisk package for communicating with Kafka or Message Hub | [![Build Status](https://travis-ci.org/apache/openwhisk-package-kafka.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-kafka) |
 
 
 ## Samples and Examples
@@ -103,18 +102,18 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 | Module | Description |
 |---	|---	|
 | [incubator-openwhisk-debugger](https://github.com/apache/incubator-openwhisk-debugger) | The OpenWhisk debugger project |
-| [incubator-openwhisk-devtools](https://github.com/apache/incubator-openwhisk-devtools) | Development tools for building and deploying Apache OpenWhisk |
 | [incubator-openwhisk-playground](https://github.com/apache/incubator-openwhisk-playground) | This library provides functionality of executing a snippet of source code as OpenWhisk action for OpenWhisk Xcode Source Editor Extension |
 | [incubator-openwhisk-vscode](https://github.com/apache/incubator-openwhisk-vscode) | Visual Studio Code extension (prototype) for authoring OpenWhisk actions inside the editor. |
 | [incubator-openwhisk-xcode](https://github.com/apache/incubator-openwhisk-xcode) | Collection of OpenWhisk tools for OS X implemented in Swift 3. |
+| [openwhisk-devtools](https://github.com/apache/openwhisk-devtools) | Development tools for building and deploying Apache OpenWhisk |
 
 
 ## Utilities
 
 | Module | Description |
 |---	|---	|
-| [incubator-openwhisk-release](https://github.com/apache/incubator-openwhisk-release) | Apache openwhisk release |
-| [incubator-openwhisk-utilities](https://github.com/apache/incubator-openwhisk-utilities) | Shared utilities used across Apache OpenWhisk project repositories. |
+| [openwhisk-release](https://github.com/apache/openwhisk-release) | Apache openwhisk release |
+| [openwhisk-utilities](https://github.com/apache/openwhisk-utilities) | Shared utilities used across Apache OpenWhisk project repositories. |
 
 
 ## Others
@@ -123,10 +122,11 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 |---	|---	|
 | [incubator-openwhisk-composer-python](https://github.com/apache/incubator-openwhisk-composer-python) | Composer for Python is a new programming model for composing cloud functions built on Apache OpenWhisk (Incubating) |
 | [incubator-openwhisk-external-resources](https://github.com/apache/incubator-openwhisk-external-resources) | ✨ Curated list of awesome OpenWhisk things ✨ |
-| [incubator-openwhisk-pluggable-provider](https://github.com/apache/incubator-openwhisk-pluggable-provider) | Apache OpenWhisk pluggable trigger feed event provider  |
 | [incubator-openwhisk-podspecs](https://github.com/apache/incubator-openwhisk-podspecs) | CocoaPods Podspecs repo for openwhisk-client-swift |
 | [incubator-openwhisk-selfserve-test](https://github.com/apache/incubator-openwhisk-selfserve-test) | Apache openwhisk |
 | [incubator-openwhisk-test](https://github.com/apache/incubator-openwhisk-test) | Test repo. for Apache OpenWhisk client-side tooling. |
-| [incubator-openwhisk-website](https://github.com/apache/incubator-openwhisk-website) | Apache OpenWhisk website (openwhisk.incubator.apache.org) code built using Jekyll |
+| [openwhisk](https://github.com/apache/openwhisk) | Apache OpenWhisk is a serverless event-based programming service and an Apache Incubator project. |
+| [openwhisk-pluggable-provider](https://github.com/apache/openwhisk-pluggable-provider) | Apache OpenWhisk pluggable trigger feed event provider  |
+| [openwhisk-website](https://github.com/apache/openwhisk-website) | Apache OpenWhisk website (openwhisk.incubator.apache.org) code built using Jekyll |
 
 

--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -39,10 +39,10 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-client-python](https://github.com/apache/incubator-openwhisk-client-python) | REST API of OpenWhisk can be used directly from Python | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-python.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-python) |
-| [incubator-openwhisk-client-swift](https://github.com/apache/incubator-openwhisk-client-swift) | openwhisk-client-swift is a Swift client SDK for OpenWhisk with support for iOS, WatchOS2, and Darwin CLI apps | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-swift.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-swift) |
 | [openwhisk-client-go](https://github.com/apache/openwhisk-client-go) | Apache OpenWhisk Go client API library | [![Build Status](https://travis-ci.org/apache/openwhisk-client-go.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-go) |
 | [openwhisk-client-js](https://github.com/apache/openwhisk-client-js) | JavaScript client library for the OpenWhisk platform | [![Build Status](https://travis-ci.org/apache/openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-js) |
+| [openwhisk-client-python](https://github.com/apache/openwhisk-client-python) | REST API of OpenWhisk can be used directly from Python | [![Build Status](https://travis-ci.org/apache/openwhisk-client-python.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-python) |
+| [openwhisk-client-swift](https://github.com/apache/openwhisk-client-swift) | openwhisk-client-swift is a Swift client SDK for OpenWhisk with support for iOS, WatchOS2, and Darwin CLI apps | [![Build Status](https://travis-ci.org/apache/openwhisk-client-swift.svg?branch=master)](https://travis-ci.org/apache/openwhisk-client-swift) |
 
 
 ## Runtimes
@@ -66,46 +66,46 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-deploy-mesos](https://github.com/apache/incubator-openwhisk-deploy-mesos) | Apache OpenWhisk deployment scripts and configuration files for running under Apache Mesos. | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-deploy-mesos.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-deploy-mesos) |
-| [incubator-openwhisk-deploy-openshift](https://github.com/apache/incubator-openwhisk-deploy-openshift) | This project can be used to deploy Apache OpenWhisk to the OpenShift platform | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-deploy-openshift.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-deploy-openshift) |
 | [openwhisk-deploy-kube](https://github.com/apache/openwhisk-deploy-kube) | This project can be used to deploy Apache OpenWhisk to a Kubernetes cluster | [![Build Status](https://travis-ci.org/apache/openwhisk-deploy-kube.svg?branch=master)](https://travis-ci.org/apache/openwhisk-deploy-kube) |
+| [openwhisk-deploy-mesos](https://github.com/apache/openwhisk-deploy-mesos) | Apache OpenWhisk deployment scripts and configuration files for running under Apache Mesos. | [![Build Status](https://travis-ci.org/apache/openwhisk-deploy-mesos.svg?branch=master)](https://travis-ci.org/apache/openwhisk-deploy-mesos) |
+| [openwhisk-deploy-openshift](https://github.com/apache/openwhisk-deploy-openshift) | This project can be used to deploy Apache OpenWhisk to the OpenShift platform | [![Build Status](https://travis-ci.org/apache/openwhisk-deploy-openshift.svg?branch=master)](https://travis-ci.org/apache/openwhisk-deploy-openshift) |
 
 
 ## Packages
 
 | Module | Description | Module Status |
 |---	|---	|---    |
-| [incubator-openwhisk-package-deploy](https://github.com/apache/incubator-openwhisk-package-deploy) | Apache openwhisk | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-deploy.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-deploy) |
-| [incubator-openwhisk-package-jira](https://github.com/apache/incubator-openwhisk-package-jira) | Interact with JIRA software software development tool used for issue tracking, and project management functions | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-jira.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-jira) |
-| [incubator-openwhisk-package-pushnotifications](https://github.com/apache/incubator-openwhisk-package-pushnotifications) | OpenWhisk Package for Bluemix Push Notifications Service | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-pushnotifications.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-pushnotifications) |
-| [incubator-openwhisk-package-rss](https://github.com/apache/incubator-openwhisk-package-rss) | RSS feed package | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-rss.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-rss) |
-| [incubator-openwhisk-package-template](https://github.com/apache/incubator-openwhisk-package-template) | This is a template to be use when creating new packages for OpenWhisk | [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-package-template.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-package-template) |
 | [openwhisk-package-alarms](https://github.com/apache/openwhisk-package-alarms) | Apache OpenWhisk package that can be used to create periodic, time-based alarms | [![Build Status](https://travis-ci.org/apache/openwhisk-package-alarms.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-alarms) |
 | [openwhisk-package-cloudant](https://github.com/apache/openwhisk-package-cloudant) | The /whisk.system/cloudant package enables you to work with a Cloudant database | [![Build Status](https://travis-ci.org/apache/openwhisk-package-cloudant.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-cloudant) |
+| [openwhisk-package-deploy](https://github.com/apache/openwhisk-package-deploy) | Apache openwhisk | [![Build Status](https://travis-ci.org/apache/openwhisk-package-deploy.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-deploy) |
+| [openwhisk-package-jira](https://github.com/apache/openwhisk-package-jira) | Interact with JIRA software software development tool used for issue tracking, and project management functions | [![Build Status](https://travis-ci.org/apache/openwhisk-package-jira.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-jira) |
 | [openwhisk-package-kafka](https://github.com/apache/openwhisk-package-kafka) | Apache OpenWhisk package for communicating with Kafka or Message Hub | [![Build Status](https://travis-ci.org/apache/openwhisk-package-kafka.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-kafka) |
+| [openwhisk-package-pushnotifications](https://github.com/apache/openwhisk-package-pushnotifications) | OpenWhisk Package for Bluemix Push Notifications Service | [![Build Status](https://travis-ci.org/apache/openwhisk-package-pushnotifications.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-pushnotifications) |
+| [openwhisk-package-rss](https://github.com/apache/openwhisk-package-rss) | RSS feed package | [![Build Status](https://travis-ci.org/apache/openwhisk-package-rss.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-rss) |
+| [openwhisk-package-template](https://github.com/apache/openwhisk-package-template) | This is a template to be use when creating new packages for OpenWhisk | [![Build Status](https://travis-ci.org/apache/openwhisk-package-template.svg?branch=master)](https://travis-ci.org/apache/openwhisk-package-template) |
 
 
 ## Samples and Examples
 
 | Module | Description |
 |---	|---	|
-| [incubator-openwhisk-GitHubSlackBot](https://github.com/apache/incubator-openwhisk-GitHubSlackBot) | Demonstration of integration of GitHub Pull Request management with Slack and using Alarms |
-| [incubator-openwhisk-sample-matos](https://github.com/apache/incubator-openwhisk-sample-matos) | sample application with Message Hub and Object Store |
-| [incubator-openwhisk-sample-slackbot](https://github.com/apache/incubator-openwhisk-sample-slackbot) | A proof-of-concept Slackbot to invoke OpenWhisk actions. |
-| [incubator-openwhisk-slackinvite](https://github.com/apache/incubator-openwhisk-slackinvite) | Invite for Apache OpenWhisk Team on Slack |
-| [incubator-openwhisk-tutorial](https://github.com/apache/incubator-openwhisk-tutorial) | An interactive learning environment for the Apache OpenWhisk command line |
-| [incubator-openwhisk-workshop](https://github.com/apache/incubator-openwhisk-workshop) | OpenWhisk workshop to help developers learn how to build serverless applications using the platform. |
+| [openwhisk-GitHubSlackBot](https://github.com/apache/openwhisk-GitHubSlackBot) | Demonstration of integration of GitHub Pull Request management with Slack and using Alarms |
+| [openwhisk-sample-matos](https://github.com/apache/openwhisk-sample-matos) | sample application with Message Hub and Object Store |
+| [openwhisk-sample-slackbot](https://github.com/apache/openwhisk-sample-slackbot) | A proof-of-concept Slackbot to invoke OpenWhisk actions. |
+| [openwhisk-slackinvite](https://github.com/apache/openwhisk-slackinvite) | Invite for Apache OpenWhisk Team on Slack |
+| [openwhisk-tutorial](https://github.com/apache/openwhisk-tutorial) | An interactive learning environment for the Apache OpenWhisk command line |
+| [openwhisk-workshop](https://github.com/apache/openwhisk-workshop) | OpenWhisk workshop to help developers learn how to build serverless applications using the platform. |
 
 
 ## Development Tools
 
 | Module | Description |
 |---	|---	|
-| [incubator-openwhisk-debugger](https://github.com/apache/incubator-openwhisk-debugger) | The OpenWhisk debugger project |
-| [incubator-openwhisk-playground](https://github.com/apache/incubator-openwhisk-playground) | This library provides functionality of executing a snippet of source code as OpenWhisk action for OpenWhisk Xcode Source Editor Extension |
-| [incubator-openwhisk-vscode](https://github.com/apache/incubator-openwhisk-vscode) | Visual Studio Code extension (prototype) for authoring OpenWhisk actions inside the editor. |
-| [incubator-openwhisk-xcode](https://github.com/apache/incubator-openwhisk-xcode) | Collection of OpenWhisk tools for OS X implemented in Swift 3. |
+| [openwhisk-debugger](https://github.com/apache/openwhisk-debugger) | The OpenWhisk debugger project |
 | [openwhisk-devtools](https://github.com/apache/openwhisk-devtools) | Development tools for building and deploying Apache OpenWhisk |
+| [openwhisk-playground](https://github.com/apache/openwhisk-playground) | This library provides functionality of executing a snippet of source code as OpenWhisk action for OpenWhisk Xcode Source Editor Extension |
+| [openwhisk-vscode](https://github.com/apache/openwhisk-vscode) | Visual Studio Code extension (prototype) for authoring OpenWhisk actions inside the editor. |
+| [openwhisk-xcode](https://github.com/apache/openwhisk-xcode) | Collection of OpenWhisk tools for OS X implemented in Swift 3. |
 
 
 ## Utilities
@@ -120,13 +120,13 @@ This page is generated via script `./gradlew :tools:dev:renderModuleDetails`. Se
 
 | Module | Description |
 |---	|---	|
-| [incubator-openwhisk-composer-python](https://github.com/apache/incubator-openwhisk-composer-python) | Composer for Python is a new programming model for composing cloud functions built on Apache OpenWhisk (Incubating) |
-| [incubator-openwhisk-external-resources](https://github.com/apache/incubator-openwhisk-external-resources) | ✨ Curated list of awesome OpenWhisk things ✨ |
-| [incubator-openwhisk-podspecs](https://github.com/apache/incubator-openwhisk-podspecs) | CocoaPods Podspecs repo for openwhisk-client-swift |
-| [incubator-openwhisk-selfserve-test](https://github.com/apache/incubator-openwhisk-selfserve-test) | Apache openwhisk |
-| [incubator-openwhisk-test](https://github.com/apache/incubator-openwhisk-test) | Test repo. for Apache OpenWhisk client-side tooling. |
 | [openwhisk](https://github.com/apache/openwhisk) | Apache OpenWhisk is a serverless event-based programming service and an Apache Incubator project. |
+| [openwhisk-composer-python](https://github.com/apache/openwhisk-composer-python) | Composer for Python is a new programming model for composing cloud functions built on Apache OpenWhisk (Incubating) |
+| [openwhisk-external-resources](https://github.com/apache/openwhisk-external-resources) | ✨ Curated list of awesome OpenWhisk things ✨ |
 | [openwhisk-pluggable-provider](https://github.com/apache/openwhisk-pluggable-provider) | Apache OpenWhisk pluggable trigger feed event provider  |
+| [openwhisk-podspecs](https://github.com/apache/openwhisk-podspecs) | CocoaPods Podspecs repo for openwhisk-client-swift |
+| [openwhisk-selfserve-test](https://github.com/apache/openwhisk-selfserve-test) | Apache openwhisk |
+| [openwhisk-test](https://github.com/apache/openwhisk-test) | Test repo. for Apache OpenWhisk client-side tooling. |
 | [openwhisk-website](https://github.com/apache/openwhisk-website) | Apache OpenWhisk website (openwhisk.incubator.apache.org) code built using Jekyll |
 
 

--- a/docs/mobile_sdk.md
+++ b/docs/mobile_sdk.md
@@ -35,11 +35,11 @@ install! 'cocoapods', :deterministic_uuids => false
 use_frameworks!
 
 target 'MyApp' do
-     pod 'OpenWhisk', :git => 'https://github.com/apache/incubator-openwhisk-client-swift.git', :tag => '0.3.0'
+     pod 'OpenWhisk', :git => 'https://github.com/apache/openwhisk-client-swift.git', :tag => '0.3.0'
 end
 
 target 'MyApp WatchKit Extension' do
-     pod 'OpenWhisk', :git => 'https://github.com/apache/incubator-openwhisk-client-swift.git', :tag => '0.3.0'
+     pod 'OpenWhisk', :git => 'https://github.com/apache/openwhisk-client-swift.git', :tag => '0.3.0'
 end
 ```
 
@@ -72,7 +72,7 @@ You must then add OpenWhisk.framework to the embedded frameworks in your Xcode p
 
 ### Installing from source code
 
-Source code is available at https://github.com/apache/incubator-openwhisk-client-swift.git.
+Source code is available at https://github.com/apache/openwhisk-client-swift.git.
 Open the project by using the `OpenWhisk.xcodeproj` using Xcode.
 The project contains two schemes: "OpenWhisk" (targeted for iOS) and "OpenWhiskWatch" (targeted for watchOS 2).
 Build the project for the targets that you need and add the resulting frameworks to your app (usually in ~/Library/Developer/Xcode/DerivedData/your app name).

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -17,7 +17,7 @@
 #
 -->
 # OpenWhisk samples
-Here is a list of [OpenWhisk community resources](https://github.com/apache/incubator-openwhisk-external-resources), which includes more samples, complete OpenWhisk applications, articles, tutorials, podcasts and much more.
+Here is a list of [OpenWhisk community resources](https://github.com/apache/openwhisk-external-resources), which includes more samples, complete OpenWhisk applications, articles, tutorials, podcasts and much more.
 
 <!-- TODO
 "Complete listing of OpenWhisk samples can be found here." <- need to insert a link to the OpenWhisk samples repo when there is one -->
@@ -75,4 +75,4 @@ You can also use the event-driven capabilities in OpenWhisk to invoke this actio
 
 ## CLI tutorial
 
-If you prefer learning while doing, consider using this [OpenWhisk Workshop](https://github.com/apache/incubator-openwhisk-workshop).
+If you prefer learning while doing, consider using this [OpenWhisk Workshop](https://github.com/apache/openwhisk-workshop).

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerApiTests.scala
@@ -48,7 +48,7 @@ class ControllerApiTests extends FlatSpec with RestUtil with Matchers with Strea
 
     val expectedJson = JsObject(
       "support" -> JsObject(
-        "github" -> "https://github.com/apache/incubator-openwhisk/issues".toJson,
+        "github" -> "https://github.com/apache/openwhisk/issues".toJson,
         "slack" -> "http://slack.openwhisk.org".toJson),
       "description" -> "OpenWhisk".toJson,
       "api_paths" -> JsArray("/api/v1".toJson),

--- a/tools/actionProxy/README.md
+++ b/tools/actionProxy/README.md
@@ -51,6 +51,6 @@ line of output to `stdout` is a valid JSON object serialized to string if the ac
 A return value is optional but must be a JSON object (properly serialized) if present.
 
 For an example implementation of an `ActionRunner` that overrides `epilogue()` and `build()` see the
-[Swift 3.x](https://github.com/apache/incubator-openwhisk-runtime-swift/blob/master/core/swift3Action/swift3runner.py) action proxy. An implementation of the runner for Python actions
-is available [here](https://github.com/apache/incubator-openwhisk-runtime-python/blob/master/core/pythonAction/pythonrunner.py). Lastly, an example Docker action that uses `C` is
-available in this [example](https://github.com/apache/incubator-openwhisk-runtime-docker/blob/master/sdk/docker/Dockerfile).
+[Swift 3.x](https://github.com/apache/openwhisk-runtime-swift/blob/master/core/swift3Action/swift3runner.py) action proxy. An implementation of the runner for Python actions
+is available [here](https://github.com/apache/openwhisk-runtime-python/blob/master/core/pythonAction/pythonrunner.py). Lastly, an example Docker action that uses `C` is
+available in this [example](https://github.com/apache/openwhisk-runtime-docker/blob/master/sdk/docker/Dockerfile).

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -51,7 +51,7 @@ Some components are dynamically generated. This is supported by a generic compon
 which specifies a regex. The `runtime:([\w]+)` is one such component, useful for rebuilding
 action runtime images.
 
-  * `redo --dir /path/to/incubator-openwhisk-runtime-nodejs runtime:nodejs6action`
+  * `redo --dir /path/to/openwhisk-runtime-nodejs runtime:nodejs6action`
 
 ## How to use `citool`
 

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -148,10 +148,10 @@ can be specified by setting environment variable `GITHUB_ACCESS_TOKEN`
 ```bash
 $ ./gradlew :tools:dev:listRepos
 Found 44 repositories
-incubator-openwhisk
-incubator-openwhisk-GitHubSlackBot
-incubator-openwhisk-apigateway
-incubator-openwhisk-catalog
+openwhisk
+openwhisk-GitHubSlackBot
+openwhisk-apigateway
+openwhisk-catalog
 ...
 Stored the list in /openwhisk_home/build/repos/repos.txt
 Stored the JSON details in /openwhisk_home/build/repos/repos.json
@@ -177,10 +177,10 @@ $ ./gradlew :tools:dev:renderModuleDetails
 ```
 
 [1]: https://www.jetbrains.com/help/idea/run-debug-configurations-dialog.html#run_config_common_options
-[2]: https://github.com/apache/incubator-openwhisk/issues/3195
+[2]: https://github.com/apache/openwhisk/issues/3195
 [3]: https://www.jetbrains.com/help/idea/configuring-projects.html#project-formats
 [4]: http://docs.groovy-lang.org/2.4.2/html/gapi/groovy/util/ConfigSlurper.html
 [5]: https://developer.github.com/v3/search/
 [6]: https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 [7]: https://github.com/docker/for-mac/issues/171
-[8]: https://github.com/apache/incubator-openwhisk-devtools/tree/master/docker-compose
+[8]: https://github.com/apache/openwhisk-devtools/tree/master/docker-compose

--- a/tools/dev/src/main/groovy/intellijRunConfig.groovy
+++ b/tools/dev/src/main/groovy/intellijRunConfig.groovy
@@ -87,7 +87,7 @@ containerNames.each{cn ->
 
         //Prepare system properties
         def sysProps = getSysProps(envMap,type)
-        // disable log collection. See more at: https://github.com/apache/incubator-openwhisk/issues/3195
+        // disable log collection. See more at: https://github.com/apache/openwhisk/issues/3195
         sysProps += " -Dwhisk.log-limit.max=0 -Dwhisk.log-limit.std=0"
         // disable https protocol for controller and invoker
         sysProps = sysProps.replaceAll("protocol=https", "protocol=http")

--- a/tools/dev/src/main/groovy/listRepos.groovy
+++ b/tools/dev/src/main/groovy/listRepos.groovy
@@ -45,9 +45,10 @@ while ( link ) {
     }
 
     // add all projects matching naming conventions
+    // TODO: while in the midst of repo renaming, find both openwhisk and incubator-openwhisk repos
     def result = parser.parse(conn.inputStream)
     owRepos += result
-            .findAll { it.name.startsWith('incubator-openwhisk') }
+            .findAll { it.name.startsWith('openwhisk') || it.name.startsWith('incubator-openwhisk') }
 
     // find link to next page, if applicable
     link = null

--- a/tools/dev/src/main/groovy/listRepos.groovy
+++ b/tools/dev/src/main/groovy/listRepos.groovy
@@ -45,10 +45,9 @@ while ( link ) {
     }
 
     // add all projects matching naming conventions
-    // TODO: while in the midst of repo renaming, find both openwhisk and incubator-openwhisk repos
     def result = parser.parse(conn.inputStream)
     owRepos += result
-            .findAll { it.name.startsWith('openwhisk') || it.name.startsWith('incubator-openwhisk') }
+            .findAll { it.name.startsWith('openwhisk') }
 
     // find link to next page, if applicable
     link = null

--- a/tools/ow-utils/Dockerfile
+++ b/tools/ow-utils/Dockerfile
@@ -46,7 +46,7 @@ RUN wget --no-verbose https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER
   chmod +x /usr/bin/docker
 
 # # Install `wsk` cli in /usr/local/bin
-RUN wget -q https://github.com/apache/incubator-openwhisk-cli/releases/download/$WHISK_CLI_VERSION/OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz && \
+RUN wget -q https://github.com/apache/openwhisk-cli/releases/download/$WHISK_CLI_VERSION/OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz && \
   tar xzf OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz -C /usr/local/bin wsk && \
   rm OpenWhisk_CLI-$WHISK_CLI_VERSION-linux-amd64.tgz
 

--- a/tools/owperf/README.md
+++ b/tools/owperf/README.md
@@ -49,7 +49,7 @@ Test setup and teardown can be independently skipped via CLI, and/or directly in
 
 ## Initial Setup
 The tool requires very little setup. You need to have node.js (v8+) and the wsk CLI client installed (on $PATH). Before the first run, execute ```npm install``` in the tool folder to install the dependencies.
-**Throttling**: By default, OW performance is throttled according to some [limits](https://github.com/apache/incubator-openwhisk/blob/master/docs/reference.md#system-limits), such as maximum number of concurrent requests, or maximum invocations per minute. If your benchmark stresses OpenWhisk beyond the limit value, you might want to relax those limits. If it's an OpenWhisk deployment that you control, you can set the limits to 999999, thereby effectively cancelling the limits. If it's a third-party service, you may want to consult the service documentation and/or support to see what limits can be relaxed and by how much.
+**Throttling**: By default, OW performance is throttled according to some [limits](https://github.com/apache/openwhisk/blob/master/docs/reference.md#system-limits), such as maximum number of concurrent requests, or maximum invocations per minute. If your benchmark stresses OpenWhisk beyond the limit value, you might want to relax those limits. If it's an OpenWhisk deployment that you control, you can set the limits to 999999, thereby effectively cancelling the limits. If it's a third-party service, you may want to consult the service documentation and/or support to see what limits can be relaxed and by how much.
 
 ## Usage
 To use the tool, run ```./owperf.sh <options>``` to perform a test. To see all the available options and defaults run ```./owperf.sh -h```.

--- a/tools/travis/scan.sh
+++ b/tools/travis/scan.sh
@@ -23,14 +23,14 @@ SECONDS=0
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."
 HOMEDIR="$SCRIPTDIR/../../../"
-UTILDIR="$HOMEDIR/incubator-openwhisk-utilities/"
+UTILDIR="$HOMEDIR/openwhisk-utilities/"
 
 cd $ROOTDIR
 ./tools/travis/flake8.sh  # Check Python files for style and stop the build on syntax errors
 
 # clone the openwhisk utilities repo.
 cd $HOMEDIR
-git clone https://github.com/apache/incubator-openwhisk-utilities.git
+git clone https://github.com/apache/openwhisk-utilities.git
 
 # run the scancode util. against project source code starting at its root
 cd $UTILDIR

--- a/tools/ubuntu-setup/README.md
+++ b/tools/ubuntu-setup/README.md
@@ -30,7 +30,7 @@ Your local machine can act as the bootstrapper as well if it can connect to the 
   sudo apt-get install git -y
 
   # Clone openwhisk
-  git clone https://github.com/apache/incubator-openwhisk.git openwhisk
+  git clone https://github.com/apache/openwhisk.git openwhisk
 
   # Change current directory to openwhisk
   cd openwhisk

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -32,7 +32,7 @@ The following instructions were tested on Mac OS X El Capitan, Ubuntu 16.04 LTS.
 ### Clone the repository and change directory to `tools/vagrant`
 
 ```
-git clone --depth=1 https://github.com/apache/incubator-openwhisk.git openwhisk
+git clone --depth=1 https://github.com/apache/openwhisk.git openwhisk
 cd openwhisk/tools/vagrant
 ```
 
@@ -104,7 +104,7 @@ same IP address.
 The CLI is available in `../../bin`.
 The CLI `../../bin/wsk` is for Linux amd64.
 The CLI for all other operating systems and architectures (as well as Linux) can be
-downloaded in a compressed format from [https://github.com/apache/incubator-openwhisk-cli/releases](https://github.com/apache/incubator-openwhisk-cli/releases) .
+downloaded in a compressed format from [https://github.com/apache/openwhisk-cli/releases](https://github.com/apache/openwhisk-cli/releases) .
 For more details, please consult the relevant [documentation](https://openwhisk.apache.org/documentation.html) section "Download and
 install the wsk CLI from (Linux, Mac or Windows):".
 


### PR DESCRIPTION
Remove almost all incubator- cross references to github repos,
leaving only the subset of repos that have not yet been renamed.
