### PR TITLE
Add dev mode flag to speed up startup during development

### DIFF
--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -169,9 +169,14 @@ object StandaloneDockerSupport {
   }
 }
 
-class StandaloneDockerClient(implicit log: Logging, as: ActorSystem, ec: ExecutionContext)
+class StandaloneDockerClient(pullDisabled: Boolean)(implicit log: Logging, as: ActorSystem, ec: ExecutionContext)
     extends DockerClient()(ec)
     with WindowsDockerClient {
+
+  override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
+    if (pullDisabled) Future.successful(Unit) else super.pull(image)
+  }
+
   override def runCmd(args: Seq[String], timeout: Duration)(implicit transid: TransactionId): Future[String] =
     super.runCmd(args, timeout)
 


### PR DESCRIPTION
Reduces startup in dev mode from ~ 12-14 secs to ~7 secs

## Description
Currently the base standalone server starts in ~ 12-14 seconds. Some of this time is spent in pre flight checks and doing explicit pulls for some of the images used. This is useful for end user so as to ensure that system has required support.

However for regular development it adds up to startup time. So added a `--dev-mode` flag which disables the preflight checks and disabled explicit pulls. This should be fine for people developing on core codebase.

```
java -jar openwhisk-standalone.jar --dev-mode
```

