### PR TITLE
Action container log collection does not wait for sentinel on developer error

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -40,7 +40,6 @@ import org.apache.openwhisk.common.{AkkaLogging, TransactionId}
 import org.apache.openwhisk.core.containerpool.Container
 import org.apache.openwhisk.core.entity.{ActivationLogs, ExecutableWhiskAction, Identity, WhiskActivation}
 import org.apache.openwhisk.core.entity.size._
-import org.apache.openwhisk.http.Messages
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
@@ -123,12 +122,9 @@ class DockerToActivationFileLogStore(system: ActorSystem, destinationDirectory: 
                            container: Container,
                            action: ExecutableWhiskAction): Future[ActivationLogs] = {
 
-    val logs = logStream(
-      transid,
-      container,
-      action.limits.logs,
-      action.exec.sentinelledLogs,
-      activation.response.isContainerError) // container error means developer error
+    val logLimit = action.limits.logs
+    val isDeveloperError = activation.response.isContainerError // container error means developer error
+    val logs = logStream(transid, container, logLimit, action.exec.sentinelledLogs, isDeveloperError)
 
     // Adding the userId field to every written record, so any background process can properly correlate.
     val userIdField = Map("namespaceId" -> user.namespace.uuid.toJson)
@@ -154,12 +150,8 @@ class DockerToActivationFileLogStore(system: ActorSystem, destinationDirectory: 
     val combined = OwSink.combine(toSeq, toFile)(Broadcast[ByteString](_))
 
     logs.runWith(combined)._1.flatMap { seq =>
-      // Messages.logWarningDeveloperError shows up if the activation ends in a developer error.
-      // This must not be reported as log collection error.
-      val possibleErrors = Set(Messages.logFailure, Messages.truncateLogs(action.limits.logs.asMegaBytes))
-      val errored = seq.lastOption.exists(last => possibleErrors.exists(last.contains))
       val logs = ActivationLogs(seq.toVector)
-      if (!errored) {
+      if (!isLogCollectingError(logs, logLimit, isDeveloperError)) {
         Future.successful(logs)
       } else {
         Future.failed(LogCollectingException(logs))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationLogStore.scala
@@ -88,6 +88,9 @@ class DockerToActivationLogStore(system: ActorSystem) extends LogStore {
    *
    * In case of a developer error, append a warning message to the logs that data might be missing.
    *
+   * TODO: instead of just appending a warning message when a developer error occurs, we should
+   *       have an out-of-band error handling that injects such messages later on.
+   *
    * @param transid transaction id
    * @param container container to obtain the log from
    * @param action action that defines the log limit
@@ -121,6 +124,12 @@ class DockerToActivationLogStore(system: ActorSystem) extends LogStore {
    * If the activation failed due to a developer error, an additional error message is appended.
    * In that case, the second last message indicates whether there was a log collecting error AND
    * the last message MUST be the additional error message mentioned above.
+   *
+   * TODO: this function needs to deal with different combinations of error / warning messages that
+   *       were appended to / injected into the log collecting stream.
+   *       Instead, we should have an out-of-band error handling that does not use log messages to
+   *       detect error conditions but detects errors and appends error / warning messages in
+   *       a different way.
    *
    * @param actLogs the activation logs to check
    * @param logLimit the log limit applying to the activation

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -55,18 +55,19 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
   /* The field name that is universally recognized as the marker of an error, from the application or otherwise. */
   val ERROR_FIELD: String = "error"
 
+  // These constants need to be synchronized with messageForCode() method below
   val Success = 0 // action ran successfully and produced a result
   val ApplicationError = 1 // action ran but there was an error and it was handled
   val DeveloperError = 2 // action ran but failed to handle an error, or action did not run and failed to initialize
   val WhiskError = 3 // internal system error
 
   protected[core] def messageForCode(code: Int) = {
-    require(code >= 0 && code <= 3)
+    require(code >= Success && code <= WhiskError)
     code match {
-      case 0 => "success"
-      case 1 => "application error"
-      case 2 => "action developer error"
-      case 3 => "whisk internal error"
+      case Success          => "success"
+      case ApplicationError => "application error"
+      case DeveloperError   => "action developer error"
+      case WhiskError       => "whisk internal error"
     }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -166,6 +166,8 @@ object Messages {
   }
   val logFailure = "There was an issue while collecting your logs. Data might be missing."
 
+  val logWarningDeveloperError = "The action did not initialize or run as expected. Log data might be missing."
+
   /** Error for meta api. */
   val propertyNotFound = "Response does not include requested property."
   def invalidMedia(m: MediaType) = s"Response is not valid '${m.value}'."

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -259,24 +259,26 @@ class DockerContainer(protected val id: ContainerId,
    *
    * There are two possible modes controlled by parameter waitForSentinel:
    *
-   * 1. Wait for sentinel: tail container log file until two sentinel markers show up. Complete
-   *                       once two sentinel markers have been identified, regardless whether more
-   *                       data could be read from container log file.
-   *                       A log file reading error is reported if sentinels cannot be found.
-   *                       Managed action runtimes use the the sentinels to mark the end of
-   *                       an individual activation.
+   * 1. Wait for sentinel:
+   *    Tail container log file until two sentinel markers show up. Complete
+   *    once two sentinel markers have been identified, regardless whether more
+   *    data could be read from container log file.
+   *    A log file reading error is reported if sentinels cannot be found.
+   *    Managed action runtimes use the the sentinels to mark the end of
+   *    an individual activation.
    *
-   * 2. Do not wait for sentinel: read container log file up to its end. Stop reading once the end
-   *                              has been reached. Complete once two sentinel markers have been
-   *                              identified, regardless whether more data could be read from
-   *                              container log file.
-   *                              No log file reading error is reported if sentinels cannot be found.
-   *                              Blackbox actions do not necessarily produce marker sentinels properly,
-   *                              so this mode is used for all blackbox actions.
-   *                              In addition, this mode can / should be used in error situations with
-   *                              managed action runtimes where sentinel markers may be missing or
-   *                              arrive too late - Example: action exceeds time or memory limit during
-   *                              init or run.
+   * 2. Do not wait for sentinel:
+   *    Read container log file up to its end. Stop reading once the end
+   *    has been reached. Complete once two sentinel markers have been
+   *    identified, regardless whether more data could be read from
+   *    container log file.
+   *    No log file reading error is reported if sentinels cannot be found.
+   *    Blackbox actions do not necessarily produce marker sentinels properly,
+   *    so this mode is used for all blackbox actions.
+   *    In addition, this mode can / should be used in error situations with
+   *    managed action runtimes where sentinel markers may be missing or
+   *    arrive too late - Example: action exceeds time or memory limit during
+   *    init or run.
    *
    * The result returned from this method does never contain any log sentinel markers. These are always
    * filtered - regardless of the specified waitForSentinel mode.

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -115,7 +115,7 @@ class DockerContainerTests
         retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
         ccRes
       }
-      override protected val waitForLogs = awaitLogs
+      override protected val logCollectingIdleTimeout = awaitLogs
       override protected val filePollInterval = 1.millisecond
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationLogStoreTests.scala
@@ -30,12 +30,14 @@ import org.apache.openwhisk.core.containerpool.logging.{
 import org.apache.openwhisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
 import org.apache.openwhisk.core.entity._
 import java.time.Instant
+
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.containerpool.{Container, ContainerAddress, ContainerId}
 import org.apache.openwhisk.http.Messages
+
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
@@ -48,7 +50,7 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
     Identity(Subject(), Namespace(EntityName("testSpace"), uuid), BasicAuthenticationAuthKey(uuid, Secret()), Set.empty)
   val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
   val action = ExecutableWhiskAction(user.namespace.name.toPath, EntityName("actionName"), exec)
-  val activation =
+  val successfulActivation =
     WhiskActivation(
       user.namespace.name.toPath,
       action.name,
@@ -56,6 +58,7 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
       ActivationId.generate(),
       Instant.EPOCH,
       Instant.EPOCH)
+  val developerErrorActivation = successfulActivation.copy(response = ActivationResponse.developerError("failed"))
 
   def toByteString(logs: List[LogLine]) = logs.map(_.toJson.compactPrint).map(ByteString.apply)
 
@@ -73,8 +76,56 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
       LogLine(Instant.now.toString, "stdout", "this is a log too"))
     val container = new TestContainer(Source(toByteString(logs)))
 
-    await(store.collectLogs(tid, user, activation, container, action)) shouldBe ActivationLogs(
+    await(store.collectLogs(tid, user, successfulActivation, container, action)) shouldBe ActivationLogs(
       logs.map(_.toFormattedString).toVector)
+  }
+
+  it should "read logs into a sequence and parse them into the specified format with developer error" in {
+    val store = createStore()
+
+    val logs = List(
+      LogLine(Instant.now.toString, "stdout", "this is a log"),
+      LogLine(Instant.now.toString, "stdout", "this is a log too"))
+    val container = new TestContainer(Source(toByteString(logs)))
+
+    val collectedLogs = await(store.collectLogs(tid, user, developerErrorActivation, container, action)).logs
+
+    withClue("Collected logs should be empty:") {
+      collectedLogs.dropRight(1) shouldBe logs.map(_.toFormattedString).toVector
+    }
+
+    withClue("Last line should end with developer error warning:") {
+      val lastLogLine = collectedLogs.last
+      lastLogLine should endWith(Messages.logWarningDeveloperError)
+    }
+  }
+
+  it should "accept an empty log" in {
+    val store = createStore()
+
+    val logs = List.empty[LogLine]
+    val container = new TestContainer(Source(toByteString(logs)))
+
+    await(store.collectLogs(tid, user, successfulActivation, container, action)) shouldBe ActivationLogs(
+      Vector.empty[String])
+  }
+
+  it should "accept an empty log with developer error" in {
+    val store = createStore()
+
+    val logs = List.empty[LogLine]
+    val container = new TestContainer(Source(toByteString(logs)))
+
+    val collectedLogs = await(store.collectLogs(tid, user, developerErrorActivation, container, action)).logs
+
+    withClue("Collected logs should be empty:") {
+      collectedLogs.dropRight(1) shouldBe Vector.empty[String]
+    }
+
+    withClue("Last line should end with developer error warning:") {
+      val lastLogLine = collectedLogs.last
+      lastLogLine should endWith(Messages.logWarningDeveloperError)
+    }
   }
 
   it should "report an error if the logs contain an 'official' notice of such" in {
@@ -85,8 +136,31 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
       LogLine(Instant.now.toString, "stderr", Messages.logFailure))
     val container = new TestContainer(Source(toByteString(logs)))
 
-    val ex = the[LogCollectingException] thrownBy await(store.collectLogs(tid, user, activation, container, action))
+    val ex = the[LogCollectingException] thrownBy await(
+      store.collectLogs(tid, user, successfulActivation, container, action))
     ex.partialLogs shouldBe ActivationLogs(logs.map(_.toFormattedString).toVector)
+  }
+
+  it should "report an error if the logs contain an 'official' notice of such with developer error" in {
+    val store = createStore()
+
+    val logs = List(
+      LogLine(Instant.now.toString, "stdout", "this is a log"),
+      LogLine(Instant.now.toString, "stderr", Messages.logFailure))
+    val container = new TestContainer(Source(toByteString(logs)))
+
+    val ex = the[LogCollectingException] thrownBy await(
+      store.collectLogs(tid, user, developerErrorActivation, container, action))
+    val collectedLogs = ex.partialLogs.logs
+
+    withClue("Collected logs should match provided logs:") {
+      collectedLogs.dropRight(1) shouldBe logs.map(_.toFormattedString).toVector
+    }
+
+    withClue("Last line should end with developer error warning:") {
+      val lastLogLine = collectedLogs.last
+      lastLogLine should endWith(Messages.logWarningDeveloperError)
+    }
   }
 
   it should "report an error if logs have been truncated" in {
@@ -97,7 +171,8 @@ class DockerToActivationLogStoreTests extends FlatSpec with Matchers with WskAct
       LogLine(Instant.now.toString, "stderr", Messages.truncateLogs(action.limits.logs.asMegaBytes)))
     val container = new TestContainer(Source(toByteString(logs)))
 
-    val ex = the[LogCollectingException] thrownBy await(store.collectLogs(tid, user, activation, container, action))
+    val ex = the[LogCollectingException] thrownBy await(
+      store.collectLogs(tid, user, successfulActivation, container, action))
     ex.partialLogs shouldBe ActivationLogs(logs.map(_.toFormattedString).toVector)
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -497,7 +497,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
           result.response.result.get
             .fields("error") shouldBe Messages.timedoutActivation(allowedActionDuration, init = false).toJson
           val logs = result.logs.get
-          logs.last should include(Messages.logFailure)
+          logs.last should include(Messages.logWarningDeveloperError)
 
           val parseLogTime = (line: String) => Instant.parse(line.split(' ').head)
           val startTime = parseLogTime(logs.head)


### PR DESCRIPTION
* So far, log collection for managed Docker action containers waits for sentinels - even if a developer error occurs. Only if an action exceeded its init or run timeout, sentinel waiting will be disabled.
* This change disables sentinel waiting for all developer errors because a managed action runtime may not be able to write sentinels at all in developer error situations. With this change, missing sentinels are handled in a more robust way.
* Without sentinel waiting, the Docker action container log file is only read until file end is reached. No re-reads are performed if the sentinel has not been found yet. On busy systems, this may lead to a few missing log lines in case of developer errors.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/incubator-openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/incubator-openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.
