### PR TITLE
Add asf.yaml to configure github metadata

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+github:
+  description: "Apache OpenWhisk is an open source serverless cloud platform"
+  homepage: https://openwhisk.apache.org/
+  labels:
+    - openwhisk
+    - apache
+    - serverless
+    - cloud
+    - FaaS


### PR DESCRIPTION
Experiment with new ASF feature of using a per-repo yaml
file to configure github metadata for a project.

See https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories for what is supported.   

I suggest we experiment in the main repo to verify it works and get to a core set of tags.  Then we can replicate across all the repos & add additional per-repo tags as well