### PR TITLE
Serialize `updated` value of entity document in response

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -19,8 +19,7 @@ package org.apache.openwhisk.core.entity
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets.UTF_8
-import java.time.temporal.ChronoUnit
-import java.time.{Clock, Instant}
+import java.time.Instant
 import java.util.Base64
 
 import akka.http.scaladsl.model.ContentTypes
@@ -125,8 +124,7 @@ abstract class WhiskActionLikeMetaData(override val name: EntityName) extends Wh
  * @param version the semantic version
  * @param publish true to share the action or false otherwise
  * @param annotations the set of annotations to attribute to the action
- * @param updated the timestamp when the action is updated.
- *                Since it's stored in milliseconds in the db, it's truncated.
+ * @param updated the timestamp when the action is updated
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
@@ -138,7 +136,7 @@ case class WhiskAction(namespace: EntityPath,
                        version: SemVer = SemVer(),
                        publish: Boolean = false,
                        annotations: Parameters = Parameters(),
-                       override val updated: Instant = Instant.now(Clock.systemUTC()).truncatedTo(ChronoUnit.MILLIS))
+                       override val updated: Instant = WhiskEntity.currentMillis())
     extends WhiskActionLike(name) {
 
   require(exec != null, "exec undefined")
@@ -205,9 +203,7 @@ case class WhiskActionMetaData(namespace: EntityPath,
                                version: SemVer = SemVer(),
                                publish: Boolean = false,
                                annotations: Parameters = Parameters(),
-                               override val updated: Instant = Instant
-                                 .now(Clock.systemUTC())
-                                 .truncatedTo(ChronoUnit.MILLIS),
+                               override val updated: Instant = WhiskEntity.currentMillis(),
                                binding: Option[EntityPath] = None)
     extends WhiskActionLikeMetaData(name) {
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -92,7 +92,7 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
       parameters.definedParameters
     } else Set.empty[String]
 
-  def toJson =
+  def toJson = {
     JsObject(
       "namespace" -> namespace.toJson,
       "name" -> name.toJson,
@@ -101,8 +101,8 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
       "limits" -> limits.toJson,
       "version" -> version.toJson,
       "publish" -> publish.toJson,
-      "annotations" -> annotations.toJson,
-      "updated" -> updated.getEpochSecond.toJson)
+      "annotations" -> annotations.toJson)
+  }
 }
 
 abstract class WhiskActionLikeMetaData(override val name: EntityName) extends WhiskActionLike(name) {
@@ -553,7 +553,18 @@ object WhiskActionMetaData
   override val cacheEnabled = true
 
   override implicit val serdes = new RootJsonFormat[WhiskActionMetaData] {
-    def write(result: WhiskActionMetaData) = result.toJson
+    def write(w: WhiskActionMetaData) = {
+      JsObject(
+        "namespace" -> w.namespace.toJson,
+        "name" -> w.name.toJson,
+        "exec" -> w.exec.toJson,
+        "parameters" -> w.parameters.toJson,
+        "limits" -> w.limits.toJson,
+        "version" -> w.version.toJson,
+        "publish" -> w.publish.toJson,
+        "annotations" -> w.annotations.toJson,
+        "updated" -> w.updated.getEpochSecond.toJson)
+    }
     def read(value: JsValue): WhiskActionMetaData = {
       val fields = value.asJsObject.fields
       WhiskActionMetaData(

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -94,7 +94,7 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
       parameters.definedParameters
     } else Set.empty[String]
 
-  def toJson = {
+  def toJson =
     JsObject(
       "namespace" -> namespace.toJson,
       "name" -> name.toJson,
@@ -104,7 +104,6 @@ abstract class WhiskActionLike(override val name: EntityName) extends WhiskEntit
       "version" -> version.toJson,
       "publish" -> publish.toJson,
       "annotations" -> annotations.toJson)
-  }
 }
 
 abstract class WhiskActionLikeMetaData(override val name: EntityName) extends WhiskActionLike(name) {
@@ -125,7 +124,9 @@ abstract class WhiskActionLikeMetaData(override val name: EntityName) extends Wh
  * @param limits the limits to impose on the action
  * @param version the semantic version
  * @param publish true to share the action or false otherwise
- * @param annotation the set of annotations to attribute to the action
+ * @param annotations the set of annotations to attribute to the action
+ * @param updated the timestamp when the action is updated.
+ *                Since it's stored in milliseconds in the db, it's truncated.
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
@@ -271,7 +272,7 @@ case class WhiskActionMetaData(namespace: EntityPath,
  * @param limits the limits to impose on the action
  * @param version the semantic version
  * @param publish true to share the action or false otherwise
- * @param annotation the set of annotations to attribute to the action
+ * @param annotations the set of annotations to attribute to the action
  * @param binding the path of the package binding if any
  * @throws IllegalArgumentException if any argument is undefined
  */

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskEntity.scala
@@ -36,7 +36,7 @@ import org.apache.openwhisk.http.Messages
  * @param namespace the namespace for the entity as an abstract field
  * @param version the semantic version as an abstract field
  * @param publish true to share the entity and false to keep it private as an abstract field
- * @param annotation the set of annotations to attribute to the entity
+ * @param annotations the set of annotations to attribute to the entity
  *
  * @throws IllegalArgumentException if any argument is undefined
  */
@@ -113,8 +113,8 @@ object WhiskEntity {
   }
 
   /**
-   * Get Instant with a millisecond precision
-   * because it's stored in milliseconds in the db
+   * Get Instant object with a millisecond precision
+   * timestamp of whisk entity is stored in milliseconds in the db
    */
   def currentMillis() = {
     Instant.now(Clock.systemUTC()).truncatedTo(ChronoUnit.MILLIS)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskEntity.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskEntity.scala
@@ -19,10 +19,9 @@ package org.apache.openwhisk.core.entity
 
 import java.time.Clock
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
-import scala.Stream
 import scala.util.Try
-
 import spray.json._
 import org.apache.openwhisk.core.database.DocumentUnreadable
 import org.apache.openwhisk.core.database.DocumentTypeMismatchException
@@ -49,7 +48,7 @@ abstract class WhiskEntity protected[entity] (en: EntityName, val entityType: St
   val version: SemVer
   val publish: Boolean
   val annotations: Parameters
-  val updated = Instant.now(Clock.systemUTC())
+  val updated = WhiskEntity.currentMillis()
 
   /**
    * The name of the entity qualified with its namespace and version for
@@ -112,6 +111,15 @@ object WhiskEntity {
   def qualifiedName(namespace: EntityPath, activationId: ActivationId) = {
     s"$namespace${EntityPath.PATHSEP}$activationId"
   }
+
+  /**
+   * Get Instant with a millisecond precision
+   * because it's stored in milliseconds in the db
+   */
+  def currentMillis() = {
+    Instant.now(Clock.systemUTC()).truncatedTo(ChronoUnit.MILLIS)
+  }
+
 }
 
 object WhiskDocumentReader extends DocumentReader {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskTrigger.scala
@@ -17,6 +17,8 @@
 
 package org.apache.openwhisk.core.entity
 
+import java.time.Instant
+
 import spray.json.DefaultJsonProtocol
 import org.apache.openwhisk.core.database.DocumentFactory
 import spray.json._
@@ -54,8 +56,9 @@ case class ReducedRule(action: FullyQualifiedEntityName, status: Status)
  * @param limits the limits to impose on the trigger
  * @param version the semantic version
  * @param publish true to share the action or false otherwise
- * @param annotation the set of annotations to attribute to the trigger
+ * @param annotations the set of annotations to attribute to the trigger
  * @param rules the map of the rules that are associated with this trigger. Key is the rulename and value is the ReducedRule
+ * @param updated the timestamp when the trigger is updated
  * @throws IllegalArgumentException if any argument is undefined
  */
 @throws[IllegalArgumentException]
@@ -66,7 +69,8 @@ case class WhiskTrigger(namespace: EntityPath,
                         version: SemVer = SemVer(),
                         publish: Boolean = false,
                         annotations: Parameters = Parameters(),
-                        rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None)
+                        rules: Option[Map[FullyQualifiedEntityName, ReducedRule]] = None,
+                        override val updated: Instant = WhiskEntity.currentMillis())
     extends WhiskEntity(name, "trigger") {
 
   require(limits != null, "limits undefined")
@@ -108,11 +112,12 @@ object WhiskTrigger
     extends DocumentFactory[WhiskTrigger]
     with WhiskEntityQueries[WhiskTrigger]
     with DefaultJsonProtocol {
+  import WhiskActivation.instantSerdes
 
   override val collectionName = "triggers"
 
   private implicit val fqnSerdesAsDocId = FullyQualifiedEntityName.serdesAsDocId
-  override implicit val serdes = jsonFormat8(WhiskTrigger.apply)
+  override implicit val serdes = jsonFormat9(WhiskTrigger.apply)
 
   override val cacheEnabled = true
 }

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1998,6 +1998,10 @@
             "deactivating"
           ]
         },
+        "updated": {
+          "type": "integer",
+          "description": "Time when the rule was updated"
+        },
         "trigger": {
           "$ref": "#/definitions/PathName"
         },

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -224,7 +224,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
-  it should "not put `updated` field" in {
+  it should "not update action `updated` field with a put" in {
     implicit val tid = transid()
 
     val action = WhiskAction(namespace, aname(), jsDefault(""))

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -202,7 +202,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
-  it should "get action with `updated` field" in {
+  it should "get action with updated field" in {
     implicit val tid = transid()
 
     val action = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
@@ -224,7 +224,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     }
   }
 
-  it should "not update action `updated` field with a put" in {
+  it should "ignore updated field when updating action" in {
     implicit val tid = transid()
 
     val action = WhiskAction(namespace, aname(), jsDefault(""))

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -586,7 +586,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(NODEJS10),
-          updated = response.updated)) // ignore updated field
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -608,7 +608,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(BLACKBOX),
-          updated = response.updated)) // ignore updated field
+          updated = response.updated)) // ignored `updated` field because another test covers it
       response.exec shouldBe an[BlackBoxExec]
       response.exec.asInstanceOf[BlackBoxExec].code shouldBe empty
     }
@@ -632,7 +632,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(BLACKBOX),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
       response.exec shouldBe an[BlackBoxExec]
       val bb = response.exec.asInstanceOf[BlackBoxExec]
       bb.code shouldBe Some(Inline("cc"))
@@ -680,7 +680,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version.upPatch.upPatch,
           action.publish,
           action.annotations ++ Parameters("a", "B") ++ Parameters(WhiskAction.execFieldName, action.exec.kind),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -752,7 +752,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(NODEJS10),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -793,7 +793,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(NODEJS10),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -830,7 +830,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include(s"caching ${CacheKey(action)}")
         stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
@@ -850,7 +850,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include(s"serving from cache: ${CacheKey(action)}")
         stream.reset()
@@ -869,7 +869,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version.upPatch,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated)
+              updated = response.updated) // ignored `updated` field because another test covers it
           }
         }
         stream.toString should include(s"entity exists, will try to update '$action'")
