### PR TITLE
Update k8s client to 4.4.0 from 4.0.3

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile ('com.fasterxml.uuid:java-uuid-generator:3.1.3')
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'io.fabric8:kubernetes-client:4.4.0'
+    compile 'io.fabric8:kubernetes-client:4.4.2'
     compile ('io.kamon:kamon-core_2.12:1.1.3') {
         exclude group: 'com.lihaoyi'
     }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile ('com.fasterxml.uuid:java-uuid-generator:3.1.3')
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'io.fabric8:kubernetes-client:4.0.3'
+    compile 'io.fabric8:kubernetes-client:4.4.0'
     compile ('io.kamon:kamon-core_2.12:1.1.3') {
         exclude group: 'com.lihaoyi'
     }


### PR DESCRIPTION
Updates `io.fabric8:kubernetes-client` to 4.4.0 from 4.0.3. 

## Description

Current fabric8 k8s client version is 4.0.3 which does not support newer version of k8s (see [compatability matrix](https://github.com/fabric8io/kubernetes-client#compatibility-matrix). Updating it to 4.4.0 would enable support for newer version.

Note that with this change old version <= 1.7.0 would not work and min supported k8s version per matrix would be 1.9.0

