### PR TITLE
Combines active ack and slot release when both are available.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -231,19 +231,16 @@ object AcknowledegmentMessage extends DefaultJsonProtocol {
     // If this field is part of the JSON, we try to deserialize into one of these two types,
     // and otherwise to a ResultMessage. If all conversions fail, an error will be thrown that needs to be handled.
     override def read(json: JsValue): AcknowledegmentMessage = {
-      val obj = json.asJsObject
-
-      obj
-        .getFields("invoker")
-        .headOption
-        .map(_ => {
-          obj
-            .getFields("response")
-            .headOption
-            .map(_ => json.convertTo[CombinedCompletionAndResultMessage])
-            .getOrElse(json.convertTo[CompletionMessage])
-        })
-        .getOrElse(json.convertTo[ResultMessage])
+      val JsObject(fields) = json
+      val completion = fields.contains("invoker")
+      val result = fields.contains("response")
+      if (completion && result) {
+        json.convertTo[CombinedCompletionAndResultMessage]
+      } else if (completion) {
+        json.convertTo[CompletionMessage]
+      } else {
+        json.convertTo[ResultMessage]
+      }
     }
   }
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -187,7 +187,7 @@ trait EventMessageBody extends Message {
 
 object EventMessageBody extends DefaultJsonProtocol {
 
-  implicit def format = new JsonFormat[EventMessageBody] {
+  implicit val format = new JsonFormat[EventMessageBody] {
     def write(eventMessageBody: EventMessageBody) = eventMessageBody match {
       case m: Metric     => m.toJson
       case a: Activation => a.toJson

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -242,7 +242,7 @@ object Exec extends ArgNormalizer[Exec] with DefaultJsonProtocol {
   protected[core] val SEQUENCE = "sequence"
   protected[core] val BLACKBOX = "blackbox"
 
-  // This is for error cases while cannot get the `kind` of Exec
+  // This is for error cases where the action `kind` may not be known.
   protected[core] val UNKNOWN = "unknown"
 
   private def execManifests = ExecManifest.runtimesManifest

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -18,11 +18,13 @@
 package org.apache.openwhisk.core.containerpool
 
 import java.time.Instant
+
 import akka.actor.Status.{Failure => FailureMessage}
 import akka.actor.{FSM, Props, Stash}
 import akka.event.Logging.InfoLevel
 import akka.pattern.pipe
 import pureconfig.loadConfigOrThrow
+
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -36,6 +38,7 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.invoker.InvokerReactive.ActiveAck
 import org.apache.openwhisk.http.Messages
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -31,7 +31,6 @@ import spray.json._
 import org.apache.openwhisk.common.{AkkaLogging, Counter, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.connector.{
-  AcknowledegmentMessage,
   ActivationMessage,
   CombinedCompletionAndResultMessage,
   CompletionMessage,
@@ -715,7 +714,7 @@ object ContainerProxy {
               ByteSize,
               Int,
               Option[ExecutableWhiskAction]) => Future[Container],
-    ack: (TransactionId, WhiskActivation, Boolean, ControllerInstanceId, UUID, AcknowledegmentMessage) => Future[Any],
+    ack: ActiveAck,
     store: (TransactionId, WhiskActivation, UserContext) => Future[Any],
     collectLogs: (TransactionId, Identity, WhiskActivation, Container, ExecutableWhiskAction) => Future[ActivationLogs],
     instance: InvokerInstanceId,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -164,13 +164,15 @@ class InvokerReactive(
 
     // UserMetrics are sent, when the slot is free again. This ensures, that all metrics are sent.
     if (UserEvents.enabled && acknowledegment.isSlotFree.nonEmpty) {
-      acknowledegment.result.foreach {
-        case Right(activationResult) =>
+      acknowledegment.result match {
+        case Some(Right(activationResult: WhiskActivation)) =>
           EventMessage.from(activationResult, s"invoker${instance.instance}", userId) match {
             case Success(msg) => UserEvents.send(producer, msg)
             case Failure(t)   => logging.error(this, s"activation event was not sent: $t")
           }
-        case _ => // all acknowledegment messages should have a result
+        case _ =>
+          // all acknowledegment messages should have a result
+          logging.error(this, s"activation event was not sent because the result is missing")
       }
     }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -164,9 +164,13 @@ class InvokerReactive(
 
     // UserMetrics are sent, when the slot is free again. This ensures, that all metrics are sent.
     if (UserEvents.enabled && acknowledegment.isSlotFree.nonEmpty) {
-      EventMessage.from(activationResult, s"invoker${instance.instance}", userId) match {
-        case Success(msg) => UserEvents.send(producer, msg)
-        case Failure(t)   => logging.error(this, s"activation event was not sent: $t")
+      acknowledegment.result.foreach {
+        case Right(activationResult) =>
+          EventMessage.from(activationResult, s"invoker${instance.instance}", userId) match {
+            case Success(msg) => UserEvents.send(producer, msg)
+            case Failure(t)   => logging.error(this, s"activation event was not sent: $t")
+          }
+        case _ => // all acknowledegment messages should have a result
       }
     }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -157,7 +157,7 @@ class InvokerReactive(
     def send(msg: AcknowledegmentMessage, recovery: Boolean = false) = {
       producer.send(topic = "completed" + controllerInstance.asString, msg).andThen {
         case Success(_) =>
-          val info = if (recovery) s"recovery ${msg.name}" else msg.name
+          val info = if (recovery) s"recovery ${msg.messageType}" else msg.messageType
           logging.info(this, s"posted $info of activation ${activationResult.activationId}")
       }
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
@@ -55,20 +55,18 @@ class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInsta
   }
 
   it should "serialize a right result message" in {
-    val m =
-      ResultMessage(TransactionId.testing, Right(activation))
+    val m = ResultMessage(TransactionId.testing, Right(activation))
     m.serialize shouldBe JsObject("transid" -> m.transid.toJson, "response" -> m.response.right.get.toJson).compactPrint
   }
 
   it should "deserialize a left result message" in {
     val m = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
-    ResultMessage.parse(m.serialize) shouldBe Success(m)
+    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
   }
 
   it should "deserialize a right result message" in {
-    val m =
-      ResultMessage(TransactionId.testing, Right(activation))
-    ResultMessage.parse(m.serialize) shouldBe Success(m)
+    val m = ResultMessage(TransactionId.testing, Right(activation))
+    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
   }
 
   behavior of "acknowledgement message"
@@ -76,32 +74,46 @@ class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInsta
   it should "serialize a Completion message" in {
     val c = CompletionMessage(
       TransactionId.testing,
-      ActivationId.generate(),
+      Left(ActivationId.generate()),
       false,
       InvokerInstanceId(0, userMemory = defaultUserMemory))
-    val m: AcknowledegmentMessage = c
-    m.serialize shouldBe c.toJson.compactPrint
+    c.serialize shouldBe c.toJson.compactPrint
+  }
+
+  it should "serialize a Completion message with result" in {
+    val c = CompletionMessage(
+      TransactionId.testing,
+      Right(activation),
+      true,
+      InvokerInstanceId(0, userMemory = defaultUserMemory))
+    c.serialize shouldBe c.toJson.compactPrint
   }
 
   it should "serialize a Result message" in {
     val r = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
-    val m: AcknowledegmentMessage = r
-    m.serialize shouldBe r.toJson.compactPrint
+    r.serialize shouldBe r.toJson.compactPrint
   }
 
   it should "deserialize a Completion message" in {
     val c = CompletionMessage(
       TransactionId.testing,
-      ActivationId.generate(),
+      Left(ActivationId.generate()),
       false,
       InvokerInstanceId(0, userMemory = defaultUserMemory))
-    val m: AcknowledegmentMessage = c
-    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(c)
+    AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
+  }
+
+  it should "deserialize a Completion message with result" in {
+    val c = CompletionMessage(
+      TransactionId.testing,
+      Right(activation),
+      true,
+      InvokerInstanceId(0, userMemory = defaultUserMemory))
+    AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
   }
 
   it should "deserialize a Result message" in {
     val r = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
-    val m: AcknowledegmentMessage = r
-    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(r)
+    AcknowledegmentMessage.parse(r.serialize) shouldBe Success(r)
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/tests/AcknowledgementMessageTests.scala
@@ -40,7 +40,7 @@ import scala.util.Success
 @RunWith(classOf[JUnitRunner])
 class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInstants {
 
-  behavior of "result message"
+  behavior of "acknowledgement message"
 
   val defaultUserMemory: ByteSize = 1024.MB
   val activation = WhiskActivation(
@@ -54,70 +54,45 @@ class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInsta
     annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson),
     duration = Some(123))
 
-  it should "serialize a left result message" in {
-    val m = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
+  it should "serialize and deserialize a Result message with Left result" in {
+    val m = ResultMessage(TransactionId.testing, activation).shrink
+    m.response shouldBe 'left
+    m.isSlotFree shouldBe empty
     m.serialize shouldBe JsObject("transid" -> m.transid.toJson, "response" -> m.response.left.get.toJson).compactPrint
+    m.serialize shouldBe m.toJson.compactPrint
+    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
   }
 
-  it should "serialize a right result message" in {
-    val m = ResultMessage(TransactionId.testing, Right(activation))
+  it should "serialize and deserialize a Result message with Right result" in {
+    val m = ResultMessage(TransactionId.testing, activation)
+    m.response shouldBe 'right
+    m.isSlotFree shouldBe empty
     m.serialize shouldBe JsObject("transid" -> m.transid.toJson, "response" -> m.response.right.get.toJson).compactPrint
-  }
-
-  it should "deserialize a left result message" in {
-    val m = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
     AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
   }
 
-  it should "deserialize a right result message" in {
-    val m = ResultMessage(TransactionId.testing, Right(activation))
-    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
-  }
-
-  behavior of "acknowledgement message"
-
-  it should "serialize a Completion message" in {
-    val c = CompletionMessage(
+  it should "serialize and deserialize a Completion message" in {
+    val m = CompletionMessage(
       TransactionId.testing,
       ActivationId.generate(),
       Some(false),
       InvokerInstanceId(0, userMemory = defaultUserMemory))
-    c.isSlotFree should not be empty
-    c.serialize shouldBe c.toJson.compactPrint
+    m.isSlotFree should not be empty
+    m.serialize shouldBe m.toJson.compactPrint
+    AcknowledegmentMessage.parse(m.serialize) shouldBe Success(m)
   }
 
-  it should "deserialize a Completion message" in {
-    val c = CompletionMessage(
-      TransactionId.testing,
-      ActivationId.generate(),
-      Some(false),
-      InvokerInstanceId(0, userMemory = defaultUserMemory))
-    AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
-  }
-
-  it should "serialize a Result message" in {
-    val r = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
-    r.isSlotFree shouldBe empty
-    r.serialize shouldBe r.toJson.compactPrint
-  }
-
-  it should "deserialize a Result message" in {
-    val r = ResultMessage(TransactionId.testing, Left(ActivationId.generate()))
-    AcknowledegmentMessage.parse(r.serialize) shouldBe Success(r)
-  }
-
-  it should "serialize and deserialize a combined completion and result message" in {
+  it should "serialize and deserialize a CombinedCompletionAndResultMessage" in {
     withClue("system error false and right") {
       val c = CombinedCompletionAndResultMessage(
         TransactionId.testing,
         activation,
         InvokerInstanceId(0, userMemory = defaultUserMemory))
-
+      c.response shouldBe 'right
       c.isSlotFree should not be empty
+      c.isSystemError shouldBe Some(false)
       c.serialize shouldBe c.toJson.compactPrint
-      AcknowledegmentMessage.parse(c.serialize) shouldBe Success {
-        CombinedCompletionAndResultMessage(TransactionId.testing, Right(activation), Some(false), c.invoker)
-      }
+      AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
     }
 
     withClue("system error true and right") {
@@ -127,34 +102,35 @@ class AcknowledgementMessageTests extends FlatSpec with Matchers with WhiskInsta
         TransactionId.testing,
         someActivation,
         InvokerInstanceId(0, userMemory = defaultUserMemory))
-
+      c.response shouldBe 'right
       c.isSlotFree should not be empty
+      c.isSystemError shouldBe Some(true)
       c.serialize shouldBe c.toJson.compactPrint
-      AcknowledegmentMessage.parse(c.serialize) shouldBe Success {
-        CombinedCompletionAndResultMessage(TransactionId.testing, Right(someActivation), Some(true), c.invoker)
-      }
+      AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
     }
 
     withClue("system error false and left") {
       val c = CombinedCompletionAndResultMessage(
         TransactionId.testing,
-        Left(activation.activationId),
-        Some(false),
-        InvokerInstanceId(0, userMemory = defaultUserMemory))
-
+        activation,
+        InvokerInstanceId(0, userMemory = defaultUserMemory)).shrink
+      c.response shouldBe 'left
       c.isSlotFree should not be empty
+      c.isSystemError shouldBe Some(false)
       c.serialize shouldBe c.toJson.compactPrint
       AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
     }
 
     withClue("system error true and left") {
+      val response = ActivationResponse.whiskError(JsString("error"))
+      val someActivation = activation.copy(response = response)
       val c = CombinedCompletionAndResultMessage(
         TransactionId.testing,
-        Left(activation.activationId),
-        Some(true),
-        InvokerInstanceId(0, userMemory = defaultUserMemory))
-
+        someActivation,
+        InvokerInstanceId(0, userMemory = defaultUserMemory)).shrink
+      c.response shouldBe 'left
       c.isSlotFree should not be empty
+      c.isSystemError shouldBe Some(true)
       c.serialize shouldBe c.toJson.compactPrint
       AcknowledegmentMessage.parse(c.serialize) shouldBe Success(c)
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -18,6 +18,7 @@
 package org.apache.openwhisk.core.containerpool.test
 
 import java.time.Instant
+
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor.{ActorRef, ActorSystem, FSM}
 import akka.stream.scaladsl.Source
@@ -26,13 +27,14 @@ import akka.util.ByteString
 import common.{LoggedFunction, StreamLogging, SynchronizedLoggedFunction, WhiskProperties}
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicInteger
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
-import org.apache.openwhisk.core.connector.ActivationMessage
+import org.apache.openwhisk.core.connector.{AcknowledegmentMessage, ActivationMessage}
 import org.apache.openwhisk.core.containerpool.WarmingData
 import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.containerpool.logging.LogCollectingException
@@ -41,6 +43,7 @@ import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.database.UserContext
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
@@ -161,7 +164,12 @@ class ContainerProxyTests
 
   /** Creates an inspectable version of the ack method, which records all calls in a buffer */
   def createAcker(a: ExecutableWhiskAction = action) = LoggedFunction {
-    (_: TransactionId, activation: WhiskActivation, _: Boolean, _: ControllerInstanceId, _: UUID, _: Boolean) =>
+    (_: TransactionId,
+     activation: WhiskActivation,
+     _: Boolean,
+     _: ControllerInstanceId,
+     _: UUID,
+     _: AcknowledegmentMessage) =>
       activation.annotations.get("limits") shouldBe Some(a.limits.toJson)
       activation.annotations.get("path") shouldBe Some(a.fullyQualifiedName(false).toString.toJson)
       activation.annotations.get("kind") shouldBe Some(a.exec.kind.toJson)
@@ -170,7 +178,12 @@ class ContainerProxyTests
 
   /** Creates an synchronized inspectable version of the ack method, which records all calls in a buffer */
   def createSyncAcker(a: ExecutableWhiskAction = action) = SynchronizedLoggedFunction {
-    (_: TransactionId, activation: WhiskActivation, _: Boolean, _: ControllerInstanceId, _: UUID, _: Boolean) =>
+    (_: TransactionId,
+     activation: WhiskActivation,
+     _: Boolean,
+     _: ControllerInstanceId,
+     _: UUID,
+     _: AcknowledegmentMessage) =>
       activation.annotations.get("limits") shouldBe Some(a.limits.toJson)
       activation.annotations.get("path") shouldBe Some(a.fullyQualifiedName(false).toString.toJson)
       activation.annotations.get("kind") shouldBe Some(a.exec.kind.toJson)

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -565,8 +565,8 @@ class ShardingContainerPoolBalancerTests
 
   def completeActivation(invoker: InvokerInstanceId, balancer: ShardingContainerPoolBalancer, aid: ActivationId) = {
     //complete activation
-    val ack = CompletionMessage(TransactionId.testing, Left(aid), false, invoker).serialize
-      .getBytes(StandardCharsets.UTF_8)
+    val ack =
+      CompletionMessage(TransactionId.testing, aid, Some(false), invoker).serialize.getBytes(StandardCharsets.UTF_8)
     balancer.processAcknowledgement(ack)
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -565,7 +565,7 @@ class ShardingContainerPoolBalancerTests
 
   def completeActivation(invoker: InvokerInstanceId, balancer: ShardingContainerPoolBalancer, aid: ActivationId) = {
     //complete activation
-    val ack = CompletionMessage(TransactionId.testing, aid, false, invoker).serialize
+    val ack = CompletionMessage(TransactionId.testing, Left(aid), false, invoker).serialize
       .getBytes(StandardCharsets.UTF_8)
     balancer.processAcknowledgement(ack)
   }


### PR DESCRIPTION
Combines active ack and slot release when both are available. If completion message carries a result, process the active ack.

There are two commits in this patch. The first is semantic preserving/refactoring. The fix is in the second commit.

Closes #4614.
Closes #4636.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4614, #4636)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