@@ -891,7 +891,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version.upPatch,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include(s"invalidating ${CacheKey(action)}")
         stream.reset()
@@ -946,7 +946,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
 
         stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
@@ -967,7 +967,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include(s"serving from cache: ${CacheKey(action)}")
         stream.toString should not include regex(notExpectedGetLog)
@@ -987,7 +987,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
 
         stream.toString should include(s"invalidating ${CacheKey(action)}")
@@ -1032,7 +1032,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(JAVA_DEFAULT),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
 
     stream.toString should not include (s"invalidating ${CacheKey(action)} on delete")
@@ -1053,7 +1053,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(JAVA_DEFAULT),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
 
     stream.toString should include(s"serving from cache: ${CacheKey(action)}")
@@ -1074,7 +1074,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.version,
           action.publish,
           action.annotations ++ systemAnnotations(JAVA_DEFAULT),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
     stream.toString should include(s"invalidating ${CacheKey(action)}")
     stream.reset()
@@ -1124,7 +1124,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
 
         stream.toString should include regex (expectedGetLog)
@@ -1232,7 +1232,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version.upPatch,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include regex (expectedPutLog)
         stream.reset()
@@ -1251,7 +1251,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               action.version.upPatch,
               action.publish,
               action.annotations ++ systemAnnotations(kind),
