### PR TITLE
Add namespace field to activation log

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -131,7 +131,8 @@ class DockerToActivationFileLogStore(system: ActorSystem, destinationDirectory: 
 
     val additionalMetadata = Map(
       "activationId" -> activation.activationId.asString.toJson,
-      "action" -> action.fullyQualifiedName(false).asString.toJson) ++ userIdField
+      "action" -> action.fullyQualifiedName(false).asString.toJson,
+      "namespace" -> user.namespace.name.asString.toJson) ++ userIdField
 
     val augmentedActivation = JsObject(activation.toJson.fields ++ userIdField)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -84,9 +84,11 @@ class ActivationFileStorage(logFilePrefix: String,
 
   private def transcribeLogs(activation: WhiskActivation, additionalFields: Map[String, JsValue]) =
     activation.logs.logs.map { log =>
-      val line = JsObject(
-        Map("type" -> "user_log".toJson) ++ Map("message" -> log.toJson) ++ Map(
-          "activationId" -> activation.activationId.toJson) ++ additionalFields)
+      val line =
+        JsObject(
+          Map("type" -> "user_log".toJson) ++ Map("message" -> log.toJson) ++ Map(
+            "activationId" -> activation.activationId.toJson) ++ Map(
+            "namespace" -> activation.namespace.asString.toJson) ++ additionalFields)
 
       ByteString(s"${line.compactPrint}\n")
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -87,8 +87,7 @@ class ActivationFileStorage(logFilePrefix: String,
       val line =
         JsObject(
           Map("type" -> "user_log".toJson) ++ Map("message" -> log.toJson) ++ Map(
-            "activationId" -> activation.activationId.toJson) ++ Map(
-            "namespace" -> activation.namespace.asString.toJson) ++ additionalFields)
+            "activationId" -> activation.activationId.toJson) ++ additionalFields)
 
       ByteString(s"${line.compactPrint}\n")
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -84,10 +84,9 @@ class ActivationFileStorage(logFilePrefix: String,
 
   private def transcribeLogs(activation: WhiskActivation, additionalFields: Map[String, JsValue]) =
     activation.logs.logs.map { log =>
-      val line =
-        JsObject(
-          Map("type" -> "user_log".toJson) ++ Map("message" -> log.toJson) ++ Map(
-            "activationId" -> activation.activationId.toJson) ++ additionalFields)
+      val line = JsObject(
+        Map("type" -> "user_log".toJson) ++ Map("message" -> log.toJson) ++ Map(
+          "activationId" -> activation.activationId.toJson) ++ additionalFields)
 
       ByteString(s"${line.compactPrint}\n")
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
@@ -55,9 +55,10 @@ class ArtifactWithFileStorageActivationStore(
   override def store(activation: WhiskActivation, context: UserContext)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
-    val additionalFields = Map(config.userIdField -> context.user.namespace.uuid.toJson)
+    val additionalFieldsForLogs = Map(config.userIdField -> context.user.namespace.uuid.toJson, "namespace" -> context.user.namespace.name.toJson)
+    val additionalFieldsForActivation = Map(config.userIdField -> context.user.namespace.uuid.toJson)
 
-    activationFileStorage.activationToFile(activation, context, additionalFields)
+    activationFileStorage.activationToFileExtended(activation, context, additionalFieldsForLogs, additionalFieldsForActivation)
     super.store(activation, context)
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
@@ -55,10 +55,15 @@ class ArtifactWithFileStorageActivationStore(
   override def store(activation: WhiskActivation, context: UserContext)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
-    val additionalFieldsForLogs = Map(config.userIdField -> context.user.namespace.uuid.toJson, "namespace" -> context.user.namespace.name.toJson)
+    val additionalFieldsForLogs =
+      Map(config.userIdField -> context.user.namespace.uuid.toJson, "namespace" -> context.user.namespace.name.toJson)
     val additionalFieldsForActivation = Map(config.userIdField -> context.user.namespace.uuid.toJson)
 
-    activationFileStorage.activationToFileExtended(activation, context, additionalFieldsForLogs, additionalFieldsForActivation)
+    activationFileStorage.activationToFileExtended(
+      activation,
+      context,
+      additionalFieldsForLogs,
+      additionalFieldsForActivation)
     super.store(activation, context)
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
@@ -47,12 +47,12 @@ class DockerToActivationFileLogStoreTests
   override def createStore() = new TestLogStoreTo(Sink.ignore)
 
   def toLoggedEvent(line: LogLine,
-                    userId: UUID,
+                    namespace: Namespace,
                     activationId: ActivationId,
                     actionName: FullyQualifiedEntityName): String = {
     val event = line.toJson.compactPrint
     val concatenated =
-      s""","activationId":"${activationId.asString}","action":"${actionName.asString}","namespaceId":"${userId.asString}""""
+      s""","activationId":"${activationId.asString}","action":"${actionName.asString}","namespace":"${namespace.name.asString}","namespaceId":"${namespace.uuid.asString}""""
 
     event.dropRight(1) ++ concatenated ++ "}\n"
   }
@@ -78,7 +78,7 @@ class DockerToActivationFileLogStoreTests
     await(collected) shouldBe ActivationLogs(logs.map(_.toFormattedString).toVector)
     logs.foreach { line =>
       testActor.expectMsg(
-        toLoggedEvent(line, user.namespace.uuid, successfulActivation.activationId, action.fullyQualifiedName(false)))
+        toLoggedEvent(line, user.namespace, successfulActivation.activationId, action.fullyQualifiedName(false)))
     }
 
     // Last message should be the full activation
@@ -111,11 +111,7 @@ class DockerToActivationFileLogStoreTests
     withClue("Provided logs should be received by log store:") {
       logs.foreach { line =>
         testActor.expectMsg(
-          toLoggedEvent(
-            line,
-            user.namespace.uuid,
-            developerErrorActivation.activationId,
-            action.fullyQualifiedName(false)))
+          toLoggedEvent(line, user.namespace, developerErrorActivation.activationId, action.fullyQualifiedName(false)))
       }
     }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -99,9 +99,9 @@ class ArtifactWithFileStorageActivationStoreTests()
             "type" -> "user_log".toJson,
             "message" -> log.toJson,
             "activationId" -> activation.activationId.toJson,
+            "namespace" -> activation.namespace.asString.toJson,
             "namespaceId" -> user.namespace.uuid.toJson)
             ++ additionalFieldsForLogs: _*)
-
       }
     }
     val expectedResult = if (includeResult) {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -59,7 +59,7 @@ class ArtifactWithFileStorageActivationStoreTests()
   private val uuid = UUID()
   private val subject = Subject()
   private val user =
-    Identity(subject, Namespace(EntityName("testSpace"), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
+    Identity(subject, Namespace(EntityName(subject.asString), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
   private val context = UserContext(user, HttpRequest())
 
   override def afterAll(): Unit = {
@@ -282,7 +282,7 @@ class ArtifactWithFileStorageActivationStoreTests()
           activationFileStorage.activationToFileExtended(
             activation,
             context,
-            additionalFields ++ additionalFieldsForLogs,
+            additionalFields ++ additionalFieldsForLogs ++ Map("namespace" -> JsString(subject.asString)),
             additionalFields ++ additionalFieldsForActivation,
             shallResultBeIncluded)
 


### PR DESCRIPTION
Add **namespace** field to activation log while using `DockerToActivationFileLogStore`
 
## Description
Currently there is no **namespace** field  but a **namespaceId** in the activation log while save activation logs to a separate file, while I think add **namesapce** will be more convenient for users when they process the log file, such as using Logstash to send logs to different indices(e.g. `openwhisk-%{namespace}`) in ElasticSearch

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

