### PR TITLE
add missing install task for proper maven publishing (build break in cli repo)

### DIFF
--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -18,6 +18,7 @@
 apply plugin: 'scala'
 apply plugin: 'application'
 apply plugin: 'org.scoverage'
+apply plugin: 'maven'
 
 ext.dockerImageName = 'user-events'
 apply from: "../../../gradle/docker.gradle"


### PR DESCRIPTION
Add maven plugin to the user-events build gradle in order to inherit the install task for proper publishing of the jar to the maven repo/local cache.

## Description
Without the maven plugin the user-events jar is not properly published during builds to the maven repo/local .m2 cache. As a result downstream repo builds fail, e.g. for the openwhisk-cli

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