-              updated = response.updated))
+              updated = response.updated)) // ignored `updated` field because another test covers it
         }
         stream.toString should include(s"invalidating ${CacheKey(action)}")
         stream.reset()
@@ -1299,7 +1299,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           actionOldSchema.version.upPatch,
           actionOldSchema.publish,
           actionOldSchema.annotations ++ systemAnnotations(NODEJS10, create = false),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
 
     stream.toString should include regex (expectedPutLog)
@@ -1324,7 +1324,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           actionOldSchema.version.upPatch,
           actionOldSchema.publish,
           actionOldSchema.annotations ++ systemAnnotations(NODEJS10, create = false),
-          updated = response.updated))
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -1370,7 +1370,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             content.limits.get.concurrency.get),
           version = action.version.upPatch,
           annotations = action.annotations ++ systemAnnotations(NODEJS10, create = false),
-          updated = response.updated)
+          updated = response.updated) // ignored `updated` field because another test covers it
       }
     }
   }
@@ -1392,7 +1392,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           content.parameters.get,
           version = action.version.upPatch,
           annotations = action.annotations ++ systemAnnotations(NODEJS10, false),
-          updated = response.updated)
+          updated = response.updated) // ignored `updated` field because another test covers it
       }
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -228,7 +228,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     implicit val tid = transid()
 
     val action = WhiskAction(namespace, aname(), jsDefault(""))
