### PR TITLE
update lastUse timestamp when advancing ContainerProxy instances in use

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -137,7 +137,7 @@ case class WarmingData(override val container: Container,
     extends ContainerStarted(container, lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warming"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 /** type representing a cold (not yet running) container that is being initialized (for a specific action + invocation namespace) */
@@ -148,7 +148,7 @@ case class WarmingColdData(invocationNamespace: EntityName,
     extends ContainerNotStarted(lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warmingCold"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 /** type representing a warm container that has already been in use (for a specific action + invocation namespace) */
@@ -160,7 +160,7 @@ case class WarmedData(override val container: Container,
     extends ContainerStarted(container, lastUsed, action.limits.memory.megabytes.MB, activeActivationCount)
     with ContainerInUse {
   override val initingState = "warmed"
-  override def nextRun(r: Run) = copy(activeActivationCount = activeActivationCount + 1)
+  override def nextRun(r: Run) = copy(lastUsed = Instant.now, activeActivationCount = activeActivationCount + 1)
 }
 
 // Events received by the actor

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -18,15 +18,14 @@
 package org.apache.openwhisk.core.containerpool.test
 
 import java.time.Instant
-
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor.{ActorRef, ActorSystem, FSM}
 import akka.stream.scaladsl.Source
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.ByteString
 import common.{LoggedFunction, StreamLogging, SynchronizedLoggedFunction, WhiskProperties}
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
@@ -34,6 +33,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.connector.ActivationMessage
+import org.apache.openwhisk.core.containerpool.WarmingData
 import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.containerpool.logging.LogCollectingException
 import org.apache.openwhisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
@@ -41,7 +41,6 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -1108,6 +1107,61 @@ class ContainerProxyTests
       acker.calls should have size 1
       store.calls should have size 1
     }
+  }
+  it should "reset the lastUse and increment the activationCount on nextRun()" in {
+    //NoData/MemoryData/PrewarmedData always reset activation count to 1, and reset lastUse
+    val noData = NoData()
+    noData.nextRun(Run(action, message)) should matchPattern {
+      case WarmingColdData(message.user.namespace.name, action, _, 1) =>
+    }
+
+    val memData = MemoryData(action.limits.memory.megabytes.MB)
+    memData.nextRun(Run(action, message)) should matchPattern {
+      case WarmingColdData(message.user.namespace.name, action, _, 1) =>
+    }
+    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB)
+    pwData.nextRun(Run(action, message)) should matchPattern {
+      case WarmingData(pwData.container, message.user.namespace.name, action, _, 1) =>
+    }
+
+    //WarmingData, WarmingColdData, and WarmedData increment counts and reset lastUse
+    val timeDiffSeconds = 20
+    val initialCount = 10
+    //WarmingData
+    val warmingData = WarmingData(
+      pwData.container,
+      message.user.namespace.name,
+      action,
+      Instant.now.minusSeconds(timeDiffSeconds),
+      initialCount)
+    val nextWarmingData = warmingData.nextRun(Run(action, message))
+    val nextCount = warmingData.activeActivationCount + 1
+    nextWarmingData should matchPattern {
+      case WarmingData(pwData.container, message.user.namespace.name, action, _, nextCount) =>
+    }
+    warmingData.lastUsed.until(nextWarmingData.lastUsed, ChronoUnit.SECONDS) should be >= timeDiffSeconds.toLong
+
+    //WarmingColdData
+    val warmingColdData =
+      WarmingColdData(message.user.namespace.name, action, Instant.now.minusSeconds(timeDiffSeconds), initialCount)
+    val nextWarmingColdData = warmingColdData.nextRun(Run(action, message))
+    nextWarmingColdData should matchPattern {
+      case WarmingColdData(message.user.namespace.name, action, _, newCount) =>
+    }
+    warmingColdData.lastUsed.until(nextWarmingColdData.lastUsed, ChronoUnit.SECONDS) should be >= timeDiffSeconds.toLong
+
+    //WarmedData
+    val warmedData = WarmedData(
+      pwData.container,
+      message.user.namespace.name,
+      action,
+      Instant.now.minusSeconds(timeDiffSeconds),
+      initialCount)
+    val nextWarmedData = warmedData.nextRun(Run(action, message))
+    nextWarmedData should matchPattern {
+      case WarmedData(pwData.container, message.user.namespace.name, action, _, newCount) =>
+    }
+    warmedData.lastUsed.until(nextWarmedData.lastUsed, ChronoUnit.SECONDS) should be >= timeDiffSeconds.toLong
   }
 
   /**


### PR DESCRIPTION

## Description
ContainerProxy states (ContainerData impls) may not propagate `lastUse` timestamp properly in certain states (concurrent cold start and prewarm use). 
This fixes potential for container removal based on oldest lastUse where lastUse may not actually be the last instant this container was used.

<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

