### PR TITLE
Allow decision about action result inclusion in logs on a per call basis

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -91,9 +91,11 @@ class ActivationFileStorage(logFilePrefix: String,
       ByteString(s"${line.compactPrint}\n")
     }
 
-  private def transcribeActivation(activation: WhiskActivation, additionalFields: Map[String, JsValue]) = {
+  private def transcribeActivation(activation: WhiskActivation,
+                                   additionalFields: Map[String, JsValue],
+                                   includeResult: Boolean) = {
     val transactionType = Map("type" -> "activation_record".toJson)
-    val message = Map(if (writeResultToFile) {
+    val message = Map(if (includeResult) {
       "message" -> JsString(activation.response.result.getOrElse(JsNull).compactPrint)
     } else {
       "message" -> JsString(s"Activation record '${activation.activationId}' for entity '${activation.name}'")
@@ -118,9 +120,10 @@ class ActivationFileStorage(logFilePrefix: String,
   def activationToFileExtended(activation: WhiskActivation,
                                context: UserContext,
                                additionalFieldsForLogs: Map[String, JsValue] = Map.empty,
-                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty): Unit = {
+                               additionalFieldsForActivation: Map[String, JsValue] = Map.empty,
+                               includeResult: Boolean = writeResultToFile): Unit = {
     val transcribedLogs = transcribeLogs(activation, additionalFieldsForLogs)
-    val transcribedActivation = transcribeActivation(activation, additionalFieldsForActivation)
+    val transcribedActivation = transcribeActivation(activation, additionalFieldsForActivation, includeResult)
 
     // Write each log line to file and then write the activation metadata
     Source

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -245,7 +245,7 @@ class ArtifactWithFileStorageActivationStoreTests()
     val additionalFieldsForLogs = Map("field1" -> JsString("value1"))
     val additionalFieldsForActivation = Map("field2" -> JsString("value2"))
 
-    // START -- example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
+    // START - example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
 
     case class ArtifactWithFileStorageActivationStoreConfigExtendedTest(logFilePrefix: String,
                                                                         logPath: String,
@@ -293,7 +293,7 @@ class ArtifactWithFileStorageActivationStoreTests()
 
     }
 
-    // END -- example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
+    // END - example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
 
     // writeResultToFile=true should be overriden by this test
     val config = ArtifactWithFileStorageActivationStoreConfigExtendedTest("userlogs", "logs", "namespaceId", true)

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.database
 
 import java.io.File
+import java.nio.file.Paths
 import java.time.Instant
 
 import akka.actor.ActorSystem
@@ -31,9 +32,11 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import org.apache.openwhisk.common.{TransactionId, WhiskInstants}
+import org.apache.openwhisk.common.{Logging, TransactionId, WhiskInstants}
+import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size.SizeInt
+import pureconfig.loadConfigOrThrow
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -85,13 +88,21 @@ class ArtifactWithFileStorageActivationStoreTests()
           "2018-03-05T02:10:38.196754258Z stdout: second log line of multiple lines")))
   }
 
-  def expectedFileContent(activation: WhiskActivation, includeResult: Boolean) = {
+  def expectedFileContent(activation: WhiskActivation,
+                          includeResult: Boolean,
+                          additionalFieldsForLogs: Seq[JsField] = Seq(),
+                          additionalFieldsForActivation: Seq[JsField] = Seq()) = {
     val expectedLogs = activation.logs.logs.map { log =>
-      JsObject(
-        "type" -> "user_log".toJson,
-        "message" -> log.toJson,
-        "activationId" -> activation.activationId.toJson,
-        "namespaceId" -> user.namespace.uuid.toJson)
+      {
+        JsObject(
+          Seq(
+            "type" -> "user_log".toJson,
+            "message" -> log.toJson,
+            "activationId" -> activation.activationId.toJson,
+            "namespaceId" -> user.namespace.uuid.toJson)
+            ++ additionalFieldsForLogs: _*)
+
+      }
     }
     val expectedResult = if (includeResult) {
       JsString(activation.response.result.getOrElse(JsNull).compactPrint)
@@ -99,23 +110,25 @@ class ArtifactWithFileStorageActivationStoreTests()
       JsString(s"Activation record '${activation.activationId}' for entity '${activation.name}'")
     }
     val expectedActivation = JsObject(
-      "type" -> "activation_record".toJson,
-      "duration" -> activation.duration.toJson,
-      "name" -> activation.name.toJson,
-      "subject" -> activation.subject.toJson,
-      "waitTime" -> activation.annotations.get("waitTime").toJson.toJson,
-      "activationId" -> activation.activationId.toJson,
-      "namespaceId" -> user.namespace.uuid.toJson,
-      "publish" -> activation.publish.toJson,
-      "version" -> activation.version.toJson,
-      "response" -> activation.response.withoutResult.toExtendedJson,
-      "end" -> activation.end.toEpochMilli.toJson,
-      "message" -> expectedResult,
-      "kind" -> activation.annotations.get("kind").toJson.toJson,
-      "start" -> activation.start.toEpochMilli.toJson,
-      "limits" -> activation.annotations.get("limits").toJson.toJson,
-      "initTime" -> activation.annotations.get("initTime").toJson,
-      "namespace" -> activation.namespace.toJson)
+      Seq(
+        "type" -> "activation_record".toJson,
+        "duration" -> activation.duration.toJson,
+        "name" -> activation.name.toJson,
+        "subject" -> activation.subject.toJson,
+        "waitTime" -> activation.annotations.get("waitTime").toJson.toJson,
+        "activationId" -> activation.activationId.toJson,
+        "namespaceId" -> user.namespace.uuid.toJson,
+        "publish" -> activation.publish.toJson,
+        "version" -> activation.version.toJson,
+        "response" -> activation.response.withoutResult.toExtendedJson,
+        "end" -> activation.end.toEpochMilli.toJson,
+        "message" -> expectedResult,
+        "kind" -> activation.annotations.get("kind").toJson.toJson,
+        "start" -> activation.start.toEpochMilli.toJson,
+        "limits" -> activation.annotations.get("limits").toJson.toJson,
+        "initTime" -> activation.annotations.get("initTime").toJson,
+        "namespace" -> activation.namespace.toJson)
+        ++ additionalFieldsForActivation: _*)
 
     expectedLogs ++ Seq(expectedActivation)
   }
@@ -214,6 +227,117 @@ class ArtifactWithFileStorageActivationStoreTests()
         .convertTo[JsArray] shouldBe activations
         .map(a => expectedFileContent(a, true))
         .flatten
+        .toJson
+        .convertTo[JsArray]
+    } finally {
+      activationStore.getLogFile.toFile.getAbsoluteFile.delete
+      logDir.delete
+    }
+  }
+
+  // Calling activationToFileExtended with includeResult=true/false is already covered by the
+  // previous tests since activationToFile calls activationToFileExtended, and the tests define
+  // writeResultToFile with true/false (indirectly via the variable 'config').
+  // So it remains to test the ability for setting different additional fields for logs and activation in activationToFileExtended.
+  it should "test activationToFileExtended: store activations in artifact store and in file without result, using different additional fields" in {
+
+    // used in ArtifactWithFileStorageActivationStoreExtended and for test data
+    val additionalFieldsForLogs = Map("field1" -> JsString("value1"))
+    val additionalFieldsForActivation = Map("field2" -> JsString("value2"))
+
+    // START -- example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
+
+    case class ArtifactWithFileStorageActivationStoreConfigExtendedTest(logFilePrefix: String,
+                                                                        logPath: String,
+                                                                        userIdField: String,
+                                                                        writeResultToFile: Boolean)
+
+    class ArtifactWithFileStorageActivationStoreExtendedTest(
+      actorSystem: ActorSystem,
+      actorMaterializer: ActorMaterializer,
+      logging: Logging,
+      config: ArtifactWithFileStorageActivationStoreConfigExtendedTest =
+        loadConfigOrThrow[ArtifactWithFileStorageActivationStoreConfigExtendedTest](
+          ConfigKeys.activationStoreWithFileStorage))
+        extends ArtifactActivationStore(actorSystem, actorMaterializer, logging) {
+
+      private val activationFileStorage =
+        new ActivationFileStorage(
+          config.logFilePrefix,
+          Paths.get(config.logPath),
+          config.writeResultToFile,
+          actorMaterializer,
+          logging)
+
+      def getLogFile = activationFileStorage.getLogFile
+
+      // the flag is already tested with the previous tests. Keep it simple for this test.
+      def shallResultBeIncluded: Boolean = false
+      // other simple usage example for the flag: (!activation.response.isSuccess)
+
+      override def store(activation: WhiskActivation, context: UserContext)(
+        implicit transid: TransactionId,
+        notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
+
+        val additionalFields = Map(config.userIdField -> context.user.namespace.uuid.toJson)
+
+        activationFileStorage.activationToFileExtended(
+          activation,
+          context,
+          additionalFields ++ additionalFieldsForLogs,
+          additionalFields ++ additionalFieldsForActivation,
+          shallResultBeIncluded)
+
+        super.store(activation, context)
+      }
+
+    }
+
+    // END -- example of a simple ArtifactActivationStore implementation that uses activationToFileExtended
+
+    // writeResultToFile=true should be overriden by this test
+    val config = ArtifactWithFileStorageActivationStoreConfigExtendedTest("userlogs", "logs", "namespaceId", true)
+
+    val activationStore = new ArtifactWithFileStorageActivationStoreExtendedTest(system, materializer, logging, config)
+    val logDir = new File(new File(".").getCanonicalPath, config.logPath)
+
+    try {
+      logDir.mkdir
+
+      val activations = responsePermutations.flatMap { response =>
+        logPermutations.map { logs =>
+          val activation = WhiskActivation(
+            namespace = EntityPath(subject.asString),
+            name = EntityName("name"),
+            subject = subject,
+            activationId = ActivationId.generate(),
+            start = Instant.now.inMills,
+            end = Instant.now.inMills,
+            response = response,
+            logs = logs,
+            duration = Some(101L),
+            annotations = Parameters("kind", "nodejs:6") ++ Parameters(
+              "limits",
+              ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
+              Parameters("waitTime", 16.toJson) ++
+              Parameters("initTime", 44.toJson))
+          val docInfo = await(activationStore.store(activation, context))
+          val fullyQualifiedActivationId = ActivationId(docInfo.id.asString)
+
+          await(activationStore.get(fullyQualifiedActivationId, context)) shouldBe activation
+          await(activationStore.delete(fullyQualifiedActivationId, context))
+          activation
+        }
+      }
+
+      Source
+        .fromFile(activationStore.getLogFile.toFile.getAbsoluteFile)
+        .getLines
+        .toList
+        .map(_.parseJson)
+        .toJson
+        .convertTo[JsArray] shouldBe activations
+        .flatMap(a => expectedFileContent(a, false, additionalFieldsForLogs.toSeq, additionalFieldsForActivation.toSeq))
         .toJson
         .convertTo[JsArray]
     } finally {


### PR DESCRIPTION
Add the possibility to decide whether results should be included in the action log on a per-call basis for each activation individually.

## Description
Action results may contain sensible data that should not be logged. There is a system configuration flag (`writeResultToFile`) that can be used to switch on or off the result inclusion in logs. But this is a global switch that holds for all activations. In our case we want to able to decide per activation whether or not the result should be included in the log. In our special case we want results to be included in case of errors (in other words, 'Does the result contain an error field?'). But also other decision logic may be applicable. 

## My changes affect the following components
- Controller (for sequences)
- Invoker

## Types of changes
Small, low risk change: add one optional, boolean parameter to the method `activationToFileExtended` of `org.apache.openwhisk.core.database.ActivationFileStorage` that determines the decision whether or not the result of the current activation should be included in the log. The default value of the new parameter is the value of the system configuration flag `writeResultToFile`. The method `activationToFile` is unchanged and works as before. The private method `transcribeActivation` now takes the flag from `activationToFileExtended`. 