-    val dummyUpdated = 1569400000000L;
+    val dummyUpdated = WhiskEntity.currentMillis().toEpochMilli
+
     val content = JsObject(
       "exec" -> JsObject("code" -> "".toJson, "kind" -> action.exec.kind.toJson),
       "updated" -> dummyUpdated.toJson)
@@ -236,7 +237,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      response.updated.toEpochMilli should not be (dummyUpdated)
+      response.updated.toEpochMilli should be > dummyUpdated
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -71,14 +71,6 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   val actionLimit = Exec.sizeLimit
   val parametersLimit = Parameters.sizeLimit
 
-  def checkWhiskActionResponse(response: WhiskAction, expected: WhiskAction) =
-    // ignore `updated` field because another test covers it
-    response should be(expected copy (updated = response.updated))
-
-  def checkWhiskActionMetadataResponse(response: WhiskActionMetaData, expected: WhiskActionMetaData) =
-    // ignore `updated` field because another test covers it
-    response should be(expected copy (updated = response.updated))
-
   //// GET /actions
   it should "return empty list when no actions exist" in {
     implicit val tid = transid()
@@ -355,7 +347,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(response, expectedWhiskAction)
+          checkWhiskEntityResponse(response, expectedWhiskAction)
         }
 
         Get(s"$collectionPath/${action.name}?code=false") ~> Route.seal(routes(creds)) ~> check {
@@ -363,21 +355,21 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           val responseJson = responseAs[JsObject]
           responseJson.fields("exec").asJsObject.fields should not(contain key "code")
           val response = responseAs[WhiskActionMetaData]
-          checkWhiskActionMetadataResponse(response, expectedWhiskActionMetaData)
+          checkWhiskEntityResponse(response, expectedWhiskActionMetaData)
         }
 
         Seq(s"$collectionPath/${action.name}", s"$collectionPath/${action.name}?code=true").foreach { path =>
           Get(path) ~> Route.seal(routes(creds)) ~> check {
             status should be(OK)
             val response = responseAs[WhiskAction]
-            checkWhiskActionResponse(response, expectedWhiskAction)
+            checkWhiskEntityResponse(response, expectedWhiskAction)
           }
         }
 
         Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(response, expectedWhiskAction)
+          checkWhiskEntityResponse(response, expectedWhiskAction)
         }
     }
   }
@@ -576,7 +568,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -598,7 +590,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -622,7 +614,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -651,7 +643,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -670,7 +662,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -742,7 +734,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -783,7 +775,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -820,7 +812,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -840,7 +832,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -859,7 +851,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -880,7 +872,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -935,7 +927,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -956,7 +948,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Get(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -976,7 +968,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Delete(s"$collectionPath/${action.name}") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -1021,7 +1013,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Put(s"$collectionPath/$name", content) ~> Route.seal(routes(creds)(transid())) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -1042,7 +1034,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -1063,7 +1055,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -1113,7 +1105,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -1173,7 +1165,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
         status should be(OK)
         val response = responseAs[WhiskAction]
-        checkWhiskActionResponse(response, expectedAction)
+        checkWhiskEntityResponse(response, expectedAction)
       }
     }
 
