### PR TITLE
Retry NoHttpResponseException for standalone mode in ApacheContainerClient

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -449,6 +449,15 @@ whisk {
         # for details
         require-api-key-annotation = true
     }
+
+    apache-client {
+        # By default Apache HTTP Client would not retry NoHttpResponseException cases
+        # as its not sure that server has processed the request or not
+        # At times this issue is seen in local setups where with retry the request flow
+        # work as expected. So for such cases like when running in Standalone mode this
+        # setting can be enabled
+        retry-no-http-response-exception = false
+    }
 }
 #placeholder for test overrides so that tests can override defaults in application.conf (todo: move all defaults to reference.conf)
 test {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -452,10 +452,9 @@ whisk {
 
     apache-client {
         # By default Apache HTTP Client would not retry NoHttpResponseException cases
-        # as its not sure that server has processed the request or not
-        # At times this issue is seen in local setups where with retry the request flow
-        # work as expected. So for such cases like when running in Standalone mode this
-        # setting can be enabled
+        # For some setups like Standalone mode this setting may need to be enabled
+        # to work around some Docker network issue
+        # In general this setting should be left to its default disabled state
         retry-no-http-response-exception = false
     }
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -263,4 +263,6 @@ object ConfigKeys {
 
   val whiskConfig = "whisk.config"
   val swaggerUi = "whisk.swagger-ui"
+
+  val apacheClientConfig = "whisk.apache-client"
 }

--- a/core/standalone/src/main/resources/standalone.conf
+++ b/core/standalone/src/main/resources/standalone.conf
@@ -115,4 +115,7 @@ whisk {
       ]
     }
   }
+  apache-client {
+    retry-no-http-response-exception = true
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerTests.scala
@@ -27,22 +27,4 @@ import system.basic.WskRestBasicTests
 @RunWith(classOf[JUnitRunner])
 class StandaloneServerTests extends WskRestBasicTests with StandaloneServerFixture {
   override implicit val wskprops = WskProps().copy(apihost = serverUrl)
-
-  //Following tests always fail on Mac but pass when standalone server is running on Linux
-  //It looks related to how networking works on Mac for Docker container
-  //For now ignoring there failure
-  private val ignoredTestsOnMac = Set(
-    "Wsk Action REST should create, and invoke an action that utilizes a docker container",
-    "Wsk Action REST should create, and invoke an action that utilizes dockerskeleton with native zip",
-    "Wsk Action REST should create and invoke a blocking action resulting in an application error response",
-    "Wsk Action REST should create an action, and invoke an action that returns an empty JSON object")
-
-  override def withFixture(test: NoArgTest) = {
-    val outcome = super.withFixture(test)
-    val result = if (outcome.isFailed && SystemUtils.IS_OS_MAC && ignoredTestsOnMac.contains(test.name)) {
-      println(s"Ignoring known failed test for Mac [${test.name}]")
-      Pending
-    } else outcome
-    result
-  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerTests.scala
@@ -18,9 +18,7 @@
 package org.apache.openwhisk.standalone
 
 import common.WskProps
-import org.apache.commons.lang3.SystemUtils
 import org.junit.runner.RunWith
-import org.scalatest.Pending
 import org.scalatest.junit.JUnitRunner
 import system.basic.WskRestBasicTests
 


### PR DESCRIPTION
In local setups on Mac using Standalone OpenWhisk mode sometime few test fail. Also some times some steps in compositions are seen to fail. In all such cases the failure happens due to failure during initialization due to `NoHttpResponseException`

For some container upon retry the init seems to pass fine. This PR modifies the `ApacheBlockingContainerClient` logic to enable retry for `NoHttpResponseException` based on explicit config.

By default `NoHttpResponseException` would not be retried. However if config is enabled then retry would be performed. For standalone case this config is enabled.

With this change all test now pass on Mac in a reliable way. This is also needed for some conductor related test in #4632


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

