### PR TITLE
Update api gateway to released 0.11.0 in standalone mode

### DIFF
--- a/core/standalone/src/main/resources/standalone.conf
+++ b/core/standalone/src/main/resources/standalone.conf
@@ -88,7 +88,7 @@ whisk {
     }
 
     api-gateway {
-      image = "openwhisk/apigateway:nightly"
+      image = "openwhisk/apigateway:0.11.0"
     }
 
     couchdb {


### PR DESCRIPTION
Updates the gateway version from a nightly build to released version which has the fix for apache/openwhisk-apigateway#347