@@ -1221,7 +1213,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Put(s"$collectionPath/$name?overwrite=true", content) ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -1240,7 +1232,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
         Delete(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
           status should be(OK)
           val response = responseAs[WhiskAction]
-          checkWhiskActionResponse(
+          checkWhiskEntityResponse(
             response,
             WhiskAction(
               action.namespace,
@@ -1288,7 +1280,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     Put(s"$collectionPath/${actionOldSchema.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           actionOldSchema.namespace,
@@ -1313,7 +1305,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     Delete(s"$collectionPath/${actionOldSchema.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           actionOldSchema.namespace,
@@ -1356,7 +1348,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       val response = responseAs[WhiskAction]
 
       response.updated should not be action.updated
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,
@@ -1382,7 +1374,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      checkWhiskActionResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskAction(
           action.namespace,

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
@@ -85,6 +85,18 @@ protected trait ControllerTestCommon
     }
   }
 
+  def checkWhiskEntityResponse(response: WhiskEntity, expected: WhiskEntity): Unit = {
+    // Used to ignore `updated` field because timestamp is not known before inserting into the DB
+    // If you use this method, test case that checks timestamp must be added
+    val r = response match {
+      case whiskAction: WhiskAction                 => whiskAction.copy(updated = expected.updated)
+      case whiskActionMetaData: WhiskActionMetaData => whiskActionMetaData.copy(updated = expected.updated)
+      case whiskTrigger: WhiskTrigger               => whiskTrigger.copy(updated = expected.updated)
+      case whiskPackage: WhiskPackage               => whiskPackage.copy(updated = expected.updated)
+    }
+    r should be(expected)
+  }
+
   def systemAnnotations(kind: String, create: Boolean = true): Parameters = {
     val base = if (create && FeatureFlags.requireApiKeyAnnotation) {
       Parameters(Annotations.ProvideApiKeyAnnotationName, JsFalse)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackageActionsApiTests.scala
@@ -162,7 +162,8 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.limits,
           action.version,
           action.publish,
-          action.annotations ++ systemAnnotations(NODEJS10)))
+          action.annotations ++ systemAnnotations(NODEJS10),
+          updated = response.updated))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -54,6 +54,10 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   def aname() = MakeName.next("packages_tests")
   val parametersLimit = Parameters.sizeLimit
 
+  def checkResponse(response: WhiskPackage, expected: WhiskPackage) =
+    // ignore `updated` field because another test covers it
+    response should be(expected copy (updated = response.updated))
+
   private def bindingAnnotation(binding: Binding) = {
     Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(binding))
   }
@@ -437,7 +441,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(provider.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      response should be(provider copy (updated = response.updated)) // ignored `updated` field because another test covers it
+      checkResponse(response, provider)
     }
   }
 
@@ -507,7 +511,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      response should be(reference copy (updated = response.updated)) // ignored `updated` field because another test covers it
+      checkResponse(response, reference)
     }
   }
 
@@ -537,14 +541,13 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      response should be {
+      checkResponse(
+        response,
         WhiskPackage(
           reference.namespace,
           reference.name,
           provider.bind,
-          annotations = bindingAnnotation(provider.bind.get),
-          updated = response.updated) // ignored `updated` field because another test covers it
-      }
+          annotations = bindingAnnotation(provider.bind.get)))
     }
   }
 
@@ -648,14 +651,9 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       deletePackage(provider.docid)
       val response = responseAs[WhiskPackage]
-      response should be(
-        WhiskPackage(
-          namespace,
-          provider.name,
-          None,
-          version = provider.version.upPatch,
-          publish = true,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+      checkResponse(
+        response,
+        WhiskPackage(namespace, provider.name, None, version = provider.version.upPatch, publish = true))
     }
   }
 
