### PR TITLE
Embedded Kafka support in OpenWhisk Standalone mode

### DIFF
--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -75,21 +75,36 @@ $ java -jar openwhisk-standalone.jar -h
  \   \  /  \/    \___/| .__/ \___|_| |_|__/\__|_| |_|_|___/_|\_\
   \___\/ tm           |_|
 
-      --api-gw                  Enable API Gateway support
-      --api-gw-port  <arg>      Api Gateway Port
-      --clean                   Clean any existing state like database
-  -c, --config-file  <arg>      application.conf which overrides the default
-                                standalone.conf
-      --couchdb                 Enable CouchDB support
-  -d, --data-dir  <arg>         Directory used for storage
-      --disable-color-logging   Disables colored logging
-  -m, --manifest  <arg>         Manifest json defining the supported runtimes
-  -p, --port  <arg>             Server port
+      --api-gw                     Enable API Gateway support
+      --api-gw-port  <arg>         Api Gateway Port
+      --clean                      Clean any existing state like database
+  -c, --config-file  <arg>         application.conf which overrides the default
+                                   standalone.conf
+      --couchdb                    Enable CouchDB support
+  -d, --data-dir  <arg>            Directory used for storage
+      --dev-mode                   Developer mode speeds up the startup by
+                                   disabling preflight checks and avoiding
+                                   explicit pulls.
+      --disable-color-logging      Disables colored logging
+      --kafka                      Enable embedded Kafka support
+      --kafka-docker-port  <arg>   Kafka port for use by docker based services.
+                                   If not specified then 9091 or some random
+                                   free port (if 9091 is busy) would be used
+      --kafka-port  <arg>          Kafka port. If not specified then 9092 or
+                                   some random free port (if 9092 is busy) would
+                                   be used
+      --kafka-ui                   Enable Kafka UI
+  -m, --manifest  <arg>            Manifest json defining the supported runtimes
+  -p, --port  <arg>                Server port
   -v, --verbose
-  -h, --help                    Show help message
-      --version                 Show version of this program
+      --zk-port  <arg>             Zookeeper port. If not specified then 2181 or
+                                   some random free port (if 2181 is busy) would
+                                   be used
+  -h, --help                       Show help message
+      --version                    Show version of this program
 
 OpenWhisk standalone server
+
 
 ```
 
@@ -204,7 +219,25 @@ Api Gateway mode can be enabled via `--api-gw` flag. In this mode upon launch a 
 would be launched on port `3234` (can be changed with `--api-gw-port`). In this mode you can make use of the
 [api gateway][4] support.
 
+#### Using Kafka
+
+Standalone OpenWhisk supports launching an [embedded kafka][5]. This mode is mostly useful for developers working on OpenWhisk
+implementation itself.
+
+```
+java -jar openwhisk-standalone.jar --kafka
+```
+
+It also supports launching a Kafka UI based on [Kafdrop 3][6] which enables seeing the topics created and structure of messages
+exchanged on those topics.
+
+```
+java -jar openwhisk-standalone.jar --kafka --kafka-ui
+```
+
 [1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md
 [2]: https://github.com/apache/incubator-openwhisk/blob/master/docs/samples.md
 [3]: https://github.com/apache/incubator-openwhisk-apigateway
 [4]: https://github.com/apache/incubator-openwhisk/blob/master/docs/apigateway.md
+[5]: https://github.com/embeddedkafka/embedded-kafka
+[6]: https://github.com/obsidiandynamics/kafdrop

--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -235,6 +235,16 @@ exchanged on those topics.
 java -jar openwhisk-standalone.jar --kafka --kafka-ui
 ```
 
