### PR TITLE
Pass transactionId to action container

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -572,7 +572,7 @@ class ContainerProxy(
           "namespace" -> job.msg.user.namespace.name.toJson,
           "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
           "activation_id" -> job.msg.activationId.toString.toJson,
-          "transaction_id" -> tid.id.toJson,
+          "transaction_id" -> job.msg.transid.id.toJson,
           // compute deadline on invoker side avoids discrepancies inside container
           // but potentially under-estimates actual deadline
           "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -572,6 +572,7 @@ class ContainerProxy(
           "namespace" -> job.msg.user.namespace.name.toJson,
           "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
           "activation_id" -> job.msg.activationId.toString.toJson,
+          "transaction_id" -> tid.id.toJson,
           // compute deadline on invoker side avoids discrepancies inside container
           // but potentially under-estimates actual deadline
           "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -196,6 +196,7 @@ platform follows the following schema:
   "api_host": String,
   "api_key": String,
   "activation_id": String,
+  "transaction_id": String,
   "deadline": Number
 }
 ```
@@ -204,6 +205,7 @@ platform follows the following schema:
 * `namespace` is the OpenWhisk namespace for the action (e.g., `whisk.system`).
 * `action_name` is the [fully qualified name](reference.md#fully-qualified-names) of the action.
 * `activation_id` is a unique ID for this activation.
+* `transaction_id` is a unique ID for the request of which this activation is part of. 
 * `deadline` is the deadline for the function.
 * `api_key` is the API key used to invoke the action.
 

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -205,7 +205,7 @@ platform follows the following schema:
 * `namespace` is the OpenWhisk namespace for the action (e.g., `whisk.system`).
 * `action_name` is the [fully qualified name](reference.md#fully-qualified-names) of the action.
 * `activation_id` is a unique ID for this activation.
-* `transaction_id` is a unique ID for the request of which this activation is part of. 
+* `transaction_id` is a unique ID for the request of which this activation is part of.
 * `deadline` is the deadline for the function.
 * `api_key` is the API key used to invoke the action.
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1164,6 +1164,7 @@ class ContainerProxyTests
       environment.fields("namespace") shouldBe invocationNamespace.name.toJson
       environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
       environment.fields("activation_id") shouldBe message.activationId.toJson
+      environment.fields("transaction_id") shouldBe transid.id.toJson
       val authEnvironment = environment.fields.filterKeys(message.user.authkey.toEnvironment.fields.contains)
       if (apiKeyMustBePresent) {
         message.user.authkey.toEnvironment shouldBe authEnvironment.toJson.asJsObject


### PR DESCRIPTION
Enable passing the transaction_id to action containers to corelate requests made from within actions across different actions in a sequence or composition 

This change is part of #4585

## Description

Passes a new attribute `transaction_id` as part of `/run` call which would be exposed as env entry `__OW_TRANSACTION_ID` 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