@@ -679,16 +677,15 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      response should be {
+      checkResponse(
+        response,
         WhiskPackage(
           reference.namespace,
           reference.name,
           reference.binding,
           version = reference.version.upPatch,
           publish = true,
-          annotations = reference.annotations ++ Parameters("a", "b"),
-          updated = response.updated) // ignored `updated` field because another test covers it
-      }
+          annotations = reference.annotations ++ Parameters("a", "b")))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -54,10 +54,6 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
   def aname() = MakeName.next("packages_tests")
   val parametersLimit = Parameters.sizeLimit
 
-  def checkResponse(response: WhiskPackage, expected: WhiskPackage) =
-    // ignore `updated` field because another test covers it
-    response should be(expected copy (updated = response.updated))
-
   private def bindingAnnotation(binding: Binding) = {
     Parameters(WhiskPackage.bindingFieldName, Binding.serdes.write(binding))
   }
@@ -441,7 +437,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(provider.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      checkResponse(response, provider)
+      checkWhiskEntityResponse(response, provider)
     }
   }
 
@@ -511,7 +507,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      checkResponse(response, reference)
+      checkWhiskEntityResponse(response, reference)
     }
   }
 
@@ -541,7 +537,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      checkResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskPackage(
           reference.namespace,
@@ -651,7 +647,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Put(s"$collectionPath/${provider.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       deletePackage(provider.docid)
       val response = responseAs[WhiskPackage]
-      checkResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskPackage(namespace, provider.name, None, version = provider.version.upPatch, publish = true))
     }
@@ -677,7 +673,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       deletePackage(reference.docid)
       status should be(OK)
       val response = responseAs[WhiskPackage]
-      checkResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskPackage(
           reference.namespace,

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
@@ -17,6 +17,8 @@
 
 package org.apache.openwhisk.core.controller.test
 
+import java.time.Instant
+
 import scala.language.postfixOps
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -27,7 +29,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.core.controller.WhiskRulesApi
 import org.apache.openwhisk.core.entitlement.Collection
-import org.apache.openwhisk.core.entity._
+import org.apache.openwhisk.core.entity.{WhiskRuleResponse, _}
 import org.apache.openwhisk.core.entity.test.OldWhiskTrigger
 import org.apache.openwhisk.http.ErrorResponse
 
@@ -61,6 +63,11 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
   val activeStatus = s"""{"status":"${Status.ACTIVE}"}""".parseJson.asJsObject
   val inactiveStatus = s"""{"status":"${Status.INACTIVE}"}""".parseJson.asJsObject
   val parametersLimit = Parameters.sizeLimit
+  val dummyInstant = Instant.now()
+
+  def checkResponse(response: WhiskRuleResponse, expected: WhiskRuleResponse) =
+    // ignore `updated` field because another test covers it
+    response should be(expected copy (updated = response.updated))
 
   //// GET /rules
   it should "list rules by default/explicit namespace" in {
@@ -164,14 +171,14 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
 
     // it should "get trigger by name in explicit namespace owned by subject" in
     Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
 
     // it should "reject get trigger by name in explicit namespace not owned by subject" in
@@ -207,8 +214,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
     }
   }
 
@@ -253,8 +259,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -291,8 +296,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -320,8 +324,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe None
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -339,8 +342,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -359,8 +361,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -387,8 +388,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -417,8 +417,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -469,8 +468,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -502,7 +500,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -626,7 +624,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -634,7 +633,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -658,7 +657,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -666,7 +666,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -690,7 +690,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -698,7 +699,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -722,7 +723,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe a[Some[_]]
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -730,7 +732,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -751,7 +753,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -759,7 +762,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -834,7 +837,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get(rule.fullyQualifiedName(false)).action should be(action.fullyQualifiedName(false))
       val response = responseAs[WhiskRuleResponse]
-      response should be(
+      checkResponse(
+        response,
         WhiskRuleResponse(
           namespace,
           rule.name,
@@ -842,7 +846,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
           version = SemVer().upPatch,
-          updated = response.updated)) // ignored `updated` field because another test covers it
+          updated = dummyInstant))
     }
   }
 
@@ -988,8 +992,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      // ignored `updated` field because another test covers it
-      response should be(rule.toWhiskRule.withStatus(Status.INACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.toWhiskRule.withStatus(Status.INACTIVE))
     }
   }
 
