### PR TITLE
Allow individual field sets for activation_record and user_log

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -111,8 +111,15 @@ class ActivationFileStorage(logFilePrefix: String,
   def activationToFile(activation: WhiskActivation,
                        context: UserContext,
                        additionalFields: Map[String, JsValue] = Map.empty) = {
-    val transcribedLogs = transcribeLogs(activation, additionalFields)
-    val transcribedActivation = transcribeActivation(activation, additionalFields)
+    activationToFileExtended(activation, context, additionalFields, additionalFields)
+  }
+
+  def activationToFileExtended(activation: WhiskActivation,
+                               context: UserContext,
+                               additionalFieldsForLogs: Map[String, JsValue] = Map.empty,
+                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty) = {
+    val transcribedLogs = transcribeLogs(activation, additionalFieldsForLogs)
+    val transcribedActivation = transcribeActivation(activation, additionalFieldsForActivation)
 
     // Write each log line to file and then write the activation metadata
     Source

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -111,7 +111,7 @@ class ActivationFileStorage(logFilePrefix: String,
 
   def activationToFile(activation: WhiskActivation,
                        context: UserContext,
-                       additionalFields: Map[String, JsValue] = Map.empty): NotUsed = {
+                       additionalFields: Map[String, JsValue] = Map.empty): Unit = {
     activationToFileExtended(activation, context, additionalFields, additionalFields)
   }
 
@@ -119,7 +119,7 @@ class ActivationFileStorage(logFilePrefix: String,
   def activationToFileExtended(activation: WhiskActivation,
                                context: UserContext,
                                additionalFieldsForLogs: Map[String, JsValue] = Map.empty,
-                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty): NotUsed = {
+                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty): Unit = {
     val transcribedLogs = transcribeLogs(activation, additionalFieldsForLogs)
     val transcribedActivation = transcribeActivation(activation, additionalFieldsForActivation)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -22,7 +22,6 @@ import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.EnumSet
 
-import akka.NotUsed
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.file.scaladsl.LogRotatorSink
 import akka.stream.scaladsl.{Flow, MergeHub, RestartSink, Sink, Source}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -114,6 +114,7 @@ class ActivationFileStorage(logFilePrefix: String,
     activationToFileExtended(activation, context, additionalFields, additionalFields)
   }
 
+  // used by external ArtifactActivationStore SPI implementation
   def activationToFileExtended(activation: WhiskActivation,
                                context: UserContext,
                                additionalFieldsForLogs: Map[String, JsValue] = Map.empty,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -22,6 +22,7 @@ import java.nio.file.{Files, Path}
 import java.time.Instant
 import java.util.EnumSet
 
+import akka.NotUsed
 import akka.stream.ActorMaterializer
 import akka.stream.alpakka.file.scaladsl.LogRotatorSink
 import akka.stream.scaladsl.{Flow, MergeHub, RestartSink, Sink, Source}
@@ -106,11 +107,11 @@ class ActivationFileStorage(logFilePrefix: String,
     ByteString(s"${line.compactPrint}\n")
   }
 
-  def getLogFile = logFile
+  def getLogFile: Path = logFile
 
   def activationToFile(activation: WhiskActivation,
                        context: UserContext,
-                       additionalFields: Map[String, JsValue] = Map.empty) = {
+                       additionalFields: Map[String, JsValue] = Map.empty): NotUsed = {
     activationToFileExtended(activation, context, additionalFields, additionalFields)
   }
 
@@ -118,7 +119,7 @@ class ActivationFileStorage(logFilePrefix: String,
   def activationToFileExtended(activation: WhiskActivation,
                                context: UserContext,
                                additionalFieldsForLogs: Map[String, JsValue] = Map.empty,
-                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty) = {
+                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty): NotUsed = {
     val transcribedLogs = transcribeLogs(activation, additionalFieldsForLogs)
     val transcribedActivation = transcribeActivation(activation, additionalFieldsForActivation)
 


### PR DESCRIPTION
Introduce individual field set for activation records in user logs.

## Description
We need to handle activation records (i.e., activation metadata) and user logs differently in activation logs. Therefore we need individual field sets for storing these entries in `ActivationFileStorage` that we use in our Activation Store SPI imlementation.

## My changes affect the following components
- Controller (for sequences)
- Invoker

## Types of changes
Small change with low risk: add one function `activationToFileExtended`in `org.apache.openwhisk.core.database.ActivationFileStorage` that is basically the same as `activationToFile`but allows to define different sets of additional fields for activation_record and user_log. The proposed change does not replace the existing function `activationToFile` but adds the desired new function in order to not change the interface of `ActivationFileStorage` that might be used by other Activation Store SPI imlementations out there.