+By default the ui server would be accessible at http://localhost:9000. In case 9000 port is busy then a random port would
+be selected. TO find out the port look for message in log like below (or grep for `whisk-kafka-drop-ui`)
+
+```
+[ 9092  ] localhost:9092 (kafka)
+[ 9092  ] 192.168.65.2:9091 (kafka-docker)
+[ 2181  ] Zookeeper (zookeeper)
+[ 9000  ] http://localhost:9000 (whisk-kafka-drop-ui)
+```
+
 [1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md
 [2]: https://github.com/apache/incubator-openwhisk/blob/master/docs/samples.md
 [3]: https://github.com/apache/incubator-openwhisk-apigateway

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -131,6 +131,11 @@ dependencies {
     compile project(':tools:admin')
     compile 'org.rogach:scallop_2.12:3.3.1'
 
+    //Tried with 0.16.0 has support for Kafka 0.11.0 https://github.com/embeddedkafka/embedded-kafka/tree/v0.16.0
+    //But that causes class compatability issue die to use of newer client version
+    compile ("io.github.embeddedkafka:embedded-kafka_2.12:2.1.1")
+    compile ("org.scala-lang:scala-reflect:${gradle.scala.version}")
+
     testCompile 'junit:junit:4.11'
     testCompile 'org.scalatest:scalatest_2.12:3.0.5'
 }

--- a/core/standalone/src/main/resources/logback-standalone.xml
+++ b/core/standalone/src/main/resources/logback-standalone.xml
@@ -29,6 +29,8 @@
 
     <!-- Kafka -->
     <logger name="org.apache.kafka" level="ERROR" />
+    <logger name="org.apache.zookeeper" level="ERROR" />
+    <logger name="kafka.server" level="ERROR" />
 
     <root level="${logback.log.level:-INFO}">
         <appender-ref ref="console" />

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -58,6 +58,8 @@ class KafkaLauncher(docker: StandaloneDockerClient,
     //Below setting based on https://rmoff.net/2018/08/02/kafka-listeners-explained/
     // We configure two listeners where one is used for host based application and other is used for docker based application
     // to connect to Kafka server running on host
+    // Here controller / invoker will use LISTENER_LOCAL since they run in the same JVM as the embedded Kafka
+    // and Kafka UI will run in a Docker container and use LISTENER_DOCKER
     val brokerProps = Map(
       KafkaConfig.ListenersProp -> s"LISTENER_LOCAL://localhost:$kafkaPort,LISTENER_DOCKER://localhost:$kafkaDockerPort",
       KafkaConfig.AdvertisedListenersProp -> s"LISTENER_LOCAL://localhost:$kafkaPort,LISTENER_DOCKER://${StandaloneDockerSupport

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.standalone
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.commons.io.FileUtils
+import org.apache.openwhisk.common.{Logging, TransactionId}
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.WhiskConfig.kafkaHosts
+import org.apache.openwhisk.core.entity.ControllerInstanceId
+import org.apache.openwhisk.core.loadBalancer.{LeanBalancer, LoadBalancer, LoadBalancerProvider}
+import org.apache.openwhisk.standalone.StandaloneDockerSupport.checkOrAllocatePort
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.io.Directory
+import scala.util.Try
+
+class KafkaLauncher(docker: StandaloneDockerClient, kafkaPort: Int, workDir: File)(implicit logging: Logging,
+                                                                                   ec: ExecutionContext,
+                                                                                   actorSystem: ActorSystem,
+                                                                                   materializer: ActorMaterializer,
+                                                                                   tid: TransactionId) {
+
+  def run(): Future[Seq[ServiceContainer]] = {
+    for {
+      kafkaSvcs <- runKafka()
+    } yield kafkaSvcs
+  }
+
+  def runKafka(): Future[Seq[ServiceContainer]] = {
+    val zkPort = checkOrAllocatePort(2181)
+    implicit val config: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = zkPort)
+
+    val t = Try {
+      EmbeddedKafka.startZooKeeper(createDir("zookeeper"))
+      EmbeddedKafka.startKafka(createDir("kafka"))
+    }
+
+    Future
+      .fromTry(t)
+      .map(
+        _ =>
+          Seq(
+            ServiceContainer(kafkaPort, s"localhost:$kafkaPort", "kafka"),
+            ServiceContainer(zkPort, "Zookeeper", "zookeeper")))
+  }
+
+  private def createDir(name: String) = {
+    val dir = new File(workDir, name)
+    FileUtils.forceMkdir(dir)
+    Directory(dir)
+  }
+}
+
+object KafkaAwareLeanBalancer extends LoadBalancerProvider {
+  override def requiredProperties: Map[String, String] = LeanBalancer.requiredProperties ++ kafkaHosts
+
+  override def instance(whiskConfig: WhiskConfig, instance: ControllerInstanceId)(
+    implicit actorSystem: ActorSystem,
+    logging: Logging,
+    materializer: ActorMaterializer): LoadBalancer = LeanBalancer.instance(whiskConfig, instance)
+}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -120,3 +120,9 @@ object KafkaAwareLeanBalancer extends LoadBalancerProvider {
     logging: Logging,
     materializer: ActorMaterializer): LoadBalancer = LeanBalancer.instance(whiskConfig, instance)
 }
+
+object KafkaLauncher {
+  val preferredKafkaPort = 9092
+  val preferredKafkaDockerPort = preferredKafkaPort - 1
+  val preferredZkPort = 2181
+}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/KafkaLauncher.scala
@@ -35,14 +35,16 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.io.Directory
 import scala.util.Try
 
-class KafkaLauncher(docker: StandaloneDockerClient, kafkaPort: Int, workDir: File, kafkaUi: Boolean)(
-  implicit logging: Logging,
-  ec: ExecutionContext,
-  actorSystem: ActorSystem,
-  materializer: ActorMaterializer,
-  tid: TransactionId) {
-  private val kafkaDockerPort = checkOrAllocatePort(kafkaPort - 1)
-  private val zkPort = checkOrAllocatePort(2181)
+class KafkaLauncher(docker: StandaloneDockerClient,
+                    kafkaPort: Int,
+                    kafkaDockerPort: Int,
+                    zkPort: Int,
+                    workDir: File,
+                    kafkaUi: Boolean)(implicit logging: Logging,
+                                      ec: ExecutionContext,
+                                      actorSystem: ActorSystem,
+                                      materializer: ActorMaterializer,
+                                      tid: TransactionId) {
 
   def run(): Future[Seq[ServiceContainer]] = {
     for {
@@ -77,7 +79,7 @@ class KafkaLauncher(docker: StandaloneDockerClient, kafkaPort: Int, workDir: Fil
           Seq(
             ServiceContainer(kafkaPort, s"localhost:$kafkaPort", "kafka"),
             ServiceContainer(
-              kafkaPort,
+              kafkaDockerPort,
               s"${StandaloneDockerSupport.getLocalHostIp()}:$kafkaDockerPort",
               "kafka-docker"),
             ServiceContainer(zkPort, "Zookeeper", "zookeeper")))

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -42,6 +42,8 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.io.AnsiColor
 import scala.util.{Failure, Success, Try}
 
+import KafkaLauncher._
+
 class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   banner(StandaloneOpenWhisk.banner)
   footer("\nOpenWhisk standalone server")
@@ -75,18 +77,20 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   //   then that service would not start. This is mostly meant to be used for test setups
   //   where test logic would determine a port and needs the service to start on that port only
   val kafkaPort = opt[Int](
-    descr = "Kafka port. If not specified then 9092 or some random free port (if 9092 is busy) would be used",
+    descr =
+      s"Kafka port. If not specified then $preferredKafkaPort or some random free port (if $preferredKafkaPort is busy) would be used",
     noshort = true,
     required = false)
 
   val kafkaDockerPort = opt[Int](
-    descr = "Kafka port for use by docker based services. If not specified then 9091 or some random free port " +
-      "(if 9091 is busy) would be used",
+    descr = s"Kafka port for use by docker based services. If not specified then $preferredKafkaDockerPort or some random free port " +
+      s"(if $preferredKafkaDockerPort is busy) would be used",
     noshort = true,
     required = false)
 
   val zkPort = opt[Int](
-    descr = "Zookeeper port. If not specified then 2181 or some random free port (if 2181 is busy) would be used",
+    descr =
+      s"Zookeeper port. If not specified then $preferredZkPort or some random free port (if $preferredZkPort is busy) would be used",
     noshort = true,
     required = false)
 
@@ -429,13 +433,13 @@ object StandaloneOpenWhisk extends SLF4JLogging {
     as: ActorSystem,
     ec: ExecutionContext,
     materializer: ActorMaterializer): (Int, Seq[ServiceContainer]) = {
-    val kafkaPort = getPort(conf.kafkaPort.toOption, 9092)
+    val kafkaPort = getPort(conf.kafkaPort.toOption, preferredKafkaPort)
     implicit val tid: TransactionId = TransactionId(systemPrefix + "kafka")
     val k = new KafkaLauncher(
       dockerClient,
       kafkaPort,
-      getPort(conf.kafkaDockerPort.toOption, kafkaPort - 1),
-      getPort(conf.zkPort.toOption, 2181),
+      getPort(conf.kafkaDockerPort.toOption, preferredKafkaDockerPort),
+      getPort(conf.zkPort.toOption, preferredZkPort),
       workDir,
       kafkaUi)
 

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -67,6 +67,13 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val kafka = opt[Boolean](descr = "Enable embedded Kafka support", noshort = true)
   val kafkaUi = opt[Boolean](descr = "Enable Kafka UI", noshort = true)
 
+  //The port option below express following usage. Note that "preferred"" port values are not configured as default
+  // on purpose
+  // - no config - Attempt to use default port. For e.g. 9092 for Kafka
+  // - non config if default preferred port is busy then select a random port
+  // - port config provided - Then this port would be used. If port is already busy
+  //   then that service would not start. This is mostly meant to be used for test setups
+  //   where test logic would determine a port and needs the service to start on that port only
   val kafkaPort = opt[Int](
     descr = "Kafka port. If not specified then 9092 or some random free port (if 9092 is busy) would be used",
     noshort = true,

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKafkaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKafkaTests.scala
@@ -23,16 +23,10 @@ import org.scalatest.junit.JUnitRunner
 import system.basic.WskRestBasicTests
 
 @RunWith(classOf[JUnitRunner])
-class StandaloneCouchTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
+class StandaloneKafkaTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
   override implicit val wskprops = WskProps().copy(apihost = serverUrl)
 
-  override protected def extraArgs: Seq[String] =
-    Seq("--couchdb")
+  override protected def supportedTests = Set("Wsk Action REST should invoke a blocking action and get only the result")
 
-  override protected def extraVMArgs: Seq[String] = Seq("-Dwhisk.standalone.couchdb.volumes-enabled=false")
-
-  //This is more of a sanity test. So just run one of the test which trigger interaction with couchdb
-  //and skip running all other tests
-  override protected def supportedTests: Set[String] =
-    Set("Wsk Action REST should create, update, get and list an action")
+  override protected def extraArgs: Seq[String] = Seq("--kafka")
 }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneSanityTestSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneSanityTestSupport.scala
@@ -17,22 +17,17 @@
 
 package org.apache.openwhisk.standalone
 
-import common.WskProps
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import system.basic.WskRestBasicTests
+import org.scalatest.{Canceled, Outcome, TestSuite}
 
-@RunWith(classOf[JUnitRunner])
-class StandaloneCouchTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
-  override implicit val wskprops = WskProps().copy(apihost = serverUrl)
+trait StandaloneSanityTestSupport extends TestSuite {
 
-  override protected def extraArgs: Seq[String] =
-    Seq("--couchdb")
+  protected def supportedTests: Set[String]
 
-  override protected def extraVMArgs: Seq[String] = Seq("-Dwhisk.standalone.couchdb.volumes-enabled=false")
-
-  //This is more of a sanity test. So just run one of the test which trigger interaction with couchdb
-  //and skip running all other tests
-  override protected def supportedTests: Set[String] =
-    Set("Wsk Action REST should create, update, get and list an action")
+  override def withFixture(test: NoArgTest): Outcome = {
+    if (supportedTests.contains(test.name)) {
+      super.withFixture(test)
+    } else {
+      Canceled()
+    }
+  }
 }


### PR DESCRIPTION
Adds support for launching Embedded Kafka and Kafka Drop UI

## Description

This PR adds support for launching an [embedded-kafka][1]. This is mostly meant to enable local development for features which need Kafka support (like User Event or Activation Persister Service etc). In this mode an inprocess Kafka Server (v2.1.1 currently) and Zookeeper Server

```
$ ./gradlew :core:standalone:build
$ java -jar bin/openwhisk-standalone.jar --kafka

# Or just run from OpenWhisk home dir
$ ./gradlew :core:standalone:bootRun --args='--kafka'
```

Key aspects

* Kafka version 2.1.1 is being used while we run with 0.11.0.1. Tried to use that but then it causes class compatability issue with newer version of Kafka client being used
* This mode is also useful to simulate some of the integration test scenarios with Activation Persister Service
* Kafka Server launched is supporting connection from both host and within Docker container based on [kafka listeners explanation][3]
* Kafka and Zookeeper generated files are stored in `~/.openwhisk/standalone/server-3233/tmp` and are removed upon restart

Once launched you can see the details of port used etc as below

```
[ 9092  ] localhost:9092 (kafka)
[ 9092  ] 192.168.65.2:9091 (kafka-docker)
[ 2181  ] Zookeeper (zookeeper)
[ 9000  ] http://localhost:9000 (whisk-kafka-drop-ui)
``` 

### Kafka Ui - Kafdrop 3 
This PR also adds support for launching an optional [Kafdrop 3][2]

```
java -jar openwhisk-standalone.jar --kafka --kafka-ui
```

This UI can help a developer to understand the structure of messages exchanged on various topics easily

![image](https://user-images.githubusercontent.com/664531/65041635-d71dd100-d974-11e9-8bec-e0673fefe1ca.png)


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

[1]: https://github.com/embeddedkafka/embedded-kafka
[2]: https://github.com/obsidiandynamics/kafdrop
[3]: https://rmoff.net/2018/08/02/kafka-listeners-explained/