@@ -1013,9 +1016,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
       val response = responseAs[WhiskRuleResponse]
-
-      // ignored `updated` field because another test covers it
-      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+      checkResponse(response, rule.withStatus(Status.ACTIVE))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
@@ -164,14 +164,14 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
 
     // it should "get trigger by name in explicit namespace owned by subject" in
     Get(s"/$namespace/${collection.path}/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
 
     // it should "reject get trigger by name in explicit namespace not owned by subject" in
@@ -207,7 +207,33 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
+    }
+  }
+
+  it should "get rule with updated field" in {
+    implicit val tid = transid()
+
+    val rule = WhiskRule(
+      namespace,
+      EntityName("get_active_rule"),
+      afullname(namespace, "get_active_rule trigger"),
+      afullname(namespace, "an action"))
+    val trigger = WhiskTrigger(rule.trigger.path, rule.trigger.name, rules = Some {
+      Map(rule.fullyQualifiedName(false) -> ReducedRule(rule.action, Status.ACTIVE))
+    })
+
+    put(entityStore, trigger)
+    put(entityStore, rule)
+
+    // `updated` field should be compared with a document in DB
+    val r = get(entityStore, rule.docid, WhiskRule)
+
+    Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskRuleResponse]
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = r.updated))
     }
   }
 
@@ -227,7 +253,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -264,7 +291,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -292,7 +320,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get.get(rule.fullyQualifiedName(false)) shouldBe None
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -310,7 +339,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Delete(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -329,7 +359,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -356,7 +387,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -385,7 +417,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -436,7 +469,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -468,7 +502,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
 
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
     }
   }
@@ -599,7 +633,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -630,7 +665,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -661,7 +697,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -692,7 +729,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -720,7 +758,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.INACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -802,7 +841,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
           Status.ACTIVE,
           trigger.fullyQualifiedName(false),
           action.fullyQualifiedName(false),
-          version = SemVer().upPatch))
+          version = SemVer().upPatch,
+          updated = response.updated)) // ignored `updated` field because another test covers it
     }
   }
 
@@ -948,7 +988,8 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
     Get(s"$collectionPath/${rule.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.toWhiskRule.withStatus(Status.INACTIVE))
+      // ignored `updated` field because another test covers it
+      response should be(rule.toWhiskRule.withStatus(Status.INACTIVE) copy (updated = response.updated))
     }
   }
 
@@ -972,7 +1013,9 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       status should be(OK)
       t.rules.get(rule.fullyQualifiedName(false)) shouldBe ReducedRule(action.fullyQualifiedName(false), Status.ACTIVE)
       val response = responseAs[WhiskRuleResponse]
-      response should be(rule.withStatus(Status.ACTIVE))
+
+      // ignored `updated` field because another test covers it
+      response should be(rule.withStatus(Status.ACTIVE) copy (updated = response.updated))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -194,7 +194,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger copy(updated = t.updated))
+      response should be(trigger copy (updated = t.updated))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -69,10 +69,6 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   val parametersLimit = Parameters.sizeLimit
   val dummyInstant = Instant.now()
 
-  def checkResponse(response: WhiskTrigger, expected: WhiskTrigger) =
-    // ignore `updated` field because another test covers it
-    response should be(expected copy (updated = response.updated))
-
   //// GET /triggers
   it should "list triggers by default/explicit namespace" in {
     implicit val tid = transid()
@@ -237,7 +233,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      checkResponse(response, trigger.withoutRules)
+      checkWhiskEntityResponse(response, trigger.withoutRules)
     }
   }
 
@@ -249,7 +245,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      checkResponse(response, trigger.withoutRules)
+      checkWhiskEntityResponse(response, trigger.withoutRules)
     }
   }
 
