### PR TITLE
fix indent on labels in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,8 +19,8 @@ github:
   description: "Apache OpenWhisk is an open source serverless cloud platform"
   homepage: https://openwhisk.apache.org/
   labels:
-    - openwhisk
-    - apache
-    - serverless
-    - cloud
-    - FaaS
+  - openwhisk
+  - apache
+  - serverless
+  - cloud
+  - FaaS


### PR DESCRIPTION
See if this works; looks like the example yaml on cwiki
had the wrong indentation level for the labels...

