### PR TITLE
Revert erroneous change which drops user events on some completions.

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
@@ -41,7 +41,7 @@ class UserEventTests extends FlatSpec with Matchers with WskTestHelpers with Str
 
   val groupid = "kafkatest"
   val topic = "events"
-  val maxPollInterval = 10.seconds
+  val maxPollInterval = 20.seconds
 
   lazy val consumer = new KafkaConsumerConnector(kafkaHosts, groupid, topic)
   val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")

--- a/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
@@ -41,7 +41,7 @@ class UserEventTests extends FlatSpec with Matchers with WskTestHelpers with Str
 
   val groupid = "kafkatest"
   val topic = "events"
-  val maxPollInterval = 20.seconds
+  val maxPollInterval = 60.seconds
 
   lazy val consumer = new KafkaConsumerConnector(kafkaHosts, groupid, topic)
   val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")

--- a/tests/src/test/scala/org/apache/openwhisk/common/UserEventsITTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/UserEventsITTests.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import akka.stream.ActorMaterializer
+import common.{FreePortFinder, WskProps}
+import org.apache.openwhisk.standalone.StandaloneServerFixture
+
+class UserEventsITTests extends UserEventTests with StandaloneServerFixture {
+  private implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private val kafkaPort = sys.props.get("whisk.kafka.port").map(_.toInt).getOrElse(FreePortFinder.freePort())
+
+  protected override val customConfig = Some("""
+      |include classpath("standalone.conf")
+      |whisk {
+      |  user-events {
+      |    enabled = true
+      |  }
+      |}
+      """.stripMargin)
+
+  override protected def extraArgs: Seq[String] =
+    Seq("--kafka", "--dev-mode", "--kafka-port", kafkaPort.toString)
+
+  override implicit val wskprops = WskProps().copy(apihost = serverUrl)
+
+  override def userEventsEnabled = true
+
+  override def kafkaHosts = s"localhost:$kafkaPort"
+}

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneUserEventTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneUserEventTests.scala
@@ -20,7 +20,10 @@ package org.apache.openwhisk.standalone
 import akka.stream.ActorMaterializer
 import common.{FreePortFinder, WskProps}
 import org.apache.openwhisk.common.UserEventTests
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class StandaloneUserEventTests extends UserEventTests with StandaloneServerFixture {
   private implicit val materializer: ActorMaterializer = ActorMaterializer()
   private val kafkaPort = sys.props.get("whisk.kafka.port").map(_.toInt).getOrElse(FreePortFinder.freePort())

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneUserEventTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneUserEventTests.scala
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.openwhisk.common
+package org.apache.openwhisk.standalone
 
 import akka.stream.ActorMaterializer
 import common.{FreePortFinder, WskProps}
-import org.apache.openwhisk.standalone.StandaloneServerFixture
+import org.apache.openwhisk.common.UserEventTests
 
-class UserEventsITTests extends UserEventTests with StandaloneServerFixture {
+class StandaloneUserEventTests extends UserEventTests with StandaloneServerFixture {
   private implicit val materializer: ActorMaterializer = ActorMaterializer()
   private val kafkaPort = sys.props.get("whisk.kafka.port").map(_.toInt).getOrElse(FreePortFinder.freePort())
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
This fixes a bug introduced in a previous PR which drops user events on completion messages that do not carry a result (which is needed for user event generation).

Best to review this ignoring white space.

It appears there are no tests that caught the bug and so some tests are needed. 
@sven-lange-last perhaps to verify the fix you can suggest a test to add 🙏 

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