@@ -343,7 +339,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      checkResponse(
+      checkWhiskEntityResponse(
         response,
         WhiskTrigger(
           trigger.namespace,
@@ -455,7 +451,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       val response = responseAs[WhiskTrigger]
       status should be(OK)
-      checkResponse(response, trigger.toWhiskTrigger)
+      checkWhiskEntityResponse(response, trigger.toWhiskTrigger)
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -67,6 +67,11 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
   def aname() = MakeName.next("triggers_tests")
   def afullname(namespace: EntityPath, name: String) = FullyQualifiedEntityName(namespace, EntityName(name))
   val parametersLimit = Parameters.sizeLimit
+  val dummyInstant = Instant.now()
+
+  def checkResponse(response: WhiskTrigger, expected: WhiskTrigger) =
+    // ignore `updated` field because another test covers it
+    response should be(expected copy (updated = response.updated))
 
   //// GET /triggers
   it should "list triggers by default/explicit namespace" in {
@@ -232,7 +237,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger.withoutRules copy (updated = response.updated)) // ignored `updated` field because another test covers it
+      checkResponse(response, trigger.withoutRules)
     }
   }
 
@@ -244,7 +249,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(trigger.withoutRules copy (updated = response.updated))
+      checkResponse(response, trigger.withoutRules)
     }
   }
 
@@ -338,14 +343,14 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
       deleteTrigger(trigger.docid)
       status should be(OK)
       val response = responseAs[WhiskTrigger]
-      response should be(
+      checkResponse(
+        response,
         WhiskTrigger(
           trigger.namespace,
           trigger.name,
           trigger.parameters,
           version = trigger.version.upPatch,
-          // ignored `updated` field because another test covers it
-          updated = response.updated).withoutRules)
+          updated = dummyInstant).withoutRules)
     }
   }
 
@@ -450,9 +455,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     Get(s"$collectionPath/${trigger.name}") ~> Route.seal(routes(creds)) ~> check {
       val response = responseAs[WhiskTrigger]
       status should be(OK)
-
-      // ignored `updated` field because another test covers it
-      response should be(trigger.toWhiskTrigger copy (updated = response.updated))
+      checkResponse(response, trigger.toWhiskTrigger)
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -431,7 +431,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
       "parameters" -> Parameters().toJson,
       "version" -> SemVer().toJson,
       "publish" -> JsFalse,
-      "annotations" -> Parameters().toJson)
+      "annotations" -> Parameters().toJson,
+      "updated" -> pkg.updated.toEpochMilli.toJson)
   }
 
   it should "serialize and deserialize package binding" in {
@@ -443,7 +444,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
       "parameters" -> Parameters().toJson,
       "version" -> SemVer().toJson,
       "publish" -> JsFalse,
-      "annotations" -> Parameters().toJson)
+      "annotations" -> Parameters().toJson,
+      "updated" -> pkg.updated.toEpochMilli.toJson)
     //val legacyPkgAsJson = JsObject(pkgAsJson.fields + ("binding" -> JsObject("namespace" -> "x".toJson, "name" -> "y".toJson)))
     WhiskPackage.serdes.write(pkg) shouldBe pkgAsJson
     WhiskPackage.serdes.read(pkgAsJson) shouldBe pkg

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
@@ -186,7 +186,8 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
         |		"timeout": 60000,
         |		"memory": 256
         |	},
-        |	"namespace": "namespace"
+        |	"namespace": "namespace",
+        | "updated": 1546268400000
         |}""".stripMargin.parseJson
 
     val action = WhiskDocumentReader.read(manifest[WhiskAction], json)
@@ -213,7 +214,8 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
         |    "timeout": 60000,
         |    "memory": 256
         |  },
-        |  "namespace": "namespace"
+        |  "namespace": "namespace",
+        |  "updated": 1546268400000
         |}""".stripMargin.parseJson
     val action = WhiskDocumentReader.read(manifest[WhiskAction], json)
     assertType(action.asInstanceOf[WhiskEntity], "action")

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
@@ -187,7 +187,7 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
         |		"memory": 256
         |	},
         |	"namespace": "namespace",
-        | "updated": 1546268400000
+        |	"updated": 1546268400000
         |}""".stripMargin.parseJson
 
     val action = WhiskDocumentReader.read(manifest[WhiskAction], json)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

Since an action API doesn't serialize the `updated` value of the action entity, users can't know when the action was updated.

It changes the action API to serialize and provide the `updated` value of the action


## Related issue and scope

https://github.com/apache/openwhisk/issues/4228


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

