### PR TITLE
Add CPU limit mode to container scheduling, contrast with CPU share mode

### DIFF
--- a/ansible/roles/redis/tasks/deploy.yml
+++ b/ansible/roles/redis/tasks/deploy.yml
@@ -17,13 +17,6 @@
 ---
 # This role will install redis
 
-- name: "pull the redis:{{ redis.version }} image"
-  shell: "docker pull redis:{{ redis.version }}"
-  register: result
-  until: (result.rc == 0)
-  retries: "{{ docker.pull.retries }}"
-  delay: "{{ docker.pull.delay }}"
-
 - name: (re)start redis
   docker_container:
     name: redis
@@ -38,6 +31,7 @@
     command:
       /bin/sh -c
       "docker-entrypoint.sh --requirepass {{ redis.password }}"
+    pull: "{{ redis.pull_redis | default(true) }}"
 
 - name: wait until redis is up and running
   shell: "docker run --link redis:redis --rm redis:{{ redis.version }} redis-cli -h redis -p 6379 -a {{ redis.password }} ping"

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -365,6 +365,14 @@ whisk {
         std = 256 m
     }
 
+    # action cpu configuration
+    cpu {
+        control-enabled = false
+        min = 0.1
+        max = 1.0
+        std = 0.2
+    }
+
     # action log-limit configuration
     log-limit {
         min = 0 m

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
@@ -22,36 +22,36 @@ package org.apache.openwhisk.common
   * in order to implement the actions API.
   */
 object CPULimitUtils {
-  // CPU cores would be transformed to CPU permits, and calculate by CPU permits.
+  // CPU threads would be transformed to CPU permits, and calculate by CPU permits.
   private val unitScala = 100
 
   /**
-    * transform CPU cores to CPU permits for counting slots.
-    * @param cores CPU cores, count in Float
+    * transform CPU threads to CPU permits for counting slots.
+    * @param cpuThreads CPU threads, count in Float
     */
-  def coresToPermits(cores: Float): Int = (cores * unitScala).toInt
+  def threadsToPermits(cpuThreads: Float): Int = (cpuThreads * unitScala).toInt
 
   /**
-    * transform CPU cores to CPU permits for counting slots.
-    * @param cores CPU cores, count in Float
+    * transform CPU threads to CPU permits for counting slots.
+    * @param cpuThreads CPU threads, count in Float
     */
-  def coresToPermits(cores: Double): Int = (cores * unitScala).toInt
+  def threadsToPermits(cpuThreads: Double): Int = (cpuThreads * unitScala).toInt
 
   /**
-    * transform CPU permits to CPU core for nice printing.
+    * transform CPU permits to CPU threads for nice printing.
     * @param permits CPU permits, count in Int
     */
-  def permitsToCores(permits: Int): Float = permits.toFloat / unitScala
+  def permitsToThreads(permits: Int): Float = permits.toFloat / unitScala
 }
 
 /**
- * A Semaphore that coordinates the CPU cores (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
+ * A Semaphore that coordinates the CPU threads (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
  * - for invocations when maxConcurrent == 1, delegate to super
  * - for invocations that cause acquire on cpu slots, also acquire concurrency slots, and do it atomically
- * @param cpuCores
+ * @param cpuThreads
  * @tparam T
  */
-class NestedCPUSemaphore[T](cpuCores: Float) extends NestedSemaphore[T](CPULimitUtils.coresToPermits(cpuCores)) {
+class NestedCPUSemaphore[T](cpuThreads: Float) extends NestedSemaphore[T](CPULimitUtils.threadsToPermits(cpuThreads)) {
   final override def tryAcquireConcurrent(actionid: T, maxConcurrent: Int, permits: Int): Boolean = {
     super.tryAcquireConcurrent(actionid, maxConcurrent, permits)
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
@@ -18,11 +18,10 @@
 package org.apache.openwhisk.common
 
 /**
-  * A singleton object which defines the properties that must be present in a configuration
-  * in order to implement the actions API.
+  * A singleton object which defines the action's CPU limit properties.
   */
 object CPULimitUtils {
-  // CPU threads would be transformed to CPU permits, and calculate by CPU permits.
+  // CPU threads transform to CPU permits, and calculate by CPU permits.
   private val unitScala = 100
 
   /**
@@ -47,7 +46,7 @@ object CPULimitUtils {
 /**
  * A Semaphore that coordinates the CPU threads (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
  * - for invocations when maxConcurrent == 1, delegate to super
- * - for invocations that cause acquire on cpu slots, also acquire concurrency slots, and do it atomically
+ * - for others, acquire cpu slots and concurrency slots, do it atomically
  * @param cpuThreads
  * @tparam T
  */

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+private object NestedCPUSemaphoreUtils {
+  // CPU cores would be transformed to CPU permits, and calculate by CPU permits.
+  val unitScala = 100
+  def coresToPermits(cores: Float): Int = (cores * unitScala).toInt
+  def permitsToCores(permits: Int): Float = permits.toFloat / unitScala
+}
+
+/**
+ * A Semaphore that coordinates the CPU cores (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
+ * - for invocations when maxConcurrent == 1, delegate to super
+ * - for invocations that cause acquire on cpu slots, also acquire concurrency slots, and do it atomically
+ * @param cpuCores
+ * @tparam T
+ */
+class NestedCPUSemaphore[T](cpuCores: Float) extends NestedSemaphore[T](NestedCPUSemaphoreUtils.coresToPermits(cpuCores)) {
+  final override def tryAcquireConcurrent(actionid: T, maxConcurrent: Int, permits: Int): Boolean = {
+    super.tryAcquireConcurrent(actionid, maxConcurrent, permits)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
@@ -17,10 +17,30 @@
 
 package org.apache.openwhisk.common
 
-private object NestedCPUSemaphoreUtils {
+/**
+  * A singleton object which defines the properties that must be present in a configuration
+  * in order to implement the actions API.
+  */
+object CPULimitUtils {
   // CPU cores would be transformed to CPU permits, and calculate by CPU permits.
-  val unitScala = 100
+  private val unitScala = 100
+
+  /**
+    * transform CPU cores to CPU permits for counting slots.
+    * @param cores CPU cores, count in Float
+    */
   def coresToPermits(cores: Float): Int = (cores * unitScala).toInt
+
+  /**
+    * transform CPU cores to CPU permits for counting slots.
+    * @param cores CPU cores, count in Float
+    */
+  def coresToPermits(cores: Double): Int = (cores * unitScala).toInt
+
+  /**
+    * transform CPU permits to CPU core for nice printing.
+    * @param permits CPU permits, count in Int
+    */
   def permitsToCores(permits: Int): Float = permits.toFloat / unitScala
 }
 
@@ -31,7 +51,7 @@ private object NestedCPUSemaphoreUtils {
  * @param cpuCores
  * @tparam T
  */
-class NestedCPUSemaphore[T](cpuCores: Float) extends NestedSemaphore[T](NestedCPUSemaphoreUtils.coresToPermits(cpuCores)) {
+class NestedCPUSemaphore[T](cpuCores: Float) extends NestedSemaphore[T](CPULimitUtils.coresToPermits(cpuCores)) {
   final override def tryAcquireConcurrent(actionid: T, maxConcurrent: Int, permits: Int): Boolean = {
     super.tryAcquireConcurrent(actionid, maxConcurrent, permits)
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedCPUSemaphore.scala
@@ -18,28 +18,28 @@
 package org.apache.openwhisk.common
 
 /**
-  * A singleton object which defines the action's CPU limit properties.
-  */
+ * A singleton object which defines the action's CPU limit properties.
+ */
 object CPULimitUtils {
   // CPU threads transform to CPU permits, and calculate by CPU permits.
   private val unitScala = 100
 
   /**
-    * transform CPU threads to CPU permits for counting slots.
-    * @param cpuThreads CPU threads, count in Float
-    */
+   * transform CPU threads to CPU permits for counting slots.
+   * @param cpuThreads CPU threads, count in Float
+   */
   def threadsToPermits(cpuThreads: Float): Int = (cpuThreads * unitScala).toInt
 
   /**
-    * transform CPU threads to CPU permits for counting slots.
-    * @param cpuThreads CPU threads, count in Float
-    */
+   * transform CPU threads to CPU permits for counting slots.
+   * @param cpuThreads CPU threads, count in Float
+   */
   def threadsToPermits(cpuThreads: Double): Int = (cpuThreads * unitScala).toInt
 
   /**
-    * transform CPU permits to CPU threads for nice printing.
-    * @param permits CPU permits, count in Int
-    */
+   * transform CPU permits to CPU threads for nice printing.
+   * @param permits CPU permits, count in Int
+   */
   def permitsToThreads(permits: Int): Float = permits.toFloat / unitScala
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedMemorySemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedMemorySemaphore.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+/**
+ * A Semaphore that coordinates the memory (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
+ * - for invocations when maxConcurrent == 1, delegate to super
+ * - for invocations that cause acquire on memory slots, also acquire concurrency slots, and do it atomically
+ * @param memoryPermits
+ * @tparam T
+ */
+class NestedMemorySemaphore[T](memoryPermits: Int) extends NestedSemaphore[T](memoryPermits) {
+  final override def tryAcquireConcurrent(actionid: T, maxConcurrent: Int, memoryPermits: Int): Boolean = {
+    super.tryAcquireConcurrent(actionid, maxConcurrent, memoryPermits)
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
@@ -20,9 +20,9 @@ package org.apache.openwhisk.common
 import scala.collection.concurrent.TrieMap
 
 /**
- * A Semaphore that coordinates the resources (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
+ * A Semaphore that coordinates the resource (ForcibleSemaphore) and concurrency (ResizableSemaphore) where
  * - for invocations when maxConcurrent == 1, delegate to super
- * - for invocations that cause acquire on resources slots, also acquire concurrency slots, and do it atomically
+ * - for others, acquire resource slots and concurrency slots, do it atomically
  * @param permits (no matter what) permits count in Int
  * @tparam T
  */

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
@@ -53,12 +53,7 @@ class NestedSemaphore[T](permits: Int) extends ForcibleSemaphore(permits) {
    * @param force
    * @return
    */
-  private def tryOrForceAcquireConcurrent(
-    actionid:      T,
-    maxConcurrent: Int,
-    permits:       Int,
-    force:         Boolean
-  ): Boolean = {
+  private def tryOrForceAcquireConcurrent(actionid: T, maxConcurrent: Int, permits: Int, force: Boolean): Boolean = {
     val concurrentSlots = actionConcurrentSlotsMap
       .getOrElseUpdate(actionid, new ResizableSemaphore(0, maxConcurrent))
     if (concurrentSlots.tryAcquire(1)) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/ResizableSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/ResizableSemaphore.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.common
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.AbstractQueuedSynchronizer
+
 import scala.annotation.tailrec
 
 /**

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -36,13 +36,11 @@ import scala.util.Try
  * @param propertiesFile     a File object, the whisk.properties file, which if given contains the property values.
  * @param env                an optional environment to initialize from.
  */
-class WhiskConfig(
-  requiredProperties: Map[String, String],
-  optionalProperties: Set[String]         = Set.empty,
-  propertiesFile:     File                = null,
-  env:                Map[String, String] = sys.env
-)(implicit logging: Logging)
-  extends Config(requiredProperties, optionalProperties)(env) {
+class WhiskConfig(requiredProperties: Map[String, String],
+                  optionalProperties: Set[String] = Set.empty,
+                  propertiesFile: File = null,
+                  env: Map[String, String] = sys.env)(implicit logging: Logging)
+    extends Config(requiredProperties, optionalProperties)(env) {
 
   /**
    * Loads the properties as specified above.
@@ -65,9 +63,7 @@ class WhiskConfig(
 
   val wskApiHost: String = Try(
     normalize(
-      s"${this(WhiskConfig.wskApiProtocol)}://${this(WhiskConfig.wskApiHostname)}:${this(WhiskConfig.wskApiPort)}"
-    )
-  )
+      s"${this(WhiskConfig.wskApiProtocol)}://${this(WhiskConfig.wskApiHostname)}:${this(WhiskConfig.wskApiPort)}"))
     .getOrElse("")
 
   val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
@@ -123,10 +119,8 @@ object WhiskConfig {
    * Reads a Map of key-value pairs from the environment (sys.env) -- store them in the
    * mutable properties object.
    */
-  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(
-    implicit
-    logging: Logging
-  ) = {
+  def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(implicit
+                                                                                                   logging: Logging) = {
     if (file != null && file.exists) {
       logging.info(this, s"reading properties from file $file")
       val source = Source.fromFile(file)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -36,11 +36,13 @@ import scala.util.Try
  * @param propertiesFile     a File object, the whisk.properties file, which if given contains the property values.
  * @param env                an optional environment to initialize from.
  */
-class WhiskConfig(requiredProperties: Map[String, String],
-                  optionalProperties: Set[String] = Set.empty,
-                  propertiesFile: File = null,
-                  env: Map[String, String] = sys.env)(implicit logging: Logging)
-    extends Config(requiredProperties, optionalProperties)(env) {
+class WhiskConfig(
+  requiredProperties: Map[String, String],
+  optionalProperties: Set[String]         = Set.empty,
+  propertiesFile:     File                = null,
+  env:                Map[String, String] = sys.env
+)(implicit logging: Logging)
+  extends Config(requiredProperties, optionalProperties)(env) {
 
   /**
    * Loads the properties as specified above.
@@ -63,7 +65,9 @@ class WhiskConfig(requiredProperties: Map[String, String],
 
   val wskApiHost: String = Try(
     normalize(
-      s"${this(WhiskConfig.wskApiProtocol)}://${this(WhiskConfig.wskApiHostname)}:${this(WhiskConfig.wskApiPort)}"))
+      s"${this(WhiskConfig.wskApiProtocol)}://${this(WhiskConfig.wskApiHostname)}:${this(WhiskConfig.wskApiPort)}"
+    )
+  )
     .getOrElse("")
 
   val controllerBlackboxFraction = this.getAsDouble(WhiskConfig.controllerBlackboxFraction, 0.10)
@@ -120,7 +124,9 @@ object WhiskConfig {
    * mutable properties object.
    */
   def readPropertiesFromFile(properties: scala.collection.mutable.Map[String, String], file: File)(
-    implicit logging: Logging) = {
+    implicit
+    logging: Logging
+  ) = {
     if (file != null && file.exists) {
       logging.info(this, s"reading properties from file $file")
       val source = Source.fromFile(file)
@@ -206,6 +212,7 @@ object ConfigKeys {
   val kafkaTopics = s"$kafka.topics"
 
   val memory = "whisk.memory"
+  val cpu = "whisk.cpu"
   val timeLimit = "whisk.time-limit"
   val logLimit = "whisk.log-limit"
   val concurrencyLimit = "whisk.concurrency-limit"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -116,8 +116,8 @@ trait ContainerFactory {
   /**
    * Create a new Container, using CPU limit
    *
-   * The created container has to satisfy following requirements:
-   * - The container's file system is based on the provided action image and may have a read/write layer on top.
+   * The created container has following requirements:
+   * - The container's file system is based on the provided action image, and may have a read/write layer on top.
    *   Some managed action runtimes may need the capability to write files.
    * - If the specified image is not available on the system, it is pulled from an image
    *   repository - for example, Docker Hub.
@@ -143,7 +143,7 @@ trait ContainerFactory {
     memory:            ByteSize,
     cpuPermits:        Int,
     action:            Option[ExecutableWhiskAction]
-  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = Future.failed(new Exception("You should implement this function."))
+  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = Future.failed(new Exception("Method not implemented."))
 
   /** perform any initialization */
   def init(): Unit

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -26,14 +26,12 @@ import org.apache.openwhisk.spi.Spi
 import scala.concurrent.Future
 import scala.math.max
 
-case class ContainerArgsConfig(
-  network:      String,
-  dnsServers:   Seq[String]              = Seq.empty,
-  dnsSearch:    Seq[String]              = Seq.empty,
-  dnsOptions:   Seq[String]              = Seq.empty,
-  extraEnvVars: Seq[String]              = Seq.empty,
-  extraArgs:    Map[String, Set[String]] = Map.empty
-) {
+case class ContainerArgsConfig(network: String,
+                               dnsServers: Seq[String] = Seq.empty,
+                               dnsSearch: Seq[String] = Seq.empty,
+                               dnsOptions: Seq[String] = Seq.empty,
+                               extraEnvVars: Seq[String] = Seq.empty,
+                               extraArgs: Map[String, Set[String]] = Map.empty) {
 
   val extraEnvVarMap: Map[String, String] =
     extraEnvVars.flatMap {
@@ -48,8 +46,7 @@ case class ContainerArgsConfig(
 case class ContainerPoolConfig(userMemory: ByteSize, concurrentPeekFactor: Double, akkaClient: Boolean) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
-    s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor"
-  )
+    s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")
 
   /**
    * The shareFactor indicates the number of containers that would share a single core, on average.
@@ -93,25 +90,22 @@ trait ContainerFactory {
    *   In particular, action memory limits rely on the underlying container technology.
    */
   def createContainer(
-    tid:               TransactionId,
-    name:              String,
-    actionImage:       ExecManifest.ImageName,
+    tid: TransactionId,
+    name: String,
+    actionImage: ExecManifest.ImageName,
     userProvidedImage: Boolean,
-    memory:            ByteSize,
-    cpuShares:         Int,
-    action:            Option[ExecutableWhiskAction]
-  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
+    memory: ByteSize,
+    cpuShares: Int,
+    action: Option[ExecutableWhiskAction])(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
     createContainer(tid, name, actionImage, userProvidedImage, memory, cpuShares)
   }
 
-  def createContainer(
-    tid:               TransactionId,
-    name:              String,
-    actionImage:       ExecManifest.ImageName,
-    userProvidedImage: Boolean,
-    memory:            ByteSize,
-    cpuShares:         Int
-  )(implicit config: WhiskConfig, logging: Logging): Future[Container]
+  def createContainer(tid: TransactionId,
+                      name: String,
+                      actionImage: ExecManifest.ImageName,
+                      userProvidedImage: Boolean,
+                      memory: ByteSize,
+                      cpuShares: Int)(implicit config: WhiskConfig, logging: Logging): Future[Container]
 
   /**
    * Create a new Container, using CPU limit
@@ -136,14 +130,14 @@ trait ContainerFactory {
    * @param cpuPermits count in CPU permits, should be transform to CPU threads when creating container
    */
   def createCPUContainer(
-    tid:               TransactionId,
-    name:              String,
-    actionImage:       ExecManifest.ImageName,
+    tid: TransactionId,
+    name: String,
+    actionImage: ExecManifest.ImageName,
     userProvidedImage: Boolean,
-    memory:            ByteSize,
-    cpuPermits:        Int,
-    action:            Option[ExecutableWhiskAction]
-  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = Future.failed(new Exception("Method not implemented."))
+    memory: ByteSize,
+    cpuPermits: Int,
+    action: Option[ExecutableWhiskAction])(implicit config: WhiskConfig, logging: Logging): Future[Container] =
+    Future.failed(new Exception("Method not implemented."))
 
   /** perform any initialization */
   def init(): Unit
@@ -173,11 +167,9 @@ object ContainerFactory {
  * All impls should use the parameters specified as additional args to "docker run" commands
  */
 trait ContainerFactoryProvider extends Spi {
-  def instance(
-    actorSystem: ActorSystem,
-    logging:     Logging,
-    config:      WhiskConfig,
-    instance:    InvokerInstanceId,
-    parameters:  Map[String, Set[String]]
-  ): ContainerFactory
+  def instance(actorSystem: ActorSystem,
+               logging: Logging,
+               config: WhiskConfig,
+               instance: InvokerInstanceId,
+               parameters: Map[String, Set[String]]): ContainerFactory
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/NoopActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/NoopActivationStore.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.memory
+
+import java.time.Instant
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.apache.openwhisk.common.{Logging, TransactionId, WhiskInstants}
+import org.apache.openwhisk.core.database.{
+  ActivationStore,
+  ActivationStoreProvider,
+  CacheChangeNotification,
+  UserContext
+}
+import org.apache.openwhisk.core.entity.{ActivationId, DocInfo, EntityName, EntityPath, Subject, WhiskActivation}
+import spray.json.{JsNumber, JsObject}
+
+import scala.concurrent.Future
+
+object NoopActivationStore extends ActivationStore with WhiskInstants {
+  private val emptyInfo = DocInfo("foo")
+  private val emptyCount = JsObject("activations" -> JsNumber(0))
+  private val dummyActivation = WhiskActivation(
+    EntityPath("testnamespace"),
+    EntityName("activation"),
+    Subject(),
+    ActivationId.generate(),
+    start = Instant.now.inMills,
+    end = Instant.now.inMills)
+
+  override def store(activation: WhiskActivation, context: UserContext)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[DocInfo] = Future.successful(emptyInfo)
+
+  override def get(activationId: ActivationId, context: UserContext)(
+    implicit transid: TransactionId): Future[WhiskActivation] = {
+    val activation = dummyActivation.copy(activationId = activationId)
+    Future.successful(activation)
+  }
+
+  override def delete(activationId: ActivationId, context: UserContext)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[Boolean] = Future.successful(true)
+
+  override def countActivationsInNamespace(namespace: EntityPath,
+                                           name: Option[EntityPath],
+                                           skip: Int,
+                                           since: Option[Instant],
+                                           upto: Option[Instant],
+                                           context: UserContext)(implicit transid: TransactionId): Future[JsObject] =
+    Future.successful(emptyCount)
+
+  override def listActivationsMatchingName(
+    namespace: EntityPath,
+    name: EntityPath,
+    skip: Int,
+    limit: Int,
+    includeDocs: Boolean,
+    since: Option[Instant],
+    upto: Option[Instant],
+    context: UserContext)(implicit transid: TransactionId): Future[Either[List[JsObject], List[WhiskActivation]]] =
+    Future.successful(Right(List.empty))
+
+  override def listActivationsInNamespace(
+    namespace: EntityPath,
+    skip: Int,
+    limit: Int,
+    includeDocs: Boolean,
+    since: Option[Instant],
+    upto: Option[Instant],
+    context: UserContext)(implicit transid: TransactionId): Future[Either[List[JsObject], List[WhiskActivation]]] =
+    Future.successful(Right(List.empty))
+}
+
+object NoopActivationStoreProvider extends ActivationStoreProvider {
+  override def instance(actorSystem: ActorSystem, actorMaterializer: ActorMaterializer, logging: Logging) =
+    NoopActivationStore
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
@@ -35,9 +35,9 @@ case class CPULimitConfig(controlEnabled: Boolean, min: Float, max: Float, std: 
  * The constructor is private so that argument requirements are checked and normalized
  * before creating a new instance.
  *
- * @param cores the CPU utilisation limit in cores for the action
+ * @param threads the CPU utilisation limit in cpuThreads for the action
  */
-protected[entity] class CPULimit private (val cores: Float) extends AnyVal
+protected[entity] class CPULimit private (val threads: Float) extends AnyVal
 
 protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
   val config = loadConfigOrThrow[CPULimitConfig](ConfigKeys.cpu)
@@ -56,37 +56,37 @@ protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
   /**
    * Creates CPULimit for limit, iff limit is within permissible range.
    *
-   * @param  the limit in cpu cores, must be within permissible range
+   * @param  the limit in CPU threads, must be within permissible range
    * @return CPULimit with limit set
    * @throws IllegalArgumentException if limit does not conform to requirements
    */
   @throws[IllegalArgumentException]
-  protected[core] def apply(cores: Float): CPULimit = {
-    require(cores >= MIN_CPU, s"CPU $cores below allowed threshold of $MIN_CPU")
-    require(cores <= MAX_CPU, s"CPU $cores exceeds allowed threshold of $MAX_CPU")
-    new CPULimit(cores)
+  protected[core] def apply(threads: Float): CPULimit = {
+    require(threads >= MIN_CPU, s"CPU $threads below allowed threshold of $MIN_CPU")
+    require(threads <= MAX_CPU, s"CPU $threads exceeds allowed threshold of $MAX_CPU")
+    new CPULimit(threads)
   }
 
   /**
     * Creates CPULimit for limit, iff limit is within permissible range.
     *
-    * @param  the limit in cpu cores, must be within permissible range
+    * @param  the limit in CPU threads, must be within permissible range
     * @return CPULimit with limit set
     * @throws IllegalArgumentException if limit does not conform to requirements
     */
   @throws[IllegalArgumentException]
-  protected[core] def apply(cores: Double): CPULimit = {
-    apply(cores.toFloat)
+  protected[core] def apply(cpuThreads: Double): CPULimit = {
+    apply(cpuThreads.toFloat)
   }
 
   override protected[core] implicit val serdes = new RootJsonFormat[CPULimit] {
-    def write(c: CPULimit) = JsNumber(c.cores)
+    def write(c: CPULimit) = JsNumber(c.threads)
 
     def read(value: JsValue) =
       Try {
-        val JsNumber(cores) = value
-        require(cores.isExactFloat, "CPU limit must be float number")
-        CPULimit(cores.floatValue)
+        val JsNumber(cpuThreads) = value
+        require(cpuThreads.isDecimalDouble || cpuThreads.isDecimalFloat, "CPU limit must be float number")
+        CPULimit(cpuThreads.floatValue)
       } match {
         case Success(limit)                       => limit
         case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
@@ -31,8 +31,8 @@ case class CPULimitConfig(controlEnabled: Boolean, min: Float, max: Float, std: 
  * CPULimit encapsulates allowed CPU for an action. The limit must be within a
  * permissible range (by default [0.1, 1.0]).
  *
- * It is a value type (hence == is .equals, immutable and cannot be assigned null).
- * The constructor is private so that argument requirements are checked and normalized
+ * A value type (hence == is .equals, immutable and cannot be null).
+ * The constructor is private, for checking and normalizing argument
  * before creating a new instance.
  *
  * @param threads the CPU utilisation limit in cpuThreads for the action
@@ -42,7 +42,7 @@ protected[entity] class CPULimit private (val threads: Float) extends AnyVal
 protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
   val config = loadConfigOrThrow[CPULimitConfig](ConfigKeys.cpu)
 
-  /** These values are set once at the beginning. Dynamic configuration updates are not supported at the moment. */
+  /** static value */
   protected[core] val CPU_LIMIT_ENABLED: Boolean = config.controlEnabled
   protected[core] val MIN_CPU: Float = config.min
   protected[core] val MAX_CPU: Float = config.max

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.entity
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+import spray.json._
+import org.apache.openwhisk.core.ConfigKeys
+import pureconfig._
+
+case class CPULimitConfig(controlEnabled: Boolean, min: Float, max: Float, std: Float)
+
+/**
+ * CPULimit encapsulates allowed CPU for an action. The limit must be within a
+ * permissible range (by default [0.1, 1.0]).
+ *
+ * It is a value type (hence == is .equals, immutable and cannot be assigned null).
+ * The constructor is private so that argument requirements are checked and normalized
+ * before creating a new instance.
+ *
+ * @param cores the CPU utilisation limit in cores for the action
+ */
+protected[entity] class CPULimit private (val cores: Float) extends AnyVal
+
+protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
+  val config = loadConfigOrThrow[CPULimitConfig](ConfigKeys.cpu)
+
+  /** These values are set once at the beginning. Dynamic configuration updates are not supported at the moment. */
+  protected[core] val CPU_LIMIT_ENABLED: Boolean = config.controlEnabled
+  protected[core] val MIN_CPU: Float = config.min
+  protected[core] val MAX_CPU: Float = config.max
+  protected[core] val STD_CPU: Float = config.std
+
+  /** A singleton CPULimit with default value */
+  protected[core] val standardCPULimit = CPULimit(STD_CPU)
+
+  /** Gets CPULimit with default value */
+  protected[core] def apply(): CPULimit = standardCPULimit
+
+  /**
+   * Creates CPULimit for limit, iff limit is within permissible range.
+   *
+   * @param  the limit in megabytes, must be within permissible range
+   * @return CPULimit with limit set
+   * @throws IllegalArgumentException if limit does not conform to requirements
+   */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(cores: Float): CPULimit = {
+    require(cores >= MIN_CPU, s"CPU $cores below allowed threshold of $MIN_CPU")
+    require(cores <= MAX_CPU, s"CPU $cores exceeds allowed threshold of $MAX_CPU")
+    new CPULimit(cores)
+  }
+
+  override protected[core] implicit val serdes = new RootJsonFormat[CPULimit] {
+    def write(c: CPULimit) = JsNumber(c.cores)
+
+    def read(value: JsValue) =
+      Try {
+        val JsNumber(cores) = value
+        require(cores.isExactFloat, "CPU limit must be float number")
+        CPULimit(cores.floatValue)
+      } match {
+        case Success(limit)                       => limit
+        case Failure(e: IllegalArgumentException) => deserializationError(e.getMessage, e)
+        case Failure(e: Throwable)                => deserializationError("CPU limit malformed", e)
+      }
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
@@ -68,12 +68,12 @@ protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
   }
 
   /**
-    * Creates CPULimit for limit, iff limit is within permissible range.
-    *
-    * @param  the limit in CPU threads, must be within permissible range
-    * @return CPULimit with limit set
-    * @throws IllegalArgumentException if limit does not conform to requirements
-    */
+   * Creates CPULimit for limit, iff limit is within permissible range.
+   *
+   * @param  the limit in CPU threads, must be within permissible range
+   * @return CPULimit with limit set
+   * @throws IllegalArgumentException if limit does not conform to requirements
+   */
   @throws[IllegalArgumentException]
   protected[core] def apply(cpuThreads: Double): CPULimit = {
     apply(cpuThreads.toFloat)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/CPULimit.scala
@@ -51,13 +51,12 @@ protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
   /** A singleton CPULimit with default value */
   protected[core] val standardCPULimit = CPULimit(STD_CPU)
 
-  /** Gets CPULimit with default value */
   protected[core] def apply(): CPULimit = standardCPULimit
 
   /**
    * Creates CPULimit for limit, iff limit is within permissible range.
    *
-   * @param  the limit in megabytes, must be within permissible range
+   * @param  the limit in cpu cores, must be within permissible range
    * @return CPULimit with limit set
    * @throws IllegalArgumentException if limit does not conform to requirements
    */
@@ -66,6 +65,18 @@ protected[core] object CPULimit extends ArgNormalizer[CPULimit] {
     require(cores >= MIN_CPU, s"CPU $cores below allowed threshold of $MIN_CPU")
     require(cores <= MAX_CPU, s"CPU $cores exceeds allowed threshold of $MAX_CPU")
     new CPULimit(cores)
+  }
+
+  /**
+    * Creates CPULimit for limit, iff limit is within permissible range.
+    *
+    * @param  the limit in cpu cores, must be within permissible range
+    * @return CPULimit with limit set
+    * @throws IllegalArgumentException if limit does not conform to requirements
+    */
+  @throws[IllegalArgumentException]
+  protected[core] def apply(cores: Double): CPULimit = {
+    apply(cores.toFloat)
   }
 
   override protected[core] implicit val serdes = new RootJsonFormat[CPULimit] {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -135,7 +135,7 @@ protected[core] object ExecManifest {
    * @param count  the number of stemcell containers to create
    * @param memory the max memory this stemcell will allocate
    */
-  protected[entity] case class StemCell(count: Int, memory: ByteSize) {
+  protected[entity] case class StemCell(count: Int, memory: ByteSize, cpu: Float = CPULimit.STD_CPU) {
     require(count > 0, "count must be positive")
   }
 
@@ -343,7 +343,7 @@ protected[core] object ExecManifest {
 
   protected[entity] implicit val stemCellSerdes: RootJsonFormat[StemCell] = {
     import org.apache.openwhisk.core.entity.size.serdes
-    jsonFormat2(StemCell.apply)
+    jsonFormat3(StemCell.apply)
   }
 
   protected[entity] implicit val runtimeManifestSerdes: RootJsonFormat[RuntimeManifest] = jsonFormat8(RuntimeManifest)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -132,10 +132,12 @@ protected[core] object ExecManifest {
   /**
    * A stemcell configuration read from the manifest for a container image to be initialized by the container pool.
    *
+   * The CPU limit would use `whisk.cpu.std` config, in order to do as little modifications to current vendors.
+   *
    * @param count  the number of stemcell containers to create
    * @param memory the max memory this stemcell will allocate
    */
-  protected[entity] case class StemCell(count: Int, memory: ByteSize, cpu: Float = CPULimit.STD_CPU) {
+  protected[entity] case class StemCell(count: Int, memory: ByteSize) {
     require(count > 0, "count must be positive")
   }
 
@@ -343,7 +345,7 @@ protected[core] object ExecManifest {
 
   protected[entity] implicit val stemCellSerdes: RootJsonFormat[StemCell] = {
     import org.apache.openwhisk.core.entity.size.serdes
-    jsonFormat3(StemCell.apply)
+    jsonFormat2(StemCell.apply)
   }
 
   protected[entity] implicit val runtimeManifestSerdes: RootJsonFormat[RuntimeManifest] = jsonFormat8(RuntimeManifest)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
@@ -29,7 +29,7 @@ import org.apache.openwhisk.core.entity.ControllerInstanceId.MAX_NAME_LENGTH
  * @param displayedName an identifier that is required for the health protocol to correlate Kafka topics with invoker container names
  * @param userMemory an ByteSize value for user container pool memory limit. It would grep more CPU when you require
  *                   more userMemory, iff we not enable cpu limit.
- * @param cpuCores a numeric value used for reporting the invoker instance's CPU cores. Default
+ * @param cpuThreads a numeric value used for reporting the invoker instance's CPU threads. Default
   *                        is `1.0`. Could not be modified once set, since it's solidified.
  */
 case class InvokerInstanceId(
@@ -37,7 +37,7 @@ case class InvokerInstanceId(
   uniqueName:      Option[String] = None,
   displayedName:   Option[String] = None,
   val userMemory:  ByteSize,
-  val cpuCores: Float = CPULimit.MAX_CPU
+  val cpuThreads: Float = CPULimit.MAX_CPU
 ) {
   def toInt: Int = instance
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
@@ -30,15 +30,13 @@ import org.apache.openwhisk.core.entity.ControllerInstanceId.MAX_NAME_LENGTH
  * @param userMemory an ByteSize value for user container pool memory limit. It would grep more CPU when you require
  *                   more userMemory, iff we not enable cpu limit.
  * @param cpuThreads a numeric value used for reporting the invoker instance's CPU (logical) threads. Default
-  *                        is `1.0`.
+ *                        is `1.0`.
  */
-case class InvokerInstanceId(
-  val instance:    Int,
-  uniqueName:      Option[String] = None,
-  displayedName:   Option[String] = None,
-  val userMemory:  ByteSize,
-  val cpuThreads: Float = CPULimit.MAX_CPU
-) {
+case class InvokerInstanceId(val instance: Int,
+                             uniqueName: Option[String] = None,
+                             displayedName: Option[String] = None,
+                             val userMemory: ByteSize,
+                             val cpuThreads: Float = CPULimit.MAX_CPU) {
   def toInt: Int = instance
 
   override def toString: String = (Seq("invoker" + instance) ++ uniqueName ++ displayedName).mkString("/")
@@ -47,8 +45,7 @@ case class InvokerInstanceId(
 case class ControllerInstanceId(val asString: String) {
   require(
     asString.length <= MAX_NAME_LENGTH && asString.matches(LEGAL_CHARS),
-    "Controller instance id contains invalid characters"
-  )
+    "Controller instance id contains invalid characters")
 }
 
 object InvokerInstanceId extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
@@ -26,11 +26,11 @@ import org.apache.openwhisk.core.entity.ControllerInstanceId.MAX_NAME_LENGTH
  *
  * @param instance a numeric value used for the load balancing and Kafka topic creation
  * @param uniqueName an identifier required for dynamic instance assignment by Zookeeper
- * @param displayedName an identifier that is required for the health protocol to correlate Kafka topics with invoker container names
+ * @param displayedName an identifier required for the health protocol to correlate Kafka topics with invoker container names
  * @param userMemory an ByteSize value for user container pool memory limit. It would grep more CPU when you require
  *                   more userMemory, iff we not enable cpu limit.
- * @param cpuThreads a numeric value used for reporting the invoker instance's CPU threads. Default
-  *                        is `1.0`. Could not be modified once set, since it's solidified.
+ * @param cpuThreads a numeric value used for reporting the invoker instance's CPU (logical) threads. Default
+  *                        is `1.0`.
  */
 case class InvokerInstanceId(
   val instance:    Int,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
@@ -50,7 +50,8 @@ protected[entity] abstract class Limits {
 protected[core] case class ActionLimits(timeout: TimeLimit = TimeLimit(),
                                         memory: MemoryLimit = MemoryLimit(),
                                         logs: LogLimit = LogLimit(),
-                                        concurrency: ConcurrencyLimit = ConcurrencyLimit())
+                                        concurrency: ConcurrencyLimit = ConcurrencyLimit(),
+                                        cpu: CPULimit = CPULimit())
     extends Limits {
   override protected[entity] def toJson = ActionLimits.serdes.write(this)
 }
@@ -65,7 +66,7 @@ protected[core] case class TriggerLimits protected[core] () extends Limits {
 protected[core] object ActionLimits extends ArgNormalizer[ActionLimits] with DefaultJsonProtocol {
 
   override protected[core] implicit val serdes = new RootJsonFormat[ActionLimits] {
-    val helper = jsonFormat4(ActionLimits.apply)
+    val helper = jsonFormat5(ActionLimits.apply)
 
     def read(value: JsValue) = {
       val obj = Try {
@@ -76,8 +77,9 @@ protected[core] object ActionLimits extends ArgNormalizer[ActionLimits] with Def
       val memory = MemoryLimit.serdes.read(obj.get("memory") getOrElse deserializationError("'memory' is missing"))
       val logs = obj.get("logs") map { LogLimit.serdes.read(_) } getOrElse LogLimit()
       val concurrency = obj.get("concurrency") map { ConcurrencyLimit.serdes.read(_) } getOrElse ConcurrencyLimit()
+      val cpu = obj.get("cpu") map { CPULimit.serdes.read(_) } getOrElse CPULimit()
 
-      ActionLimits(time, memory, logs, concurrency)
+      ActionLimits(time, memory, logs, concurrency, cpu)
     }
 
     def write(a: ActionLimits) = helper.write(a)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import scala.util.Try
-import spray.json.{DefaultJsonProtocol, JsNumber, JsValue, RootJsonFormat, deserializationError}
+import spray.json.{deserializationError, DefaultJsonProtocol, JsNumber, JsValue, RootJsonFormat}
 
 /**
  * Abstract type for limits on triggers and actions. This may

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Limits.scala
@@ -18,10 +18,7 @@
 package org.apache.openwhisk.core.entity
 
 import scala.util.Try
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-import spray.json.deserializationError
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, JsNumber, JsValue, RootJsonFormat, deserializationError}
 
 /**
  * Abstract type for limits on triggers and actions. This may
@@ -77,7 +74,7 @@ protected[core] object ActionLimits extends ArgNormalizer[ActionLimits] with Def
       val memory = MemoryLimit.serdes.read(obj.get("memory") getOrElse deserializationError("'memory' is missing"))
       val logs = obj.get("logs") map { LogLimit.serdes.read(_) } getOrElse LogLimit()
       val concurrency = obj.get("concurrency") map { ConcurrencyLimit.serdes.read(_) } getOrElse ConcurrencyLimit()
-      val cpu = obj.get("cpu") map { CPULimit.serdes.read(_) } getOrElse CPULimit()
+      val cpu = CPULimit.serdes.read(obj.get("cpu") getOrElse JsNumber(CPULimit.STD_CPU))
 
       ActionLimits(time, memory, logs, concurrency, cpu)
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -42,7 +42,8 @@ import org.apache.openwhisk.core.entity.types.EntityStore
 case class ActionLimitsOption(timeout: Option[TimeLimit],
                               memory: Option[MemoryLimit],
                               logs: Option[LogLimit],
-                              concurrency: Option[ConcurrencyLimit])
+                              concurrency: Option[ConcurrencyLimit],
+                              cpu: Option[CPULimit])
 
 /**
  * WhiskActionPut is a restricted WhiskAction view that eschews properties
@@ -623,7 +624,7 @@ object WhiskActionMetaData
 }
 
 object ActionLimitsOption extends DefaultJsonProtocol {
-  implicit val serdes = jsonFormat4(ActionLimitsOption.apply)
+  implicit val serdes = jsonFormat5(ActionLimitsOption.apply)
 }
 
 object WhiskActionPut extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskAction.scala
@@ -364,7 +364,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
 
   // overriden to store attached code
   override def put[A >: WhiskAction](db: ArtifactStore[A], doc: WhiskAction, old: Option[WhiskAction])(
-    implicit transid: TransactionId,
+    implicit
+    transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
     def putWithAttachment(code: String, binary: Boolean, exec: AttachedCode) = {
@@ -470,7 +471,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
   }
 
   override def del[Wsuper >: WhiskAction](db: ArtifactStore[Wsuper], doc: DocInfo)(
-    implicit transid: TransactionId,
+    implicit
+    transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[Boolean] = {
     Try {
       require(db != null, "db undefined")
@@ -494,7 +496,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
    * If it's the actual package, use its name directly as the package path name.
    */
   def resolveAction(db: EntityStore, fullyQualifiedActionName: FullyQualifiedEntityName)(
-    implicit ec: ExecutionContext,
+    implicit
+    ec: ExecutionContext,
     transid: TransactionId): Future[FullyQualifiedEntityName] = {
     // first check that there is a package to be resolved
     val entityPath = fullyQualifiedActionName.path
@@ -519,7 +522,8 @@ object WhiskAction extends DocumentFactory[WhiskAction] with WhiskEntityQueries[
    * While traversing the package bindings, merge the parameters.
    */
   def resolveActionAndMergeParameters(entityStore: EntityStore, fullyQualifiedName: FullyQualifiedEntityName)(
-    implicit ec: ExecutionContext,
+    implicit
+    ec: ExecutionContext,
     transid: TransactionId): Future[WhiskAction] = {
     // first check that there is a package to be resolved
     val entityPath = fullyQualifiedName.path
@@ -571,7 +575,8 @@ object WhiskActionMetaData
    * If it's the actual package, use its name directly as the package path name.
    */
   def resolveAction(db: EntityStore, fullyQualifiedActionName: FullyQualifiedEntityName)(
-    implicit ec: ExecutionContext,
+    implicit
+    ec: ExecutionContext,
     transid: TransactionId): Future[FullyQualifiedEntityName] = {
     // first check that there is a package to be resolved
     val entityPath = fullyQualifiedActionName.path
@@ -596,7 +601,8 @@ object WhiskActionMetaData
    * While traversing the package bindings, merge the parameters.
    */
   def resolveActionAndMergeParameters(entityStore: EntityStore, fullyQualifiedName: FullyQualifiedEntityName)(
-    implicit ec: ExecutionContext,
+    implicit
+    ec: ExecutionContext,
     transid: TransactionId): Future[WhiskActionMetaData] = {
     // first check that there is a package to be resolved
     val entityPath = fullyQualifiedName.path

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1752,6 +1752,12 @@
           "format": "int32",
           "description": "number of concurrent activations allowed",
           "default": 1
+        },
+        "cpu": {
+          "type": "number",
+          "format": "float",
+          "description": "cpu in threads",
+          "default": 0.2
         }
       }
     },

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -212,9 +212,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
 
         onComplete(checkAdditionalPrivileges) {
           case Success(_) =>
-            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, () => {
-              make(user, entityName, request)
-            })
+            putEntity(WhiskAction, entityStore, entityName.toDocId, overwrite, update(user, request) _, make(user, entityName, request))
           case Failure(f) =>
             super.handleEntitlementFailure(f)
         }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -234,7 +234,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    * - 500 Internal Server Error
    */
   override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     parameter(
       'blocking ? false,
       'result ? false,
@@ -269,12 +271,14 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     }
   }
 
-  private def doInvoke(user: Identity,
-                       actionWithMergedParams: WhiskActionMetaData,
-                       payload: Option[JsObject],
-                       blocking: Boolean,
-                       waitOverride: FiniteDuration,
-                       result: Boolean)(implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+  private def doInvoke(
+    user:                   Identity,
+    actionWithMergedParams: WhiskActionMetaData,
+    payload:                Option[JsObject],
+    blocking:               Boolean,
+    waitOverride:           FiniteDuration,
+    result:                 Boolean
+  )(implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
     val waitForResponse = if (blocking) Some(waitOverride) else None
     onComplete(invokeAction(user, actionWithMergedParams, payload, waitForResponse, cause = None)) {
       case Success(Left(activationId)) =>
@@ -339,7 +343,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    * - 500 Internal Server Error
    */
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     parameter('code ? true) { code =>
       code match {
         case true =>
@@ -372,25 +378,28 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
     parameter(
       'skip.as[ListSkip] ? ListSkip(collection.defaultListSkip),
       'limit.as[ListLimit] ? ListLimit(collection.defaultListLimit),
-      'count ? false) { (skip, limit, count) =>
-      if (!count) {
-        listEntities {
-          WhiskAction.listCollectionInNamespace(entityStore, namespace, skip.n, limit.n, includeDocs = false) map {
-            list =>
-              list.fold((js) => js, (as) => as.map(WhiskAction.serdes.write(_)))
+      'count ? false
+    ) { (skip, limit, count) =>
+        if (!count) {
+          listEntities {
+            WhiskAction.listCollectionInNamespace(entityStore, namespace, skip.n, limit.n, includeDocs = false) map {
+              list =>
+                list.fold((js) => js, (as) => as.map(WhiskAction.serdes.write(_)))
+            }
+          }
+        } else {
+          countEntities {
+            WhiskAction.countCollectionInNamespace(entityStore, namespace, skip.n)
           }
         }
-      } else {
-        countEntities {
-          WhiskAction.countCollectionInNamespace(entityStore, namespace, skip.n)
-        }
       }
-    }
   }
 
   /** Replaces default namespaces in a vector of components from a sequence with appropriate namespace. */
-  private def resolveDefaultNamespace(components: Vector[FullyQualifiedEntityName],
-                                      user: Identity): Vector[FullyQualifiedEntityName] = {
+  private def resolveDefaultNamespace(
+    components: Vector[FullyQualifiedEntityName],
+    user:       Identity
+  ): Vector[FullyQualifiedEntityName] = {
     // if components are part of the default namespace, they contain `_`; replace it!
     val resolvedComponents = components map { c =>
       FullyQualifiedEntityName(c.path.resolveNamespace(user.namespace), c.name)
@@ -409,14 +418,18 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    * Creates a WhiskAction instance from the PUT request.
    */
   private def makeWhiskAction(content: WhiskActionPut, entityName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     val exec = content.exec.get
     val limits = content.limits map { l =>
       ActionLimits(
         l.timeout getOrElse TimeLimit(),
         l.memory getOrElse MemoryLimit(),
         l.logs getOrElse LogLimit(),
-        l.concurrency getOrElse ConcurrencyLimit())
+        l.concurrency getOrElse ConcurrencyLimit(),
+        l.cpu getOrElse CPULimit()
+      )
     } getOrElse ActionLimits()
     // This is temporary while we are making sequencing directly supported in the controller.
     // The parameter override allows this to work with Pipecode.code. Any parameters other
@@ -437,12 +450,15 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
       limits,
       content.version getOrElse SemVer(),
       content.publish getOrElse false,
-      WhiskActionsApi.amendAnnotations(content.annotations getOrElse Parameters(), exec))
+      WhiskActionsApi.amendAnnotations(content.annotations getOrElse Parameters(), exec)
+    )
   }
 
   /** For a sequence action, gather referenced entities and authorize access. */
   private def entitleReferencedEntities(user: Identity, right: Privilege, exec: Option[Exec])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     exec match {
       case Some(seq: SequenceExec) =>
         logging.debug(this, "checking if sequence components are accessible")
@@ -452,7 +468,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
   }
 
   private def entitleReferencedEntitiesMetaData(user: Identity, right: Privilege, exec: Option[ExecMetaDataBase])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     exec match {
       case Some(seq: SequenceExecMetaData) =>
         logging.info(this, "checking if sequence components are accessible")
@@ -463,7 +481,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
 
   /** Creates a WhiskAction from PUT content, generating default values where necessary. */
   private def make(user: Identity, entityName: FullyQualifiedEntityName, content: WhiskActionPut)(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId
+  ) = {
     content.exec map {
       case seq: SequenceExec =>
         // check that the sequence conforms to max length and no recursion rules
@@ -508,7 +528,9 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         l.timeout getOrElse action.limits.timeout,
         l.memory getOrElse action.limits.memory,
         l.logs getOrElse action.limits.logs,
-        l.concurrency getOrElse action.limits.concurrency)
+        l.concurrency getOrElse action.limits.concurrency,
+        l.cpu getOrElse action.limits.cpu
+      )
     } getOrElse action.limits
 
     // This is temporary while we are making sequencing directly supported in the controller.
@@ -552,7 +574,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
       limits,
       content.version getOrElse action.version.upPatch,
       content.publish getOrElse action.publish,
-      WhiskActionsApi.amendAnnotations(content.annotations getOrElse action.annotations, exec, create = false))
+      WhiskActionsApi.amendAnnotations(content.annotations getOrElse action.annotations, exec, create = false)
+    )
       .revision[WhiskAction](action.docinfo.rev)
   }
 
@@ -592,7 +615,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    */
   private def checkSequenceActionLimits(
     sequenceAction: FullyQualifiedEntityName,
-    components: Vector[FullyQualifiedEntityName])(implicit transid: TransactionId): Future[Unit] = {
+    components:     Vector[FullyQualifiedEntityName]
+  )(implicit transid: TransactionId): Future[Unit] = {
     // first checks that current sequence length is allowed
     // then traverses all actions in the sequence, inlining any that are sequences
     val future = if (components.size > actionSequenceLimit) {
@@ -632,7 +656,8 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
    */
   private def countAtomicActionsAndCheckCycle(
     origSequence: FullyQualifiedEntityName,
-    components: Vector[FullyQualifiedEntityName])(implicit transid: TransactionId): Future[Int] = {
+    components:   Vector[FullyQualifiedEntityName]
+  )(implicit transid: TransactionId): Future[Int] = {
     if (components.size > actionSequenceLimit) {
       Future.failed(TooManyActionsInSequence())
     } else {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
@@ -135,7 +135,8 @@ trait ReadOps extends Directives {
    */
   protected def getEntity[A <: DocumentRevisionProvider, Au >: A](entity: Future[A],
                                                                   postProcess: Option[PostProcessEntity[A]] = None)(
-    implicit transid: TransactionId,
+    implicit
+    transid: TransactionId,
     format: RootJsonFormat[A],
     ma: Manifest[A]) = {
     onComplete(entity) {
@@ -243,7 +244,8 @@ trait WriteOps extends Directives {
                                                                   create: => Future[A],
                                                                   treatExistsAsConflict: Boolean = true,
                                                                   postProcess: Option[PostProcessEntity[A]] = None)(
-    implicit transid: TransactionId,
+    implicit
+    transid: TransactionId,
     format: RootJsonFormat[A],
     notifier: Option[CacheChangeNotification],
     ma: Manifest[A]) = {
@@ -317,7 +319,8 @@ trait WriteOps extends Directives {
                                                           docid: DocId,
                                                           confirm: A => Future[Unit],
                                                           postProcess: Option[PostProcessEntity[A]] = None)(
-    implicit transid: TransactionId,
+    implicit
+    transid: TransactionId,
     format: RootJsonFormat[A],
     notifier: Option[CacheChangeNotification],
     ma: Manifest[A]) = {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
@@ -240,7 +240,7 @@ trait WriteOps extends Directives {
                                                                   docid: DocId,
                                                                   overwrite: Boolean,
                                                                   update: A => Future[A],
-                                                                  create: () => Future[A],
+                                                                  create: => Future[A],
                                                                   treatExistsAsConflict: Boolean = true,
                                                                   postProcess: Option[PostProcessEntity[A]] = None)(
     implicit transid: TransactionId,
@@ -263,7 +263,7 @@ trait WriteOps extends Directives {
     } recoverWith {
       case _: NoDocumentException =>
         logging.debug(this, s"[PUT] entity does not exist, will try to create it")
-        create().map(newDoc => (None, newDoc))
+        create.map(newDoc => (None, newDoc))
     } flatMap {
       case (old, a) =>
         logging.debug(this, s"[PUT] entity created/updated, writing back to datastore")

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -159,6 +159,7 @@ class Controller(val instance: ControllerInstanceId,
     whiskConfig,
     TimeLimit.config,
     MemoryLimit.config,
+    CPULimit.config,
     LogLimit.config,
     runtimes,
     List(apiV1.basepath()))
@@ -184,6 +185,7 @@ object Controller {
   private def info(config: WhiskConfig,
                    timeLimit: TimeLimitConfig,
                    memLimit: MemoryLimitConfig,
+                   cpuLimit: CPULimitConfig,
                    logLimit: MemoryLimitConfig,
                    runtimes: Runtimes,
                    apis: List[String]) =
@@ -202,6 +204,9 @@ object Controller {
         "max_action_duration" -> timeLimit.max.toMillis.toJson,
         "min_action_memory" -> memLimit.min.toBytes.toJson,
         "max_action_memory" -> memLimit.max.toBytes.toJson,
+        "cpu_limit_enabled" -> cpuLimit.controlEnabled.toJson,
+        "min_action_cpu" -> cpuLimit.min.toJson,
+        "max_action_cpu" -> cpuLimit.max.toJson,
         "min_action_logs" -> logLimit.min.toBytes.toJson,
         "max_action_logs" -> logLimit.max.toBytes.toJson),
       "runtimes" -> runtimes.toJson)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -106,7 +106,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    * - 405 Not Allowed
    */
   override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     logging.error(this, "activate is not permitted on packages")
     reject
   }
@@ -156,7 +157,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    * - 500 Internal Server Error
    */
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     getEntity(WhiskPackage.get(entityStore, entityName.toDocId), Some { mergePackageWithBinding() _ })
   }
 
@@ -216,7 +218,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    * If this is a binding, confirm the referenced package exists.
    */
   private def create(content: WhiskPackagePut, pkgName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[WhiskPackage] = {
+    implicit
+    transid: TransactionId): Future[WhiskPackage] = {
     val validateBinding = content.binding map { b =>
       checkBinding(b.fullyQualifiedName)
     } getOrElse Future.successful({})
@@ -237,8 +240,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
   }
 
   /** Updates a WhiskPackage from PUT content, merging old package/binding where necessary. */
-  private def update(content: WhiskPackagePut)(wp: WhiskPackage)(
-    implicit transid: TransactionId): Future[WhiskPackage] = {
+  private def update(content: WhiskPackagePut)(wp: WhiskPackage)(implicit
+                                                                 transid: TransactionId): Future[WhiskPackage] = {
     val validateBinding = content.binding map { binding =>
       wp.binding map {
         // pre-existing entity is a binding, check that new binding is valid
@@ -266,7 +269,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
   }
 
   private def rewriteEntitlementFailure(failure: Throwable)(
-    implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+    implicit
+    transid: TransactionId): RequestContext => Future[RouteResult] = {
     logging.debug(this, s"rewriting failure $failure")
     failure match {
       case RejectRequest(NotFound, _) => terminate(BadRequest, Messages.bindingDoesNotExist)
@@ -294,7 +298,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    * Otherwise this is a package, emit it.
    */
   private def mergePackageWithBinding(ref: Option[WhiskPackage] = None)(wp: WhiskPackage)(
-    implicit transid: TransactionId): RequestContext => Future[RouteResult] = {
+    implicit
+    transid: TransactionId): RequestContext => Future[RouteResult] = {
     wp.binding map {
       case b: Binding =>
         val docid = b.fullyQualifiedName.toDocId

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -88,7 +88,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
                 entityName.toDocId,
                 overwrite,
                 update(request) _,
-                () => create(request, entityName))
+                create(request, entityName))
             case Failure(f) =>
               rewriteEntitlementFailure(f)
           }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
@@ -128,7 +128,8 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
    * - 500 Internal Server Error
    */
   override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     extractStatusRequest { requestedState =>
       val docid = entityName.toDocId
 
@@ -226,7 +227,8 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
    * - 500 Internal Server Error
    */
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     getEntity(
       WhiskRule.get(entityStore, entityName.toDocId),
       Some { rule: WhiskRule =>
@@ -271,7 +273,8 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
 
   /** Creates a WhiskRule from PUT content, generating default values where necessary. */
   private def create(content: WhiskRulePut, ruleName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[WhiskRule] = {
+    implicit
+    transid: TransactionId): Future[WhiskRule] = {
     if (content.trigger.isDefined && content.action.isDefined) {
       val triggerName = content.trigger.get
       val actionName = content.action.get
@@ -362,7 +365,8 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
    * @return Status of the rule
    */
   private def getStatus(triggerOpt: Option[WhiskTrigger], ruleName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Status = {
+    implicit
+    transid: TransactionId): Status = {
     val statusFromTrigger = for {
       trigger <- triggerOpt
       rules <- trigger.rules
@@ -391,7 +395,8 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
    * @return future that completes with references trigger and action if they exist
    */
   private def checkTriggerAndActionExist(trigger: FullyQualifiedEntityName, action: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[(WhiskTrigger, WhiskActionMetaData)] = {
+    implicit
+    transid: TransactionId): Future[(WhiskTrigger, WhiskActionMetaData)] = {
 
     for {
       triggerExists <- WhiskTrigger.get(entityStore, trigger.toDocId) recoverWith {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Rules.scala
@@ -91,9 +91,7 @@ trait WhiskRulesApi extends WhiskCollectionAPI with ReferencedEntities {
               entityName.toDocId,
               overwrite,
               update(request) _,
-              () => {
-                create(request, entityName)
-              },
+              create(request, entityName),
               postProcess = Some { rule: WhiskRule =>
                 if (overwrite == true) {
                   val getRuleWithStatus = getTrigger(rule.trigger) map { trigger =>

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -115,9 +115,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
       entity(as[WhiskTriggerPut]) { content =>
-        putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, () => {
-          create(content, entityName)
-        }, postProcess = Some { trigger =>
+        putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, create(content, entityName),
+          postProcess = Some { trigger =>
           completeAsTriggerResponse(trigger)
         })
       }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -115,10 +115,16 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
   override def create(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
     parameter('overwrite ? false) { overwrite =>
       entity(as[WhiskTriggerPut]) { content =>
-        putEntity(WhiskTrigger, entityStore, entityName.toDocId, overwrite, update(content) _, create(content, entityName),
+        putEntity(
+          WhiskTrigger,
+          entityStore,
+          entityName.toDocId,
+          overwrite,
+          update(content) _,
+          create(content, entityName),
           postProcess = Some { trigger =>
-          completeAsTriggerResponse(trigger)
-        })
+            completeAsTriggerResponse(trigger)
+          })
       }
     }
   }
@@ -133,7 +139,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    * - 500 Internal Server Error
    */
   override def activate(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     extractRequest { request =>
       val context = UserContext(user, request)
 
@@ -214,7 +221,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    * - 500 Internal Server Error
    */
   override def fetch(user: Identity, entityName: FullyQualifiedEntityName, env: Option[Parameters])(
-    implicit transid: TransactionId) = {
+    implicit
+    transid: TransactionId) = {
     getEntity(WhiskTrigger.get(entityStore, entityName.toDocId), Some { trigger =>
       completeAsTriggerResponse(trigger)
     })
@@ -249,7 +257,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
 
   /** Creates a WhiskTrigger from PUT content, generating default values where necessary. */
   private def create(content: WhiskTriggerPut, triggerName: FullyQualifiedEntityName)(
-    implicit transid: TransactionId): Future[WhiskTrigger] = {
+    implicit
+    transid: TransactionId): Future[WhiskTrigger] = {
     val newTrigger = WhiskTrigger(
       triggerName.path,
       triggerName.name,
@@ -262,8 +271,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
   }
 
   /** Updates a WhiskTrigger from PUT content, merging old trigger where necessary. */
-  private def update(content: WhiskTriggerPut)(trigger: WhiskTrigger)(
-    implicit transid: TransactionId): Future[WhiskTrigger] = {
+  private def update(content: WhiskTriggerPut)(trigger: WhiskTrigger)(implicit
+                                                                      transid: TransactionId): Future[WhiskTrigger] = {
     val newTrigger = WhiskTrigger(
       trigger.namespace,
       trigger.name,
@@ -318,7 +327,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
   private def activateRules(user: Identity,
                             args: JsObject,
                             rulesToActivate: Map[FullyQualifiedEntityName, ReducedRule])(
-    implicit transid: TransactionId): Future[Iterable[RuleActivationResult]] = {
+    implicit
+    transid: TransactionId): Future[Iterable[RuleActivationResult]] = {
     val ruleResults = rulesToActivate.map {
       case (ruleName, rule) if (rule.status != Status.ACTIVE) =>
         Future.successful {
@@ -387,7 +397,8 @@ trait WhiskTriggersApi extends WhiskCollectionAPI {
    * @return a future with the HTTP response from the action activation
    */
   private def postActivation(user: Identity, rule: ReducedRule, args: JsObject)(
-    implicit transid: TransactionId): Future[HttpResponse] = {
+    implicit
+    transid: TransactionId): Future[HttpResponse] = {
     // Build the url to invoke an action mapped to the rule
     val actionUrl = baseControllerPath / rule.action.path.root.asString / "actions"
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -76,15 +76,14 @@ protected[actions] trait PrimitiveActions {
 
   /** A method that knows how to invoke a sequence of actions. */
   protected[actions] def invokeSequence(
-    user:                     Identity,
-    action:                   WhiskActionMetaData,
-    components:               Vector[FullyQualifiedEntityName],
-    payload:                  Option[JsObject],
+    user: Identity,
+    action: WhiskActionMetaData,
+    components: Vector[FullyQualifiedEntityName],
+    payload: Option[JsObject],
     waitForOutermostResponse: Option[FiniteDuration],
-    cause:                    Option[ActivationId],
-    topmost:                  Boolean,
-    atomicActionsCount:       Int
-  )(implicit transid: TransactionId): Future[(Either[ActivationId, WhiskActivation], Int)]
+    cause: Option[ActivationId],
+    topmost: Boolean,
+    atomicActionsCount: Int)(implicit transid: TransactionId): Future[(Either[ActivationId, WhiskActivation], Int)]
 
   /**
    * A method that knows how to invoke a single primitive action or a composition.
@@ -107,12 +106,11 @@ protected[actions] trait PrimitiveActions {
    * The activation record for a composition also includes a specific annotation "conductor" with value true.
    */
   protected[actions] def invokeSingleAction(
-    user:            Identity,
-    action:          ExecutableWhiskActionMetaData,
-    payload:         Option[JsObject],
+    user: Identity,
+    action: ExecutableWhiskActionMetaData,
+    payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
-    cause:           Option[ActivationId]
-  )(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
 
     if (action.annotations.isTruthy(WhiskActivation.conductorAnnotation)) {
       invokeComposition(user, action, payload, waitForResponse, cause)
@@ -151,12 +149,11 @@ protected[actions] trait PrimitiveActions {
    *            RequestEntityTooLarge if the message is too large to to post to the message bus
    */
   private def invokeSimpleAction(
-    user:            Identity,
-    action:          ExecutableWhiskActionMetaData,
-    payload:         Option[JsObject],
+    user: Identity,
+    action: ExecutableWhiskActionMetaData,
+    payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
-    cause:           Option[ActivationId]
-  )(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
+    cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
 
     // merge package parameters with action (action parameters supersede), then merge in payload
     val args = action.parameters merge payload
@@ -167,8 +164,7 @@ protected[actions] trait PrimitiveActions {
       waitForResponse
         .map(_ => LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING)
         .getOrElse(LoggingMarkers.CONTROLLER_ACTIVATION),
-      logLevel = InfoLevel
-    )
+      logLevel = InfoLevel)
     val startLoadbalancer =
       transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${activationId}")
 
@@ -183,8 +179,7 @@ protected[actions] trait PrimitiveActions {
       args,
       action.parameters.initParameters,
       cause = cause,
-      WhiskTracerProvider.tracer.getTraceContext(transid)
-    )
+      WhiskTracerProvider.tracer.getTraceContext(transid))
 
     val postedFuture = loadBalancer.publish(action, message)
 
@@ -244,17 +239,15 @@ protected[actions] trait PrimitiveActions {
    * @param logs a mutable buffer that is appended with new activation ids as the composition unfolds
    *             (in contrast with sequences, the logs of a hierarchy of compositions is not flattened)
    */
-  private case class Session(
-    activationId:  ActivationId,
-    start:         Instant,
-    action:        ExecutableWhiskActionMetaData,
-    cause:         Option[ActivationId],
-    var duration:  Long,
-    var maxMemory: ByteSize,
-    var state:     Option[JsObject],
-    accounting:    CompositionAccounting,
-    logs:          Buffer[ActivationId]
-  )
+  private case class Session(activationId: ActivationId,
+                             start: Instant,
+                             action: ExecutableWhiskActionMetaData,
+                             cause: Option[ActivationId],
+                             var duration: Long,
+                             var maxMemory: ByteSize,
+                             var state: Option[JsObject],
+                             accounting: CompositionAccounting,
+                             logs: Buffer[ActivationId])
 
   /**
    * A method that knows how to invoke a composition.
@@ -274,17 +267,14 @@ protected[actions] trait PrimitiveActions {
    *            Right(WhiskActivation) if waiting for a response and response is ready within allowed duration,
    *            Left(ActivationId) if not waiting for a response, or allowed duration has elapsed without a result ready
    */
-  private def invokeComposition(
-    user:            Identity,
-    action:          ExecutableWhiskActionMetaData,
-    payload:         Option[JsObject],
-    waitForResponse: Option[FiniteDuration],
-    cause:           Option[ActivationId],
-    accounting:      Option[CompositionAccounting] = None
-  )(
+  private def invokeComposition(user: Identity,
+                                action: ExecutableWhiskActionMetaData,
+                                payload: Option[JsObject],
+                                waitForResponse: Option[FiniteDuration],
+                                cause: Option[ActivationId],
+                                accounting: Option[CompositionAccounting] = None)(
     implicit
-    transid: TransactionId
-  ): Future[Either[ActivationId, WhiskActivation]] = {
+    transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
 
     val session = Session(
       activationId = activationIdFactory.make(),
@@ -295,8 +285,7 @@ protected[actions] trait PrimitiveActions {
       maxMemory = action.limits.memory.megabytes MB,
       state = None,
       accounting = accounting.getOrElse(CompositionAccounting()), // share accounting with caller
-      logs = Buffer.empty
-    )
+      logs = Buffer.empty)
 
     logging.info(this, s"invoking composition $action topmost ${cause.isEmpty} activationid '${session.activationId}'")
 
@@ -308,12 +297,10 @@ protected[actions] trait PrimitiveActions {
       .map(_ => response) // ignore waitForResponse when not topmost
       .orElse(
         // blocking invoke, wait until timeout
-        waitForResponse.map(response.withAlternativeAfterTimeout(_, Future.successful(Left(session.activationId))))
-      )
+        waitForResponse.map(response.withAlternativeAfterTimeout(_, Future.successful(Left(session.activationId)))))
       .getOrElse(
         // no, return the session id
-        Future.successful(Left(session.activationId))
-      )
+        Future.successful(Left(session.activationId)))
   }
 
   /**
@@ -331,8 +318,7 @@ protected[actions] trait PrimitiveActions {
    */
   private def invokeConductor(user: Identity, payload: Option[JsObject], session: Session)(
     implicit
-    transid: TransactionId
-  ): Future[ActivationResponse] = {
+    transid: TransactionId): Future[ActivationResponse] = {
 
     if (session.accounting.conductors > 2 * actionSequenceLimit) {
       // composition is too long
@@ -351,8 +337,7 @@ protected[actions] trait PrimitiveActions {
           action = session.action,
           payload = params,
           waitForResponse = Some(session.action.limits.timeout.duration + 1.minute), // wait for result
-          cause = Some(session.activationId)
-        ) // cause is session id
+          cause = Some(session.activationId)) // cause is session id
 
       waitForActivation(user, session, activationResponse).flatMap {
         case Left(response) => // unsuccessful invocation, return error response
@@ -386,15 +371,13 @@ protected[actions] trait PrimitiveActions {
                   invokeConductor(
                     user,
                     payload = Some(JsObject(ERROR_FIELD -> JsString(compositionIsTooLong))),
-                    session = session
-                  )
+                    session = session)
 
                 case None => // parsing failure
                   invokeConductor(
                     user,
                     payload = Some(JsObject(ERROR_FIELD -> JsString(compositionComponentInvalid(next)))),
-                    session = session
-                  )
+                    session = session)
 
               }
           }
@@ -414,8 +397,7 @@ protected[actions] trait PrimitiveActions {
    */
   private def tryInvokeNext(user: Identity, fqn: FullyQualifiedEntityName, params: Option[JsObject], session: Session)(
     implicit
-    transid: TransactionId
-  ): Future[ActivationResponse] = {
+    transid: TransactionId): Future[ActivationResponse] = {
     val resource = Resource(fqn.path, Collection(Collection.ACTIONS), Some(fqn.name.asString))
     entitlementProvider
       .check(user, Privilege.ACTIVATE, Set(resource), noThrottle = true)
@@ -434,8 +416,7 @@ protected[actions] trait PrimitiveActions {
               invokeConductor(
                 user,
                 payload = Some(JsObject(ERROR_FIELD -> JsString(compositionComponentNotFound(fqn.asString)))),
-                session = session
-              )
+                session = session)
           }
       }
       .recoverWith {
@@ -444,8 +425,7 @@ protected[actions] trait PrimitiveActions {
           invokeConductor(
             user,
             payload = Some(JsObject(ERROR_FIELD -> JsString(compositionComponentNotAccessible(fqn.asString)))),
-            session = session
-          )
+            session = session)
       }
   }
 
@@ -463,8 +443,7 @@ protected[actions] trait PrimitiveActions {
    */
   private def invokeComponent(user: Identity, action: WhiskActionMetaData, payload: Option[JsObject], session: Session)(
     implicit
-    transid: TransactionId
-  ): Future[ActivationResponse] = {
+    transid: TransactionId): Future[ActivationResponse] = {
 
     val exec = action.toExecutableWhiskAction
     val activationResponse: Future[Either[ActivationId, WhiskActivation]] = exec match {
@@ -476,8 +455,7 @@ protected[actions] trait PrimitiveActions {
           payload,
           waitForResponse = None, // not topmost, hence blocking, no need for timeout
           cause = Some(session.activationId),
-          accounting = Some(session.accounting)
-        )
+          accounting = Some(session.accounting))
       case Some(action) => // primitive action
         session.accounting.components += 1
         invokeSimpleAction(
@@ -485,8 +463,7 @@ protected[actions] trait PrimitiveActions {
           action,
           payload,
           waitForResponse = Some(action.limits.timeout.duration + 1.minute),
-          cause = Some(session.activationId)
-        )
+          cause = Some(session.activationId))
       case None => // sequence
         session.accounting.components += 1
         val SequenceExecMetaData(components) = action.exec
@@ -498,8 +475,7 @@ protected[actions] trait PrimitiveActions {
           waitForOutermostResponse = None,
           cause = Some(session.activationId),
           topmost = false,
-          atomicActionsCount = 0
-        ).map(r => r._1)
+          atomicActionsCount = 0).map(r => r._1)
     }
 
     waitForActivation(user, session, activationResponse).flatMap {
@@ -521,14 +497,11 @@ protected[actions] trait PrimitiveActions {
    * @param activationResponse the future activation to wait on
    * @param transid a transaction id for logging
    */
-  private def waitForActivation(
-    user:               Identity,
-    session:            Session,
-    activationResponse: Future[Either[ActivationId, WhiskActivation]]
-  )(
+  private def waitForActivation(user: Identity,
+                                session: Session,
+                                activationResponse: Future[Either[ActivationId, WhiskActivation]])(
     implicit
-    transid: TransactionId
-  ): Future[Either[ActivationResponse, WhiskActivation]] = {
+    transid: TransactionId): Future[Either[ActivationResponse, WhiskActivation]] = {
 
     activationResponse
       .map {
@@ -559,18 +532,18 @@ protected[actions] trait PrimitiveActions {
    */
   private def completeActivation(user: Identity, session: Session, response: ActivationResponse)(
     implicit
-    transid: TransactionId
-  ): WhiskActivation = {
+    transid: TransactionId): WhiskActivation = {
 
     val context = UserContext(user)
 
     // compute max memory
     val sequenceLimits = Parameters(
       WhiskActivation.limitsAnnotation,
-      ActionLimits(session.action.limits.timeout, MemoryLimit(session.maxMemory), session.action.limits.logs,
-        cpu = session.action.limits.cpu)
-        .toJson
-    )
+      ActionLimits(
+        session.action.limits.timeout,
+        MemoryLimit(session.maxMemory),
+        session.action.limits.logs,
+        cpu = session.action.limits.cpu).toJson)
 
     // set causedBy if not topmost
     val causedBy = session.cause.map { _ =>
@@ -602,8 +575,7 @@ protected[actions] trait PrimitiveActions {
         Parameters(WhiskActivation.conductorAnnotation, JsTrue) ++
         causedBy ++ binding ++
         sequenceLimits,
-      duration = Some(session.duration)
-    )
+      duration = Some(session.duration))
 
     if (UserEvents.enabled) {
       EventMessage.from(activation, s"controller${activeAckTopicIndex.asString}", user.namespace.uuid) match {
@@ -626,15 +598,12 @@ protected[actions] trait PrimitiveActions {
    * which could happen if the connection from an invoker to the message bus is disrupted, or if the publishing of the response
    * fails because the message is too large.
    */
-  private def waitForActivationResponse(
-    user:              Identity,
-    activationId:      ActivationId,
-    totalWaitTime:     FiniteDuration,
-    activeAckResponse: Future[Either[ActivationId, WhiskActivation]]
-  )(
+  private def waitForActivationResponse(user: Identity,
+                                        activationId: ActivationId,
+                                        totalWaitTime: FiniteDuration,
+                                        activeAckResponse: Future[Either[ActivationId, WhiskActivation]])(
     implicit
-    transid: TransactionId
-  ): Future[Either[ActivationId, WhiskActivation]] = {
+    transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     val context = UserContext(user)
     val result = Promise[Either[ActivationId, WhiskActivation]]
     val docid = new DocId(WhiskEntity.qualifiedName(user.namespace.name.toPath, activationId))
@@ -672,14 +641,12 @@ protected[actions] trait PrimitiveActions {
    * @param docid the docid to poll for
    * @param result promise to resolve on result. Is also used to abort polling once completed.
    */
-  private def pollActivation(
-    docid:      DocId,
-    context:    UserContext,
-    result:     Promise[Either[ActivationId, WhiskActivation]],
-    wait:       Int => FiniteDuration,
-    retries:    Int                                            = 0,
-    maxRetries: Int                                            = Int.MaxValue
-  )(implicit transid: TransactionId): Unit = {
+  private def pollActivation(docid: DocId,
+                             context: UserContext,
+                             result: Promise[Either[ActivationId, WhiskActivation]],
+                             wait: Int => FiniteDuration,
+                             retries: Int = 0,
+                             maxRetries: Int = Int.MaxValue)(implicit transid: TransactionId): Unit = {
     if (!result.isCompleted && retries < maxRetries) {
       val schedule = actorSystem.scheduler.scheduleOnce(wait(retries)) {
         activationStore.get(ActivationId(docid.asString), context).onComplete {
@@ -688,8 +655,7 @@ protected[actions] trait PrimitiveActions {
               this,
               LoggingMarkers.CONTROLLER_ACTIVATION_BLOCKING_DATABASE_RETRIEVAL,
               s"retrieved activation for blocking invocation via DB polling",
-              logLevel = InfoLevel
-            )
+              logLevel = InfoLevel)
             result.trySuccess(Right(activation.withoutLogs))
           case Failure(_: NoDocumentException) => pollActivation(docid, context, result, wait, retries + 1, maxRetries)
           case Failure(t: Throwable)           => result.tryFailure(t)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/SequenceActions.scala
@@ -154,7 +154,8 @@ protected[actions] trait SequenceActions {
                                          topmost: Boolean,
                                          start: Instant,
                                          cause: Option[ActivationId])(
-    implicit transid: TransactionId): Future[(Right[ActivationId, WhiskActivation], Int)] = {
+    implicit
+    transid: TransactionId): Future[(Right[ActivationId, WhiskActivation], Int)] = {
     val context = UserContext(user)
 
     // not topmost, no need to worry about terminating incoming request
@@ -199,9 +200,11 @@ protected[actions] trait SequenceActions {
     val sequenceLimits = accounting.maxMemory map { maxMemoryAcrossActionsInSequence =>
       Parameters(
         WhiskActivation.limitsAnnotation,
-        ActionLimits(action.limits.timeout, MemoryLimit(maxMemoryAcrossActionsInSequence MB), action.limits.logs,
-          cpu = action.limits.cpu)
-          .toJson)
+        ActionLimits(
+          action.limits.timeout,
+          MemoryLimit(maxMemoryAcrossActionsInSequence MB),
+          action.limits.logs,
+          cpu = action.limits.cpu).toJson)
     }
 
     // set causedBy if not topmost sequence

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/SequenceActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/SequenceActions.scala
@@ -199,7 +199,9 @@ protected[actions] trait SequenceActions {
     val sequenceLimits = accounting.maxMemory map { maxMemoryAcrossActionsInSequence =>
       Parameters(
         WhiskActivation.limitsAnnotation,
-        ActionLimits(action.limits.timeout, MemoryLimit(maxMemoryAcrossActionsInSequence MB), action.limits.logs).toJson)
+        ActionLimits(action.limits.timeout, MemoryLimit(maxMemoryAcrossActionsInSequence MB), action.limits.logs,
+          cpu = action.limits.cpu)
+          .toJson)
     }
 
     // set causedBy if not topmost sequence

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -163,6 +163,7 @@ abstract class CommonLoadBalancer(
         msg.activationId,
         msg.user.namespace.uuid,
         instance,
+        action.limits.cpu.cores,
         action.limits.memory.megabytes.MB,
         action.limits.timeout.duration,
         action.limits.concurrency.maxConcurrent,
@@ -290,6 +291,7 @@ abstract class CommonLoadBalancer(
       }
     }
 
+    // TODO: Need to do something when enabled CPU limits
     activationSlots.remove(aid) match {
       case Some(entry) =>
         totalActivations.decrement()
@@ -378,6 +380,7 @@ case class ContainerPoolBalancerConfig(managedFraction: Double, blackboxFraction
  * @param id id of the activation
  * @param namespaceId namespace that invoked the action
  * @param invokerName invoker the action is scheduled to
+ * @param cpuLimit CPU limit of the invoked action
  * @param memoryLimit memory limit of the invoked action
  * @param timeLimit time limit of the invoked action
  * @param maxConcurrent concurrency limit of the invoked action
@@ -390,6 +393,7 @@ case class ActivationEntry(
   id:                       ActivationId,
   namespaceId:              UUID,
   invokerName:              InvokerInstanceId,
+  cpuLimit:                 Float,
   memoryLimit:              ByteSize,
   timeLimit:                FiniteDuration,
   maxConcurrent:            Int,

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -54,8 +54,8 @@ abstract class CommonLoadBalancer(
 
   protected implicit val executionContext: ExecutionContext = actorSystem.dispatcher
 
-  val lbConfig: ShardingContainerPoolBalancerConfig =
-    loadConfigOrThrow[ShardingContainerPoolBalancerConfig](ConfigKeys.loadbalancer)
+  val lbConfig: ContainerPoolBalancerConfig =
+    loadConfigOrThrow[ContainerPoolBalancerConfig](ConfigKeys.loadbalancer)
   protected val invokerPool: ActorRef
 
   /** State related to invocations and throttling */
@@ -363,6 +363,14 @@ abstract class CommonLoadBalancer(
     }
   }
 }
+
+/**
+ * Configuration for the container pool balancer.
+ *
+ * @param blackboxFraction the fraction of all invokers to use exclusively for blackboxes
+ * @param timeoutFactor factor to influence the timeout period for forced active acks (time-limit.std * timeoutFactor + 1m)
+ */
+case class ContainerPoolBalancerConfig(managedFraction: Double, blackboxFraction: Double, timeoutFactor: Int)
 
 /**
  * State kept for each activation slot until completion.

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorRef
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.LongAdder
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorSystem, Cancellable}
 import akka.event.Logging.InfoLevel
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata
@@ -363,3 +363,30 @@ abstract class CommonLoadBalancer(
     }
   }
 }
+
+/**
+ * State kept for each activation slot until completion.
+ *
+ * @param id id of the activation
+ * @param namespaceId namespace that invoked the action
+ * @param invokerName invoker the action is scheduled to
+ * @param memoryLimit memory limit of the invoked action
+ * @param timeLimit time limit of the invoked action
+ * @param maxConcurrent concurrency limit of the invoked action
+ * @param fullyQualifiedEntityName fully qualified name of the invoked action
+ * @param timeoutHandler times out completion of this activation, should be canceled on good paths
+ * @param isBlackbox true if the invoked action is a blackbox action, otherwise false (managed action)
+ * @param isBlocking true if the action is invoked in a blocking fashion, i.e. "somebody" waits for the result
+ */
+case class ActivationEntry(
+  id:                       ActivationId,
+  namespaceId:              UUID,
+  invokerName:              InvokerInstanceId,
+  memoryLimit:              ByteSize,
+  timeLimit:                FiniteDuration,
+  maxConcurrent:            Int,
+  fullyQualifiedEntityName: FullyQualifiedEntityName,
+  timeoutHandler:           Cancellable,
+  isBlackbox:               Boolean,
+  isBlocking:               Boolean
+)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -161,7 +161,7 @@ abstract class CommonLoadBalancer(
         msg.activationId,
         msg.user.namespace.uuid,
         instance,
-        action.limits.cpu.cores,
+        action.limits.cpu.threads,
         action.limits.memory.megabytes.MB,
         action.limits.timeout.duration,
         action.limits.concurrency.maxConcurrent,
@@ -317,7 +317,7 @@ abstract class CommonLoadBalancer(
           logging.warn(
             this,
             if (cpuLimitConfig.controlEnabled) {
-              s"forced completion ack for '$aid', action '${entry.fullyQualifiedEntityName}' ($actionType), $blockingType, cpu limit ${entry.cpuLimit} cores, mem limit ${entry.memoryLimit.toMB} MB, time limit ${entry.timeLimit.toMillis} ms, completion ack timeout $completionAckTimeout from $invoker"
+              s"forced completion ack for '$aid', action '${entry.fullyQualifiedEntityName}' ($actionType), $blockingType, cpu limit ${entry.cpuLimit} cpuThreads, mem limit ${entry.memoryLimit.toMB} MB, time limit ${entry.timeLimit.toMillis} ms, completion ack timeout $completionAckTimeout from $invoker"
             } else {
               s"forced completion ack for '$aid', action '${entry.fullyQualifiedEntityName}' ($actionType), $blockingType, mem limit ${entry.memoryLimit.toMB} MB, time limit ${entry.timeLimit.toMillis} ms, completion ack timeout $completionAckTimeout from $invoker"
             }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -97,13 +97,11 @@ final case class InvokerInfo(buffer: RingBuffer[InvocationFinishedResult])
  * Note: An Invoker that never sends an initial Ping will not be considered
  * by the InvokerPool and thus might not be caught by monitoring.
  */
-class InvokerPool(
-  childFactory:            (ActorRefFactory, InvokerInstanceId) => ActorRef,
-  sendActivationToInvoker: (ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
-  pingConsumer:            MessageConsumer,
-  monitor:                 Option[ActorRef]
-)
-  extends Actor {
+class InvokerPool(childFactory: (ActorRefFactory, InvokerInstanceId) => ActorRef,
+                  sendActivationToInvoker: (ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
+                  pingConsumer: MessageConsumer,
+                  monitor: Option[ActorRef])
+    extends Actor {
 
   import InvokerState._
 
@@ -170,8 +168,7 @@ class InvokerPool(
       pingConsumer.maxPeek,
       pingPollDuration,
       processInvokerPing,
-      logHandoff = false
-    )
+      logHandoff = false)
   })
 
   def processInvokerPing(bytes: Array[Byte]): Future[Unit] = Future {
@@ -199,11 +196,10 @@ class InvokerPool(
     status = padToIndexed(
       status,
       instanceId.toInt + 1,
-      i => new InvokerHealth(
-        InvokerInstanceId(i, userMemory = instanceId.userMemory, cpuThreads = instanceId.cpuThreads),
-        Offline
-      )
-    )
+      i =>
+        new InvokerHealth(
+          InvokerInstanceId(i, userMemory = instanceId.userMemory, cpuThreads = instanceId.cpuThreads),
+          Offline))
     status = status.updated(instanceId.toInt, new InvokerHealth(instanceId, Offline))
 
     val ref = childFactory(context, instanceId)
@@ -212,7 +208,6 @@ class InvokerPool(
 
     ref
   }
-
 }
 
 object InvokerPool {
@@ -254,17 +249,14 @@ object InvokerPool {
       }
       .orElse {
         throw new IllegalStateException(
-          "cannot create test action for invoker health because runtime manifest is not valid"
-        )
+          "cannot create test action for invoker health because runtime manifest is not valid")
       }
   }
 
-  def props(
-    f:  (ActorRefFactory, InvokerInstanceId) => ActorRef,
-    p:  (ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
-    pc: MessageConsumer,
-    m:  Option[ActorRef]                                                 = None
-  ): Props = {
+  def props(f: (ActorRefFactory, InvokerInstanceId) => ActorRef,
+            p: (ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
+            pc: MessageConsumer,
+            m: Option[ActorRef] = None): Props = {
     Props(new InvokerPool(f, p, pc, m))
   }
 
@@ -282,8 +274,7 @@ object InvokerPool {
         namespace = healthActionIdentity.namespace.name.toPath,
         name = EntityName(s"invokerHealthTestAction${i.asString}"),
         exec = CodeExecAsString(manifest, """function main(params) { return params; }""", None),
-        limits = ActionLimits(memory = MemoryLimit(MemoryLimit.MIN_MEMORY), cpu = CPULimit(CPULimit.MIN_CPU))
-      )
+        limits = ActionLimits(memory = MemoryLimit(MemoryLimit.MIN_MEMORY), cpu = CPULimit(CPULimit.MIN_CPU)))
     }
 }
 
@@ -294,7 +285,7 @@ object InvokerPool {
  * states "Healthy" and "Offline".
  */
 class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: ControllerInstanceId)
-  extends FSM[InvokerState, InvokerInfo] {
+    extends FSM[InvokerState, InvokerInfo] {
 
   import InvokerState._
 
@@ -355,8 +346,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
         this,
         LoggingMarkers.LOADBALANCER_INVOKER_STATUS_CHANGE(newState.asString),
         s"$name is ${newState.asString}",
-        akka.event.Logging.WarningLevel
-      )
+        akka.event.Logging.WarningLevel)
     case _ -> newState if newState.isUsable => logging.info(this, s"$name is ${newState.asString}")
   }
 
@@ -380,10 +370,8 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
    * @param result: result of Activation
    * @param buffer to be used
    */
-  private def handleCompletionMessage(
-    result: InvocationFinishedResult,
-    buffer: RingBuffer[InvocationFinishedResult]
-  ) = {
+  private def handleCompletionMessage(result: InvocationFinishedResult,
+                                      buffer: RingBuffer[InvocationFinishedResult]) = {
     buffer.add(result)
 
     // If the action is successful it seems like the Invoker is Healthy again. So we execute immediately
@@ -430,8 +418,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
         rootControllerIndex = controllerInstance,
         blocking = false,
         content = None,
-        initArgs = Set.empty
-      )
+        initArgs = Set.empty)
 
       context.parent ! ActivationRequest(activationMessage, invokerInstance)
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -200,7 +200,7 @@ class InvokerPool(
       status,
       instanceId.toInt + 1,
       i => new InvokerHealth(
-        InvokerInstanceId(i, userMemory = instanceId.userMemory, cpuCores = instanceId.cpuCores),
+        InvokerInstanceId(i, userMemory = instanceId.userMemory, cpuThreads = instanceId.cpuThreads),
         Offline
       )
     )

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -282,7 +282,7 @@ object InvokerPool {
         namespace = healthActionIdentity.namespace.name.toPath,
         name = EntityName(s"invokerHealthTestAction${i.asString}"),
         exec = CodeExecAsString(manifest, """function main(params) { return params; }""", None),
-        limits = ActionLimits(memory = MemoryLimit(MemoryLimit.MIN_MEMORY))
+        limits = ActionLimits(memory = MemoryLimit(MemoryLimit.MIN_MEMORY), cpu = CPULimit(CPULimit.MIN_CPU))
       )
     }
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -21,7 +21,7 @@ import akka.actor.ActorRef
 import akka.actor.ActorRefFactory
 import java.util.concurrent.ThreadLocalRandom
 
-import akka.actor.{Actor, ActorSystem, Cancellable, Props}
+import akka.actor.{Actor, ActorSystem, Props}
 import akka.cluster.ClusterEvent._
 import akka.cluster.{Cluster, Member, MemberStatus}
 import akka.management.AkkaManagement
@@ -41,7 +41,6 @@ import org.apache.openwhisk.spi.SpiLoader
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 /**
  * A loadbalancer that schedules workload based on a hashing-algorithm.
@@ -628,29 +627,3 @@ case class ClusterConfig(useClusterBootstrap: Boolean)
  */
 case class ShardingContainerPoolBalancerConfig(managedFraction: Double, blackboxFraction: Double, timeoutFactor: Int)
 
-/**
- * State kept for each activation slot until completion.
- *
- * @param id id of the activation
- * @param namespaceId namespace that invoked the action
- * @param invokerName invoker the action is scheduled to
- * @param memoryLimit memory limit of the invoked action
- * @param timeLimit time limit of the invoked action
- * @param maxConcurrent concurrency limit of the invoked action
- * @param fullyQualifiedEntityName fully qualified name of the invoked action
- * @param timeoutHandler times out completion of this activation, should be canceled on good paths
- * @param isBlackbox true if the invoked action is a blackbox action, otherwise false (managed action)
- * @param isBlocking true if the action is invoked in a blocking fashion, i.e. "somebody" waits for the result
- */
-case class ActivationEntry(
-  id:                       ActivationId,
-  namespaceId:              UUID,
-  invokerName:              InvokerInstanceId,
-  memoryLimit:              ByteSize,
-  timeLimit:                FiniteDuration,
-  maxConcurrent:            Int,
-  fullyQualifiedEntityName: FullyQualifiedEntityName,
-  timeoutHandler:           Cancellable,
-  isBlackbox:               Boolean,
-  isBlocking:               Boolean
-)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -303,7 +303,7 @@ class ShardingContainerPoolBalancer(
       .map { invoker =>
         // CPULimit() and MemoryLimit() and TimeLimit() return singletons - they should be fast enough to be used here
         val cpuLimit = action.limits.cpu
-        val cpuLimitInfo = if (cpuLimit == CPULimit()) "std" else "non=std"
+        val cpuLimitInfo = if (cpuLimit == CPULimit()) "std" else "non-std"
         val memoryLimit = action.limits.memory
         val memoryLimitInfo = if (memoryLimit == MemoryLimit()) "std" else "non-std"
         val timeLimit = action.limits.timeout

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -476,7 +476,7 @@ case class ShardingContainerPoolBalancerState(
 
   protected[loadBalancer] var _invokerSlots: IndexedSeq[NestedMemorySemaphore[FullyQualifiedEntityName]] = IndexedSeq.empty[NestedMemorySemaphore[FullyQualifiedEntityName]]
 )(
-  lbConfig: ShardingContainerPoolBalancerConfig = loadConfigOrThrow[ShardingContainerPoolBalancerConfig](ConfigKeys.loadbalancer)
+  lbConfig: ContainerPoolBalancerConfig = loadConfigOrThrow[ContainerPoolBalancerConfig](ConfigKeys.loadbalancer)
 )(implicit logging: Logging) {
 
   // Managed fraction and blackbox fraction can be between 0.0 and 1.0. The sum of these two fractions has to be between
@@ -618,12 +618,3 @@ case class ShardingContainerPoolBalancerState(
  * @param useClusterBootstrap Whether or not to use a bootstrap mechanism
  */
 case class ClusterConfig(useClusterBootstrap: Boolean)
-
-/**
- * Configuration for the sharding container pool balancer.
- *
- * @param blackboxFraction the fraction of all invokers to use exclusively for blackboxes
- * @param timeoutFactor factor to influence the timeout period for forced active acks (time-limit.std * timeoutFactor + 1m)
- */
-case class ShardingContainerPoolBalancerConfig(managedFraction: Double, blackboxFraction: Double, timeoutFactor: Int)
-

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -49,19 +49,22 @@ case class WorkerData(data: ContainerData, state: WorkerState)
  * to the provided prewarmConfig, iff set. Those containers will **not** be
  * part of the poolsize calculation, which is capped by the poolSize parameter.
  * Prewarm containers are only used, if they have matching arguments
- * (kind, memory) and there is space in the pool.
+ * (kind, memory, cpu) and there is space in the pool.
  *
  * @param childFactory method to create new container proxy actor
  * @param feed actor to request more work from
  * @param prewarmConfig optional settings for container prewarming
  * @param poolConfig config for the ContainerPool
  */
-class ContainerPool(childFactory: ActorRefFactory => ActorRef,
-                    feed: ActorRef,
-                    prewarmConfig: List[PrewarmingConfig] = List.empty,
-                    poolConfig: ContainerPoolConfig)
-    extends Actor {
-  import ContainerPool.memoryConsumptionOf
+class ContainerPool(
+  childFactory:  ActorRefFactory => ActorRef,
+  feed:          ActorRef,
+  prewarmConfig: List[PrewarmingConfig]      = List.empty,
+  poolConfig:    ContainerPoolConfig,
+  cpuCores:      Float
+)
+  extends Actor {
+  import ContainerPool.{memoryConsumptionOf, cpuConsumptionOf}
 
   implicit val logging = new AkkaLogging(context.system.log)
 
@@ -70,17 +73,18 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
   var freePool = immutable.Map.empty[ActorRef, ContainerData]
   var busyPool = immutable.Map.empty[ActorRef, ContainerData]
   var prewarmedPool = immutable.Map.empty[ActorRef, ContainerData]
-  // If all memory slots are occupied and if there is currently no container to be removed, than the actions will be
+  // If all memory/CPU slots are occupied and if there is currently no container to be removed, then the actions will be
   // buffered here to keep order of computation.
-  // Otherwise actions with small memory-limits could block actions with large memory limits.
+  // Otherwise actions with small memory-limits/CPU-limits could block actions with large memory/CPU limits.
   var runBuffer = immutable.Queue.empty[Run]
   val logMessageInterval = 10.seconds
 
   prewarmConfig.foreach { config =>
-    logging.info(this, s"pre-warming ${config.count} ${config.exec.kind} ${config.memoryLimit.toString}")(
-      TransactionId.invokerWarmup)
+    logging.info(this, s"pre-warming ${config.count} ${config.exec.kind} ${config.memoryLimit.toString} ${config.cpuLimit}")(
+      TransactionId.invokerWarmup
+    )
     (1 to config.count).foreach { _ =>
-      prewarmContainer(config.exec, config.memoryLimit)
+      prewarmContainer(config.exec, config.memoryLimit, config.cpuLimit)
     }
   }
 
@@ -113,7 +117,10 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
       if (runBuffer.isEmpty || isResentFromBuffer) {
         val createdContainer =
           // Is there enough space on the invoker for this action to be executed.
-          if (hasPoolSpaceFor(busyPool, r.action.limits.memory.megabytes.MB)) {
+          if (if (!cpuLimitConfig.controlEnabled)
+            hasPoolSpaceFor(busyPool, r.action.limits.memory.megabytes.MB)
+          else
+            hasPoolSpaceFor(busyPool, r.action.limits.memory.megabytes.MB, r.action.limits.cpu.cores)) {
             // Schedule a job to a warm container
             ContainerPool
               .schedule(r.action, r.msg.user.namespace.name, freePool)
@@ -122,15 +129,20 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
                 // There was no warm/warming/warmingCold container. Try to take a prewarm container or a cold container.
 
                 // Is there enough space to create a new container or do other containers have to be removed?
-                if (hasPoolSpaceFor(busyPool ++ freePool, r.action.limits.memory.megabytes.MB)) {
+                if (if (!cpuLimitConfig.controlEnabled)
+                  hasPoolSpaceFor(busyPool ++ freePool, r.action.limits.memory.megabytes.MB)
+                else
+                  hasPoolSpaceFor(busyPool ++ freePool, r.action.limits.memory.megabytes.MB, r.action.limits.cpu.cores)) {
                   takePrewarmContainer(r.action)
                     .map(container => (container, "prewarmed"))
-                    .orElse(Some(createContainer(r.action.limits.memory.megabytes.MB), "cold"))
-                } else None)
+                    .orElse(Some(createContainer(r.action.limits.memory.megabytes.MB, r.action.limits.cpu.cores), "cold"))
+                } else None
+              )
               .orElse(
                 // Remove a container and create a new one for the given job
-                ContainerPool
-                // Only free up the amount, that is really needed to free up
+                if (!cpuLimitConfig.controlEnabled)
+                  ContainerPool
+                  // Only free up the amount, that is really needed to free up
                   .remove(freePool, Math.min(r.action.limits.memory.megabytes, memoryConsumptionOf(freePool)).MB)
                   .map(removeContainer)
                   // If the list had at least one entry, enough containers were removed to start the new container. After
@@ -139,7 +151,20 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
                   .map(_ =>
                     takePrewarmContainer(r.action)
                       .map(container => (container, "recreatedPrewarm"))
-                      .getOrElse(createContainer(r.action.limits.memory.megabytes.MB), "recreated")))
+                      .getOrElse(createContainer(r.action.limits.memory.megabytes.MB, r.action.limits.cpu.cores), "recreated"))
+                else
+                  ContainerPool
+                    // Only free up the amount, that is really needed to free up
+                    .removeByCPU(freePool, Math.min(r.action.limits.cpu.cores, cpuConsumptionOf(freePool)), Math.min(r.action.limits.memory.megabytes, memoryConsumptionOf(freePool)).MB)
+                    .map(removeContainer)
+                    // If the list had at least one entry, enough containers were removed to start the new container. After
+                    // removing the containers, we are not interested anymore in the containers that have been removed.
+                    .headOption
+                    .map(_ =>
+                      takePrewarmContainer(r.action)
+                        .map(container => (container, "recreatedPrewarm"))
+                        .getOrElse(createContainer(r.action.limits.memory.megabytes.MB, r.action.limits.cpu.cores), "recreated"))
+              )
 
           } else None
 
@@ -182,15 +207,31 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
             // (and a new container would over commit the pool)
             val isErrorLogged = r.retryLogDeadline.map(_.isOverdue).getOrElse(true)
             val retryLogDeadline = if (isErrorLogged) {
-              logging.error(
-                this,
-                s"Rescheduling Run message, too many message in the pool, " +
-                  s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
-                  s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
-                  s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
-                  s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
-                  s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
-                  s"waiting messages: ${runBuffer.size}")(r.msg.transid)
+              if (!cpuLimitConfig.controlEnabled)
+                logging.error(
+                  this,
+                  s"Rescheduling Run message, too many message in the pool, " +
+                    s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
+                    s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
+                    s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
+                    s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
+                    s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
+                    s"waiting messages: ${runBuffer.size}"
+                )(r.msg.transid)
+              else
+                logging.error(
+                  this,
+                  s"Rescheduling Run message, too many message in the pool, " +
+                    s"freePoolSize: ${freePool.size} containers and ${cpuConsumptionOf(freePool)} cores and ${memoryConsumptionOf(freePool)} MB, " +
+                    s"busyPoolSize: ${busyPool.size} containers and ${cpuConsumptionOf(busyPool)} cores and  ${memoryConsumptionOf(busyPool)} MB, " +
+                    s"maxContainerCPU ${cpuCores} cores," +
+                    s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
+                    s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
+                    s"needed CPU: ${r.action.limits.cpu.cores} cores," +
+                    s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
+                    s"waiting messages: ${runBuffer.size}"
+                )(r.msg.transid)
+
               Some(logMessageInterval.fromNow)
             } else {
               r.retryLogDeadline
@@ -321,6 +362,17 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
   def hasPoolSpaceFor[A](pool: Map[A, ContainerData], memory: ByteSize): Boolean = {
     memoryConsumptionOf(pool) + memory.toMB <= poolConfig.userMemory.toMB
   }
+
+  /**
+   * Calculate if there is enough free memory within a given pool.
+   *
+   * @param pool The pool, that has to be checked, if there is enough free memory.
+   * @param memory The amount of memory to check.
+   * @return true, if there is enough space for the given amount of memory.
+   */
+  def hasPoolSpaceFor[A](pool: Map[A, ContainerData], memory: ByteSize, cpu: Float): Boolean = {
+    cpuConsumptionOf(pool) + cpu <= cpuCores && hasPoolSpaceFor(pool, memory)
+  }
 }
 
 object ContainerPool {
@@ -333,6 +385,16 @@ object ContainerPool {
    */
   protected[containerpool] def memoryConsumptionOf[A](pool: Map[A, ContainerData]): Long = {
     pool.map(_._2.memoryLimit.toMB).sum
+  }
+
+  /**
+   * Calculate the CPU of a given pool.
+   *
+   * @param pool The pool with the containers.
+   * @return The cpu consumption of all containers in the pool in cores.
+   */
+  protected[containerpool] def cpuConsumptionOf[A](pool: Map[A, ContainerData]): Float = {
+    pool.map(_._2.cpuCoresLimit).sum
   }
 
   /**
@@ -412,11 +474,59 @@ object ContainerPool {
     }
   }
 
-  def props(factory: ActorRefFactory => ActorRef,
-            poolConfig: ContainerPoolConfig,
-            feed: ActorRef,
-            prewarmConfig: List[PrewarmingConfig] = List.empty) =
-    Props(new ContainerPool(factory, feed, prewarmConfig, poolConfig))
+  /**
+   * Finds the oldest previously used container to remove to make space for the job passed to run.
+   * Depending on the space that has to be allocated, several containers might be removed.
+   *
+   * NOTE: This method is never called to remove an action that is in the pool already,
+   * since this would be picked up earlier in the scheduler and the container reused.
+   *
+   * @param pool a map of all free containers in the pool
+   * @param cpu the cores of CPU that has to be freed up
+   * @param memory the amount of memory that has to be freed up
+   * @return a list of containers to be removed iff found
+   */
+  @tailrec
+  protected[containerpool] def removeByCPU[A](
+    pool:     Map[A, ContainerData],
+    cpu:      Float,
+    memory:   ByteSize,
+    toRemove: List[A]               = List.empty
+  ): List[A] = {
+    // Try to find a Free container that does NOT have any active activations AND is initialized with any OTHER action
+    val freeContainers = pool.collect {
+      // Only warm containers will be removed. Prewarmed containers will stay always.
+      case (ref, w: WarmedData) if w.activeActivationCount == 0 =>
+        ref -> w
+    }
+
+    if (cpu > 0.toFloat && memory > 0.B && freeContainers.nonEmpty && cpuConsumptionOf(freeContainers) >= cpu && memoryConsumptionOf(freeContainers) >= memory.toMB) {
+      // Remove the oldest container if:
+      // - there is more CPU/memory required
+      // - there are still containers that can be removed
+      // - there are enough free containers that can be removed
+      val (ref, data) = freeContainers.minBy(_._2.lastUsed)
+      // Catch exception if remaining CPU/memory will be negative
+      val remainingCPU = Try(cpu - data.cpuCoresLimit).getOrElse(0.toFloat)
+      val remainingMemory = Try(memory - data.memoryLimit).getOrElse(0.B)
+      removeByCPU(freeContainers - ref, remainingCPU, remainingMemory, toRemove ++ List(ref))
+    } else {
+      // If this is the first call: All containers are in use currently, or there is more memory needed than
+      // containers can be removed.
+      // Or, if this is one of the recursions: Enough containers are found to get the memory, that is
+      // necessary. -> Abort recursion
+      toRemove
+    }
+  }
+
+  def props(
+    factory:       ActorRefFactory => ActorRef,
+    poolConfig:    ContainerPoolConfig,
+    feed:          ActorRef,
+    prewarmConfig: List[PrewarmingConfig]      = List.empty,
+    cpuCores:      Float                       = CPULimit.MAX_CPU
+  ) =
+    Props(new ContainerPool(factory, feed, prewarmConfig, poolConfig, cpuCores))
 }
 
 /** Contains settings needed to perform container prewarming. */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -82,10 +82,10 @@ sealed abstract class ContainerData(val lastUsed: Instant, val memoryLimit: Byte
 
 /** abstract type to indicate an unstarted container */
 sealed abstract class ContainerNotStarted(
-                                           override val lastUsed:              Instant,
-                                           override val memoryLimit:           ByteSize,
-                                           override val cpuThreadsLimit:         Float,
-                                           override val activeActivationCount: Int
+  override val lastUsed:              Instant,
+  override val memoryLimit:           ByteSize,
+  override val cpuThreadsLimit:       Float,
+  override val activeActivationCount: Int
 )
   extends ContainerData(lastUsed, memoryLimit, cpuThreadsLimit, activeActivationCount) {
   override def getContainer = None
@@ -94,11 +94,11 @@ sealed abstract class ContainerNotStarted(
 
 /** abstract type to indicate a started container */
 sealed abstract class ContainerStarted(
-                                        val container:                      Container,
-                                        override val lastUsed:              Instant,
-                                        override val memoryLimit:           ByteSize,
-                                        override val cpuThreadsLimit:         Float,
-                                        override val activeActivationCount: Int
+  val container:                      Container,
+  override val lastUsed:              Instant,
+  override val memoryLimit:           ByteSize,
+  override val cpuThreadsLimit:       Float,
+  override val activeActivationCount: Int
 )
   extends ContainerData(lastUsed, memoryLimit, cpuThreadsLimit, activeActivationCount) {
   override def getContainer = Some(container)
@@ -133,11 +133,11 @@ case class ResourcesData(override val memoryLimit: ByteSize, override val cpuThr
 
 /** type representing a prewarmed (running, but unused) container (with a specific memory allocation) */
 case class PreWarmedData(
-                          override val container:             Container,
-                          kind:                               String,
-                          override val memoryLimit:           ByteSize,
-                          override val cpuThreadsLimit:         Float,
-                          override val activeActivationCount: Int       = 0
+  override val container:             Container,
+  kind:                               String,
+  override val memoryLimit:           ByteSize,
+  override val cpuThreadsLimit:       Float,
+  override val activeActivationCount: Int       = 0
 )
   extends ContainerStarted(container, Instant.EPOCH, memoryLimit, cpuThreadsLimit, activeActivationCount)
   with ContainerNotInUse {
@@ -325,7 +325,8 @@ class ContainerProxy(
               job.msg.blocking,
               job.msg.rootControllerIndex,
               job.msg.user.namespace.uuid,
-              CombinedCompletionAndResultMessage(transid, activation, instance))
+              CombinedCompletionAndResultMessage(transid, activation, instance)
+            )
             storeActivation(transid, activation, context)
         }
         .flatMap { container =>
@@ -663,7 +664,8 @@ class ContainerProxy(
           job.msg.blocking,
           job.msg.rootControllerIndex,
           job.msg.user.namespace.uuid,
-          ResultMessage(tid, result))
+          ResultMessage(tid, result)
+        )
       }
     } else {
       // For non-blocking request, do not forward the result.
@@ -708,7 +710,9 @@ class ContainerProxy(
               job.msg.blocking,
               job.msg.rootControllerIndex,
               job.msg.user.namespace.uuid,
-              CompletionMessage(tid, activation, instance)))
+              CompletionMessage(tid, activation, instance)
+            )
+        )
         // Storing the record. Entirely asynchronous and not waited upon.
         storeActivation(tid, activation, context)
       }
@@ -727,20 +731,15 @@ final case class ContainerProxyTimeoutConfig(idleContainer: FiniteDuration, paus
 
 object ContainerProxy {
   def props(
-    factory: (TransactionId,
-              String,
-              ImageName,
-              Boolean,
-              ByteSize,
-              Int,
-              Option[ExecutableWhiskAction]) => Future[Container],
-    ack: ActiveAck,
-    store: (TransactionId, WhiskActivation, UserContext) => Future[Any],
-    collectLogs: (TransactionId, Identity, WhiskActivation, Container, ExecutableWhiskAction) => Future[ActivationLogs],
-    instance: InvokerInstanceId,
-    poolConfig: ContainerPoolConfig,
-    unusedTimeout: FiniteDuration = timeouts.idleContainer,
-    pauseGrace: FiniteDuration = timeouts.pauseGrace) =
+    factory:       (TransactionId, String, ImageName, Boolean, ByteSize, Int, Option[ExecutableWhiskAction]) => Future[Container],
+    ack:           ActiveAck,
+    store:         (TransactionId, WhiskActivation, UserContext) => Future[Any],
+    collectLogs:   (TransactionId, Identity, WhiskActivation, Container, ExecutableWhiskAction) => Future[ActivationLogs],
+    instance:      InvokerInstanceId,
+    poolConfig:    ContainerPoolConfig,
+    unusedTimeout: FiniteDuration                                                                                                 = timeouts.idleContainer,
+    pauseGrace:    FiniteDuration                                                                                                 = timeouts.pauseGrace
+  ) =
     Props(new ContainerProxy(factory, ack, store, collectLogs, instance, poolConfig, unusedTimeout, pauseGrace))
 
   // Needs to be thread-safe as it's used by multiple proxies concurrently.

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -59,26 +59,24 @@ object DockerContainer {
    * @param useRunc use docker-runc to pause/unpause container?
    * @return a Future which either completes with a DockerContainer or one of two specific failures
    */
-  def create(
-    transid:             TransactionId,
-    image:               Either[ImageName, ImageName],
-    registryConfig:      Option[RuntimesRegistryConfig] = None,
-    memory:              ByteSize                       = 256.MB,
-    cpuShares:           Int                            = 0,
-    environment:         Map[String, String]            = Map.empty,
-    network:             String                         = "bridge",
-    dnsServers:          Seq[String]                    = Seq.empty,
-    dnsSearch:           Seq[String]                    = Seq.empty,
-    dnsOptions:          Seq[String]                    = Seq.empty,
-    name:                Option[String]                 = None,
-    useRunc:             Boolean                        = true,
-    dockerRunParameters: Map[String, Set[String]]
-  )(implicit
-    docker: DockerApiWithFileAccess,
-    runc: RuncApi,
-    as:   ActorSystem,
-    ec:   ExecutionContext,
-    log:  Logging): Future[DockerContainer] = {
+  def create(transid: TransactionId,
+             image: Either[ImageName, ImageName],
+             registryConfig: Option[RuntimesRegistryConfig] = None,
+             memory: ByteSize = 256.MB,
+             cpuShares: Int = 0,
+             environment: Map[String, String] = Map.empty,
+             network: String = "bridge",
+             dnsServers: Seq[String] = Seq.empty,
+             dnsSearch: Seq[String] = Seq.empty,
+             dnsOptions: Seq[String] = Seq.empty,
+             name: Option[String] = None,
+             useRunc: Boolean = true,
+             dockerRunParameters: Map[String, Set[String]])(implicit
+                                                            docker: DockerApiWithFileAccess,
+                                                            runc: RuncApi,
+                                                            as: ActorSystem,
+                                                            ec: ExecutionContext,
+                                                            log: Logging): Future[DockerContainer] = {
     val params = genEnvParamsAndDockerParams(environment, dockerRunParameters)
 
     // NOTE: --dns-option on modern versions of docker, but is --dns-opt on docker 1.12
@@ -91,8 +89,7 @@ object DockerContainer {
       "--memory-swap",
       s"${memory.toMB}m",
       "--network",
-      network
-    ) ++
+      network) ++
       params._1 ++
       dnsServers.flatMap(d => Seq("--dns", d)) ++
       dnsSearch.flatMap(d => Seq("--dns-search", d)) ++
@@ -117,26 +114,24 @@ object DockerContainer {
    * @param useRunc use docker-runc to pause/unpause container?
    * @return a Future which either completes with a DockerContainer or one of two specific failures
    */
-  def createByCPU(
-    transID:             TransactionId,
-    image:               Either[ImageName, ImageName],
-    registryConfig:      Option[RuntimesRegistryConfig] = None,
-    memory:              ByteSize                       = 256.MB,
-    cpu:                 Float                          = (0.2).toFloat,
-    environment:         Map[String, String]            = Map.empty,
-    network:             String                         = "bridge",
-    dnsServers:          Seq[String]                    = Seq.empty,
-    dnsSearch:           Seq[String]                    = Seq.empty,
-    dnsOptions:          Seq[String]                    = Seq.empty,
-    name:                Option[String]                 = None,
-    useRunc:             Boolean                        = true,
-    dockerRunParameters: Map[String, Set[String]]
-  )(implicit
-    docker: DockerApiWithFileAccess,
-    runc: RuncApi,
-    as:   ActorSystem,
-    ec:   ExecutionContext,
-    log:  Logging): Future[DockerContainer] = {
+  def createByCPU(transID: TransactionId,
+                  image: Either[ImageName, ImageName],
+                  registryConfig: Option[RuntimesRegistryConfig] = None,
+                  memory: ByteSize = 256.MB,
+                  cpu: Float = (0.2).toFloat,
+                  environment: Map[String, String] = Map.empty,
+                  network: String = "bridge",
+                  dnsServers: Seq[String] = Seq.empty,
+                  dnsSearch: Seq[String] = Seq.empty,
+                  dnsOptions: Seq[String] = Seq.empty,
+                  name: Option[String] = None,
+                  useRunc: Boolean = true,
+                  dockerRunParameters: Map[String, Set[String]])(implicit
+                                                                 docker: DockerApiWithFileAccess,
+                                                                 runc: RuncApi,
+                                                                 as: ActorSystem,
+                                                                 ec: ExecutionContext,
+                                                                 log: Logging): Future[DockerContainer] = {
 
     val params = genEnvParamsAndDockerParams(environment, dockerRunParameters)
 
@@ -150,8 +145,7 @@ object DockerContainer {
       "--memory-swap",
       s"${memory.toMB}m",
       "--network",
-      network
-    ) ++
+      network) ++
       params._1 ++
       dnsServers.flatMap(d => Seq("--dns", d)) ++
       dnsSearch.flatMap(d => Seq("--dns-search", d)) ++
@@ -162,25 +156,24 @@ object DockerContainer {
     createContainerWithArgs(args, transID, registryConfig, image, network, useRunc)
   }
 
-  private def genEnvParamsAndDockerParams(environment: Map[String, String], dockerRunParameters: Map[String, Set[String]]): (Iterable[String], Iterable[String]) =
-    (
-      environment.flatMap { case (key, value) => Seq("-e", s"$key=$value") },
-      dockerRunParameters.flatMap { case (key, valueList) => valueList.toList.flatMap(Seq(key, _)) }
-    )
+  private def genEnvParamsAndDockerParams(
+    environment: Map[String, String],
+    dockerRunParameters: Map[String, Set[String]]): (Iterable[String], Iterable[String]) =
+    (environment.flatMap { case (key, value) => Seq("-e", s"$key=$value") }, dockerRunParameters.flatMap {
+      case (key, valueList)                  => valueList.toList.flatMap(Seq(key, _))
+    })
 
-  private def createContainerWithArgs(
-    args:           Seq[String],
-    transID:        TransactionId,
-    registryConfig: Option[RuntimesRegistryConfig] = None,
-    image:          Either[ImageName, ImageName],
-    network:        String,
-    useRunc:        Boolean
-  )(implicit
-    docker: DockerApiWithFileAccess,
-    runc: RuncApi,
-    as:   ActorSystem,
-    ec:   ExecutionContext,
-    log:  Logging): Future[DockerContainer] = {
+  private def createContainerWithArgs(args: Seq[String],
+                                      transID: TransactionId,
+                                      registryConfig: Option[RuntimesRegistryConfig] = None,
+                                      image: Either[ImageName, ImageName],
+                                      network: String,
+                                      useRunc: Boolean)(implicit
+                                                        docker: DockerApiWithFileAccess,
+                                                        runc: RuncApi,
+                                                        as: ActorSystem,
+                                                        ec: ExecutionContext,
+                                                        log: Logging): Future[DockerContainer] = {
     implicit val tid: TransactionId = transID
 
     val registryConfigUrl = registryConfig.map(_.url).getOrElse("")
@@ -243,17 +236,15 @@ object DockerContainer {
  * @param id the id of the container
  * @param addr the ip of the container
  */
-class DockerContainer(
-  protected val id:      ContainerId,
-  protected val addr:    ContainerAddress,
-  protected val useRunc: Boolean
-)(implicit
-  docker: DockerApiWithFileAccess,
-  runc:                      RuncApi,
-  override protected val as: ActorSystem,
-  protected val ec:          ExecutionContext,
-  protected val logging:     Logging)
-  extends Container {
+class DockerContainer(protected val id: ContainerId,
+                      protected val addr: ContainerAddress,
+                      protected val useRunc: Boolean)(implicit
+                                                      docker: DockerApiWithFileAccess,
+                                                      runc: RuncApi,
+                                                      override protected val as: ActorSystem,
+                                                      protected val ec: ExecutionContext,
+                                                      protected val logging: Logging)
+    extends Container {
 
   /** The last read-position in the log file */
   private var logFileOffset = new AtomicLong(0)
@@ -286,8 +277,7 @@ class DockerContainer(
    */
   private def isOomKilled(retries: Int = (waitForOomState / filePollInterval).toInt)(
     implicit
-    transid: TransactionId
-  ): Future[Boolean] = {
+    transid: TransactionId): Future[Boolean] = {
     docker.isOomKilled(id)(TransactionId.invoker).flatMap { killed =>
       if (killed) Future.successful(true)
       else if (retries > 0) akka.pattern.after(filePollInterval, as.scheduler)(isOomKilled(retries - 1))
@@ -295,13 +285,11 @@ class DockerContainer(
     }
   }
 
-  override protected def callContainer(
-    path:          String,
-    body:          JsObject,
-    timeout:       FiniteDuration,
-    maxConcurrent: Int,
-    retry:         Boolean        = false
-  )(implicit transid: TransactionId): Future[RunResult] = {
+  override protected def callContainer(path: String,
+                                       body: JsObject,
+                                       timeout: FiniteDuration,
+                                       maxConcurrent: Int,
+                                       retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
     val started = Instant.now()
     val http = httpConnection.getOrElse {
       val conn = if (Container.config.akkaClient) {
@@ -311,8 +299,7 @@ class DockerContainer(
           s"${addr.host}:${addr.port}",
           timeout,
           ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT,
-          maxConcurrent
-        )
+          maxConcurrent)
       }
       httpConnection = Some(conn)
       conn
@@ -437,7 +424,7 @@ class DockerContainer(
  * '''Errors when''' stream completes, not enough occurrences have been found and errorOnNotEnough is true
  */
 class CompleteAfterOccurrences[T](isInEvent: T => Boolean, neededOccurrences: Int, errorOnNotEnough: Boolean)
-  extends GraphStage[FlowShape[T, T]] {
+    extends GraphStage[FlowShape[T, T]] {
   val in: Inlet[T] = Inlet[T]("WaitForOccurrences.in")
   val out: Outlet[T] = Outlet[T]("WaitForOccurrences.out")
   override val shape: FlowShape[T, T] = FlowShape.of(in, out)
@@ -479,4 +466,4 @@ class CompleteAfterOccurrences[T](isInEvent: T => Boolean, neededOccurrences: In
 
 /** Indicates that Occurrences have not been found in the stream */
 case class OccurrencesNotFoundException(neededCount: Int, actualCount: Int)
-  extends RuntimeException(s"Only found $actualCount out of $neededCount occurrences.")
+    extends RuntimeException(s"Only found $actualCount out of $neededCount occurrences.")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -22,13 +22,10 @@ import akka.actor.ActorSystem
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{CPULimitUtils, Logging, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.containerpool._
-import org.apache.openwhisk.core.entity.ByteSize
-import org.apache.openwhisk.core.entity.ExecManifest
-import org.apache.openwhisk.core.entity.InvokerInstanceId
+import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, ExecutableWhiskAction, InvokerInstanceId}
 
 import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
@@ -38,36 +35,37 @@ import org.apache.openwhisk.core.ConfigKeys
 
 case class DockerContainerFactoryConfig(useRunc: Boolean)
 
-class DockerContainerFactory(instance: InvokerInstanceId,
-                             parameters: Map[String, Set[String]],
-                             containerArgsConfig: ContainerArgsConfig =
-                               loadConfigOrThrow[ContainerArgsConfig](ConfigKeys.containerArgs),
-                             protected val runtimesRegistryConfig: RuntimesRegistryConfig =
-                               loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.runtimesRegistry),
-                             protected val userImagesRegistryConfig: RuntimesRegistryConfig =
-                               loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.userImagesRegistry),
-                             dockerContainerFactoryConfig: DockerContainerFactoryConfig =
-                               loadConfigOrThrow[DockerContainerFactoryConfig](ConfigKeys.dockerContainerFactory))(
-  implicit actorSystem: ActorSystem,
-  ec: ExecutionContext,
-  logging: Logging,
-  docker: DockerApiWithFileAccess,
-  runc: RuncApi)
-    extends ContainerFactory {
+class DockerContainerFactory(
+  instance:                               InvokerInstanceId,
+  parameters:                             Map[String, Set[String]],
+  containerArgsConfig:                    ContainerArgsConfig          = loadConfigOrThrow[ContainerArgsConfig](ConfigKeys.containerArgs),
+  protected val runtimesRegistryConfig:   RuntimesRegistryConfig       = loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.runtimesRegistry),
+  protected val userImagesRegistryConfig: RuntimesRegistryConfig       = loadConfigOrThrow[RuntimesRegistryConfig](ConfigKeys.userImagesRegistry),
+  dockerContainerFactoryConfig:           DockerContainerFactoryConfig = loadConfigOrThrow[DockerContainerFactoryConfig](ConfigKeys.dockerContainerFactory)
+)(
+  implicit
+  actorSystem: ActorSystem,
+  ec:          ExecutionContext,
+  logging:     Logging,
+  docker:      DockerApiWithFileAccess,
+  runc:        RuncApi
+)
+  extends ContainerFactory {
 
   /** Create a container using docker cli */
-  override def createContainer(tid: TransactionId,
-                               name: String,
-                               actionImage: ExecManifest.ImageName,
-                               userProvidedImage: Boolean,
-                               memory: ByteSize,
-                               cpuShares: Int)(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
+  override def createContainer(
+    tid:               TransactionId,
+    name:              String,
+    actionImage:       ExecManifest.ImageName,
+    userProvidedImage: Boolean,
+    memory:            ByteSize,
+    cpuShares:         Int
+  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
     val registryConfig =
       ContainerFactory.resolveRegistryConfig(userProvidedImage, runtimesRegistryConfig, userImagesRegistryConfig)
-    val image = if (userProvidedImage) Left(actionImage) else Right(actionImage)
     DockerContainer.create(
       tid,
-      image = image,
+      image = if (userProvidedImage) Left(actionImage) else Right(actionImage),
       registryConfig = Some(registryConfig),
       memory = memory,
       cpuShares = cpuShares,
@@ -78,7 +76,40 @@ class DockerContainerFactory(instance: InvokerInstanceId,
       dnsOptions = containerArgsConfig.dnsOptions,
       name = Some(name),
       useRunc = dockerContainerFactoryConfig.useRunc,
-      parameters ++ containerArgsConfig.extraArgs.map { case (k, v) => ("--" + k, v) })
+      parameters ++ containerArgsConfig.extraArgs.map { case (k, v) => ("--" + k, v) }
+    )
+  }
+
+  /**
+   * Create a container using docker cli using CPU limit
+   * @param action useless parameter only for the SPI enhancement.
+   */
+  override def createCPUContainer(
+    tid:               TransactionId,
+    name:              String,
+    actionImage:       ExecManifest.ImageName,
+    userProvidedImage: Boolean,
+    memory:            ByteSize,
+    cpuPermits:        Int,
+    action:            Option[ExecutableWhiskAction]
+  )(implicit config: WhiskConfig, logging: Logging): Future[Container] = {
+    val registryConfig =
+      ContainerFactory.resolveRegistryConfig(userProvidedImage, runtimesRegistryConfig, userImagesRegistryConfig)
+    DockerContainer.createByCPU(
+      tid,
+      image = if (userProvidedImage) Left(actionImage) else Right(actionImage),
+      registryConfig = Some(registryConfig),
+      memory = memory,
+      cpu = CPULimitUtils.permitsToThreads(cpuPermits),
+      environment = Map("__OW_API_HOST" -> config.wskApiHost) ++ containerArgsConfig.extraEnvVarMap,
+      network = containerArgsConfig.network,
+      dnsServers = containerArgsConfig.dnsServers,
+      dnsSearch = containerArgsConfig.dnsSearch,
+      dnsOptions = containerArgsConfig.dnsOptions,
+      name = Some(name),
+      useRunc = dockerContainerFactoryConfig.useRunc,
+      parameters ++ containerArgsConfig.extraArgs.map { case (k, v) => ("--" + k, v) }
+    )
   }
 
   /** Perform cleanup on init */
@@ -117,10 +148,10 @@ class DockerContainerFactory(instance: InvokerInstanceId,
           logging.info(this, s"removing ${containers.size} action containers.")
           val removals = containers.map { id =>
             (if (dockerContainerFactoryConfig.useRunc) {
-               runc.resume(id)
-             } else {
-               docker.unpause(id)
-             })
+              runc.resume(id)
+            } else {
+              docker.unpause(id)
+            })
               .recoverWith {
                 // Ignore resume failures and try to remove anyway
                 case _ => Future.successful(())
@@ -136,18 +167,21 @@ class DockerContainerFactory(instance: InvokerInstanceId,
 }
 
 object DockerContainerFactoryProvider extends ContainerFactoryProvider {
-  override def instance(actorSystem: ActorSystem,
-                        logging: Logging,
-                        config: WhiskConfig,
-                        instanceId: InvokerInstanceId,
-                        parameters: Map[String, Set[String]]): ContainerFactory = {
+  override def instance(
+    actorSystem: ActorSystem,
+    logging:     Logging,
+    config:      WhiskConfig,
+    instanceId:  InvokerInstanceId,
+    parameters:  Map[String, Set[String]]
+  ): ContainerFactory = {
 
     new DockerContainerFactory(instanceId, parameters)(
       actorSystem,
       actorSystem.dispatcher,
       logging,
       new DockerClientWithFileAccess()(actorSystem.dispatcher)(logging, actorSystem),
-      new RuncClient()(actorSystem.dispatcher)(logging, actorSystem))
+      new RuncClient()(actorSystem.dispatcher)(logging, actorSystem)
+    )
   }
 
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -132,11 +132,17 @@ class KubernetesClient(
         .build()
       podBuilder.withAffinity(invokerNodeAffinity)
     }
+    val secContext = new SecurityContextBuilder()
+      .withNewCapabilities()
+      .addToDrop("NET_RAW", "NET_ADMIN")
+      .endCapabilities()
+      .build()
     val pod = podBuilder
       .addNewContainer()
       .withNewResources()
       .withLimits(Map("memory" -> new Quantity(memory.toMB + "Mi")).asJava)
       .endResources()
+      .withSecurityContext(secContext)
       .withName("user-action")
       .withImage(image)
       .withEnv(envVars.asJava)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -146,10 +146,12 @@ object Invoker {
     val topicBaseName = "invoker"
     val topicName = topicBaseName + assignedInvokerId
 
-    val maxMessageBytes = Some(ActivationEntityLimit.MAX_ACTIVATION_LIMIT)
+    val cpuCores = Runtime.getRuntime.availableProcessors.toFloat // get current node's CPU cores
+    logger.info(this, s"cpu cores of id $assignedInvokerId: $cpuCores")
     val invokerInstance =
-      InvokerInstanceId(assignedInvokerId, cmdLineArgs.uniqueName, cmdLineArgs.displayedName, poolConfig.userMemory)
+      InvokerInstanceId(assignedInvokerId, cmdLineArgs.uniqueName, cmdLineArgs.displayedName, poolConfig.userMemory, cpuCores)
 
+    val maxMessageBytes = Some(ActivationEntityLimit.MAX_ACTIVATION_LIMIT)
     val msgProvider = SpiLoader.get[MessagingProvider]
     if (msgProvider
           .ensureTopic(config, topic = topicName, topicConfig = topicBaseName, maxMessageBytes = maxMessageBytes)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -149,7 +149,12 @@ object Invoker {
     val cpuThreads = Runtime.getRuntime.availableProcessors.toFloat // get current node's CPU threads
     logger.info(this, s"CPU threads of id $assignedInvokerId: $cpuThreads")
     val invokerInstance =
-      InvokerInstanceId(assignedInvokerId, cmdLineArgs.uniqueName, cmdLineArgs.displayedName, poolConfig.userMemory, cpuThreads)
+      InvokerInstanceId(
+        assignedInvokerId,
+        cmdLineArgs.uniqueName,
+        cmdLineArgs.displayedName,
+        poolConfig.userMemory,
+        cpuThreads)
 
     val maxMessageBytes = Some(ActivationEntityLimit.MAX_ACTIVATION_LIMIT)
     val msgProvider = SpiLoader.get[MessagingProvider]

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -146,10 +146,10 @@ object Invoker {
     val topicBaseName = "invoker"
     val topicName = topicBaseName + assignedInvokerId
 
-    val cpuCores = Runtime.getRuntime.availableProcessors.toFloat // get current node's CPU cores
-    logger.info(this, s"cpu cores of id $assignedInvokerId: $cpuCores")
+    val cpuThreads = Runtime.getRuntime.availableProcessors.toFloat // get current node's CPU threads
+    logger.info(this, s"CPU threads of id $assignedInvokerId: $cpuThreads")
     val invokerInstance =
-      InvokerInstanceId(assignedInvokerId, cmdLineArgs.uniqueName, cmdLineArgs.displayedName, poolConfig.userMemory, cpuCores)
+      InvokerInstanceId(assignedInvokerId, cmdLineArgs.uniqueName, cmdLineArgs.displayedName, poolConfig.userMemory, cpuThreads)
 
     val maxMessageBytes = Some(ActivationEntityLimit.MAX_ACTIVATION_LIMIT)
     val msgProvider = SpiLoader.get[MessagingProvider]

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -189,7 +189,7 @@ class InvokerReactive(
   }
 
   private val pool =
-    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs))
+    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs, instance.cpuCores))
 
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -184,7 +184,7 @@ class InvokerReactive(
     ExecManifest.runtimesManifest.stemcells.flatMap {
       case (mf, cells) =>
         cells.map { cell =>
-          PrewarmingConfig(cell.count, new CodeExecAsString(mf, "", None), cell.memory, cell.cpu)
+          PrewarmingConfig(cell.count, new CodeExecAsString(mf, "", None), cell.memory)
         }
     }.toList
   }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -183,7 +183,7 @@ class InvokerReactive(
     ExecManifest.runtimesManifest.stemcells.flatMap {
       case (mf, cells) =>
         cells.map { cell =>
-          PrewarmingConfig(cell.count, new CodeExecAsString(mf, "", None), cell.memory)
+          PrewarmingConfig(cell.count, new CodeExecAsString(mf, "", None), cell.memory, cell.cpu)
         }
     }.toList
   }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -189,7 +189,7 @@ class InvokerReactive(
   }
 
   private val pool =
-    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs, instance.cpuCores))
+    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs, instance.cpuThreads))
 
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -43,22 +43,23 @@ import scala.util.{Failure, Success}
 
 object InvokerReactive extends InvokerProvider {
 
-  /**
-   * A method for sending Active Acknowledgements (aka "active ack") messages to the load balancer. These messages
-   * are either completion messages for an activation to indicate a resource slot is free, or result-forwarding
-   * messages for continuations (e.g., sequences and conductor actions).
-   *
-   * The activation result is always provided because some acknowledegment messages may not carry the result of
-   * the activation and this is needed for sending user events.
-   *
-   * @param tid the transaction id for the activation
-   * @param activationResult is the activation result
-   * @param blockingInvoke is true iff the activation was a blocking request
-   * @param controllerInstance the originating controller/loadbalancer id
-   * @param userId is the UUID for the namespace owning the activation
-   * @param acknowledegment the acknowledgement message to send
-   */
   trait ActiveAck {
+
+    /**
+     * A method for sending Active Acknowledgements (aka "active ack") messages to the load balancer. These messages
+     * are either completion messages for an activation to indicate a resource slot is free, or result-forwarding
+     * messages for continuations (e.g., sequences and conductor actions).
+     *
+     * The activation result is always provided because some acknowledegment messages may not carry the result of
+     * the activation and this is needed for sending user events.
+     *
+     * @param tid the transaction id for the activation
+     * @param activationResult is the activation result
+     * @param blockingInvoke is true iff the activation was a blocking request
+     * @param controllerInstance the originating controller/loadbalancer id
+     * @param userId is the UUID for the namespace owning the activation
+     * @param acknowledegment the acknowledgement message to send
+     */
     def apply(tid: TransactionId,
               activationResult: WhiskActivation,
               blockingInvoke: Boolean,
@@ -188,8 +189,8 @@ class InvokerReactive(
     }.toList
   }
 
-  private val pool =
-    actorSystem.actorOf(ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs, instance.cpuThreads))
+  private val pool = actorSystem.actorOf(
+    ContainerPool.props(childFactory, poolConfig, activationFeed, prewarmingConfigs, instance.cpuThreads))
 
   /** Is called when an ActivationMessage is read from Kafka */
   def processActivationMessage(bytes: Array[Byte]): Future[Unit] = {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/LogbackConfigurator.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/LogbackConfigurator.scala
@@ -39,7 +39,10 @@ object LogbackConfigurator {
 
   def initLogging(conf: Conf): Unit = {
     val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).setLevel(toLevel(conf.verbose()))
+    //Only tweak the log level if verbose option is used
+    if (conf.verbose() != 0) {
+      ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).setLevel(toLevel(conf.verbose()))
+    }
   }
 
   private def toLevel(v: Int) = {

--- a/tests/src/test/scala/common/WhiskProperties.java
+++ b/tests/src/test/scala/common/WhiskProperties.java
@@ -47,6 +47,11 @@ public class WhiskProperties {
     protected static final String WHISK_PROPS_FILE = "whisk.properties";
 
     /**
+     * Default concurrency level if otherwise unspecified
+     */
+    private static final int DEFAULT_CONCURRENCY = 20;
+
+    /**
      * If true, then tests will direct to the router rather than the edge
      * components.
      */

--- a/tests/src/test/scala/common/WskCliOperations.scala
+++ b/tests/src/test/scala/common/WskCliOperations.scala
@@ -696,8 +696,8 @@ class CliNamespaceOperations(override val wsk: RunCliCmd)
    * @param expectedExitCode (optional) the expected exit code for the command
    * if the code is anything but DONTCARE_EXIT, assert the code is as expected
    */
-  override def list(expectedExitCode: Int = SUCCESS_EXIT, nameSort: Option[Boolean] = None)(
-    implicit wp: WskProps): RunResult = {
+  override def list(expectedExitCode: Int = SUCCESS_EXIT, nameSort: Option[Boolean] = None)(implicit
+                                                                                            wp: WskProps): RunResult = {
     val params = Seq(noun, "list", "--auth", wp.authKey) ++ {
       nameSort map { n =>
         Seq("--name-sort")
@@ -727,7 +727,8 @@ class CliNamespaceOperations(override val wsk: RunCliCmd)
    * if the code is anything but DONTCARE_EXIT, assert the code is as expected
    */
   def get(namespace: Option[String] = None, expectedExitCode: Int, nameSort: Option[Boolean] = None)(
-    implicit wp: WskProps): RunResult = {
+    implicit
+    wp: WskProps): RunResult = {
     val params = {
       nameSort map { n =>
         Seq("--name-sort")

--- a/tests/src/test/scala/common/WskCliOperations.scala
+++ b/tests/src/test/scala/common/WskCliOperations.scala
@@ -199,6 +199,7 @@ class CliActionOperations(override val wsk: RunCliCmd)
     annotationFile: Option[String] = None,
     timeout: Option[Duration] = None,
     memory: Option[ByteSize] = None,
+    cpu: Option[Float] = None,
     logsize: Option[ByteSize] = None,
     concurrency: Option[Int] = None,
     shared: Option[Boolean] = None,
@@ -244,6 +245,10 @@ class CliActionOperations(override val wsk: RunCliCmd)
     } ++ {
       memory map { m =>
         Seq("-m", m.toMB.toString)
+      } getOrElse Seq.empty
+    } ++ {
+      cpu map { c =>
+        Seq("--cpu", c.toString)
       } getOrElse Seq.empty
     } ++ {
       logsize map { l =>

--- a/tests/src/test/scala/common/WskOperations.scala
+++ b/tests/src/test/scala/common/WskOperations.scala
@@ -238,6 +238,7 @@ trait ActionOperations extends DeleteFromCollectionOperations with ListOrGetFrom
              annotationFile: Option[String] = None,
              timeout: Option[Duration] = None,
              memory: Option[ByteSize] = None,
+             cpu: Option[Float] = None,
              logsize: Option[ByteSize] = None,
              concurrency: Option[Int] = None,
              shared: Option[Boolean] = None,

--- a/tests/src/test/scala/common/WskOperations.scala
+++ b/tests/src/test/scala/common/WskOperations.scala
@@ -321,7 +321,8 @@ trait ActivationOperations {
               pollPeriod: Duration = 1.second)(implicit wp: WskProps): Seq[String]
 
   def waitForActivation(activationId: String, initialWait: Duration, pollPeriod: Duration, totalWait: Duration)(
-    implicit wp: WskProps): Either[String, JsObject]
+    implicit
+    wp: WskProps): Either[String, JsObject]
 
   def get(activationId: Option[String] = None,
           expectedExitCode: Int = SUCCESS_EXIT,
@@ -335,10 +336,12 @@ trait ActivationOperations {
               actionName: Option[String] = None)(implicit wp: WskProps): RunResult
 
   def logs(activationId: Option[String] = None, expectedExitCode: Int = SUCCESS_EXIT, last: Option[Boolean] = None)(
-    implicit wp: WskProps): RunResult
+    implicit
+    wp: WskProps): RunResult
 
   def result(activationId: Option[String] = None, expectedExitCode: Int = SUCCESS_EXIT, last: Option[Boolean] = None)(
-    implicit wp: WskProps): RunResult
+    implicit
+    wp: WskProps): RunResult
 }
 
 trait NamespaceOperations {

--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -267,6 +267,7 @@ class RestActionOperations(implicit val actorSystem: ActorSystem)
     annotationFile: Option[String] = None,
     timeout: Option[Duration] = None,
     memory: Option[ByteSize] = None,
+    cpu: Option[Float] = None,
     logsize: Option[ByteSize] = None,
     concurrency: Option[Int] = None,
     shared: Option[Boolean] = None,
@@ -344,7 +345,8 @@ class RestActionOperations(implicit val actorSystem: ActorSystem)
       timeout.map(t => Map("timeout" -> t.toMillis.toJson)).getOrElse(Map.empty) ++
         logsize.map(log => Map("logs" -> log.toMB.toJson)).getOrElse(Map.empty) ++
         memory.map(m => Map("memory" -> m.toMB.toJson)).getOrElse(Map.empty) ++
-        concurrency.map(c => Map("concurrency" -> c.toJson)).getOrElse(Map.empty)
+        concurrency.map(c => Map("concurrency" -> c.toJson)).getOrElse(Map.empty) ++
+        cpu.map(c => Map("cpu" -> c.toJson)).getOrElse(Map.empty)
     }
 
     val body: Map[String, JsValue] = if (!update) {

--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -814,8 +814,8 @@ class RestNamespaceOperations(implicit val actorSystem: ActorSystem) extends Nam
    * @param expectedExitCode (optional) the expected exit code for the command
    * if the code is anything but DONTCARE_EXIT, assert the code is as expected
    */
-  override def list(expectedExitCode: Int = OK.intValue, nameSort: Option[Boolean] = None)(
-    implicit wp: WskProps): RestResult = {
+  override def list(expectedExitCode: Int = OK.intValue, nameSort: Option[Boolean] = None)(implicit
+                                                                                           wp: WskProps): RestResult = {
     val entPath = Path(s"$basePath/namespaces")
     val resp = requestEntity(GET, entPath)
     val result = new RestResult(resp.status, getTransactionId(resp), getRespData(resp))

--- a/tests/src/test/scala/org/apache/openwhisk/common/NestedCPUSemaphoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/NestedCPUSemaphoreTests.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class NestedCPUSemaphoreTests extends FlatSpec with Matchers {
+  behavior of "NestedCPUSemaphoreTests"
+
+  it should "allow acquire of concurrency permits before acquire of CPU permits" in {
+    val s = new NestedCPUSemaphore[String](1.toFloat)
+    s.availablePermits shouldBe 100 // We only accept this unit currently
+
+    val actionId = "action1"
+    val actionConcurrency = 5
+    val actionCPU = CPULimitUtils.coresToPermits(0.06)
+    //use all concurrency on a single slot
+    (1 to 5).par.map { _ =>
+      s.tryAcquireConcurrent(actionId, actionConcurrency, actionCPU) shouldBe true
+    }
+    s.availablePermits shouldBe 100 - 6 //we used a single container (CPU permits == 6)
+    s.concurrentState(actionId).availablePermits shouldBe 0
+
+    //use up all the remaining CPU permits (94) and concurrency slots (94 / 6 * 5 = 75)
+    (1 to 75).par.map { _ =>
+      s.tryAcquireConcurrent(actionId, actionConcurrency, actionCPU) shouldBe true
+    }
+    s.availablePermits shouldBe 4 //we used 96 (100/6 = 16, 16*6 = 96)
+    s.concurrentState(actionId).availablePermits shouldBe 0
+    s.tryAcquireConcurrent("action1", actionConcurrency, actionCPU) shouldBe false
+  }
+
+  it should "not give away more permits even under concurrent load" in {
+    // 100 iterations of this test
+    (0 until 100).foreach { _ =>
+      val s = new NestedCPUSemaphore((0.32).toFloat)
+      // try to acquire more permits than allowed in parallel
+      val acquires = (0 until 64).par.map(_ => s.tryAcquire()).seq
+
+      val result = Seq.fill(32)(true) ++ Seq.fill(32)(false)
+      acquires should contain theSameElementsAs result
+    }
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/common/NestedCPUSemaphoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/NestedCPUSemaphoreTests.scala
@@ -32,7 +32,7 @@ class NestedCPUSemaphoreTests extends FlatSpec with Matchers {
 
     val actionId = "action1"
     val actionConcurrency = 5
-    val actionCPU = CPULimitUtils.coresToPermits(0.06)
+    val actionCPU = CPULimitUtils.threadsToPermits(0.06)
     //use all concurrency on a single slot
     (1 to 5).par.map { _ =>
       s.tryAcquireConcurrent(actionId, actionConcurrency, actionCPU) shouldBe true

--- a/tests/src/test/scala/org/apache/openwhisk/common/NestedMemorySemaphoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/NestedMemorySemaphoreTests.scala
@@ -23,11 +23,11 @@ import org.scalatest.Matchers
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class NestedSemaphoreTests extends FlatSpec with Matchers {
-  behavior of "NestedSemaphore"
+class NestedMemorySemaphoreTests extends FlatSpec with Matchers {
+  behavior of "NestedMemorySemaphoreTests"
 
   it should "allow acquire of concurrency permits before acquire of memory permits" in {
-    val s = new NestedSemaphore[String](20)
+    val s = new NestedMemorySemaphore[String](20)
     s.availablePermits shouldBe 20
 
     val actionId = "action1"
@@ -53,7 +53,7 @@ class NestedSemaphoreTests extends FlatSpec with Matchers {
   it should "not give away more permits even under concurrent load" in {
     // 100 iterations of this test
     (0 until 100).foreach { _ =>
-      val s = new NestedSemaphore(32)
+      val s = new NestedMemorySemaphore(32)
       // try to acquire more permits than allowed in parallel
       val acquires = (0 until 64).par.map(_ => s.tryAcquire()).seq
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
@@ -44,12 +44,12 @@ import scala.util.{Success, Try}
 
 @RunWith(classOf[JUnitRunner])
 class ElasticSearchLogStoreTests
-  extends TestKit(ActorSystem("ElasticSearchLogStore"))
-  with FlatSpecLike
-  with Matchers
-  with BeforeAndAfterAll
-  with ScalaFutures
-  with StreamLogging {
+    extends TestKit(ActorSystem("ElasticSearchLogStore"))
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with StreamLogging {
 
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val materializer: ActorMaterializer = ActorMaterializer()
@@ -70,38 +70,30 @@ class ElasticSearchLogStoreTests
       443,
       "/whisk_user_logs/_search",
       defaultLogSchema,
-      Seq("x-auth-token", "x-auth-project-id")
-    )
+      Seq("x-auth-token", "x-auth-project-id"))
 
   private val defaultHttpResponse = HttpResponse(
     StatusCodes.OK,
     entity = HttpEntity(
       ContentTypes.`application/json`,
-      s"""{"took":799,"timed_out":false,"_shards":{"total":204,"successful":204,"failed":0},"hits":{"total":2,"max_score":null,"hits":[{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196689522Z","accountId":null,"message":"some log stuff\\n","type":"user_logs","event_uuid":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenantId","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.687Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897687]},{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"14c2a5b7-8cad-4ec0-992e-70fab1996465","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196754258Z","accountId":null,"message":"more logs\\n","type":"user_logs","event_uuid":"14c2a5b7-8cad-4ec0-992e-70fab1996465","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenant","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.701Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897701]}]}}"""
-    )
-  )
+      s"""{"took":799,"timed_out":false,"_shards":{"total":204,"successful":204,"failed":0},"hits":{"total":2,"max_score":null,"hits":[{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196689522Z","accountId":null,"message":"some log stuff\\n","type":"user_logs","event_uuid":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenantId","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.687Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897687]},{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"14c2a5b7-8cad-4ec0-992e-70fab1996465","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196754258Z","accountId":null,"message":"more logs\\n","type":"user_logs","event_uuid":"14c2a5b7-8cad-4ec0-992e-70fab1996465","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenant","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.701Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897701]}]}}"""))
   private val defaultPayload = JsObject(
     "query" -> JsObject(
       "query_string" -> JsObject("query" -> JsString(
-        s"_type: ${defaultConfig.logSchema.userLogs} AND ${defaultConfig.logSchema.activationId}: $activationId"
-      ))
-    ),
+        s"_type: ${defaultConfig.logSchema.userLogs} AND ${defaultConfig.logSchema.activationId}: $activationId"))),
     "sort" -> JsArray(JsObject(defaultConfig.logSchema.time -> JsObject("order" -> JsString("asc")))),
-    "from" -> JsNumber(0)
-  ).compactPrint
+    "from" -> JsNumber(0)).compactPrint
   private val defaultHttpRequest = HttpRequest(
     POST,
     Uri(s"/whisk_user_logs/_search"),
     List(Accept(MediaTypes.`application/json`)),
-    HttpEntity(ContentTypes.`application/json`, defaultPayload)
-  )
+    HttpEntity(ContentTypes.`application/json`, defaultPayload))
   private val defaultLogStoreHttpRequest =
     HttpRequest(method = GET, uri = "https://some.url", entity = HttpEntity.Empty)
   private val defaultContext = UserContext(user, defaultLogStoreHttpRequest)
 
   private val expectedLogs = ActivationLogs(
-    Vector("2018-03-05T02:10:38.196689522Z stdout: some log stuff", "2018-03-05T02:10:38.196754258Z stdout: more logs")
-  )
+    Vector("2018-03-05T02:10:38.196689522Z stdout: some log stuff", "2018-03-05T02:10:38.196754258Z stdout: more logs"))
 
   private val activation = WhiskActivation(
     namespace = EntityPath("namespace"),
@@ -112,17 +104,17 @@ class ElasticSearchLogStoreTests
     end = ZonedDateTime.now.toInstant,
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
     logs = expectedLogs,
-    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu =
-      CPULimit(0.1))
-      .toJson)
-  )
+    annotations = Parameters(
+      "limits",
+      ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu = CPULimit(0.1)).toJson))
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
 
-  private def testFlow(httpResponse: HttpResponse = HttpResponse(), httpRequest: HttpRequest = HttpRequest()): Flow[(HttpRequest, Promise[HttpResponse]), (Try[HttpResponse], Promise[HttpResponse]), NotUsed] =
+  private def testFlow(httpResponse: HttpResponse = HttpResponse(), httpRequest: HttpRequest = HttpRequest())
+    : Flow[(HttpRequest, Promise[HttpResponse]), (Try[HttpResponse], Promise[HttpResponse]), NotUsed] =
     Flow[(HttpRequest, Promise[HttpResponse])]
       .mapAsyncUnordered(1) {
         case (request, userContext) =>
@@ -143,8 +135,7 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfig
-      )
+        elasticSearchConfig = defaultConfig)
 
     await(esLogStore.fetchLogs(activation.withoutLogs, defaultContext)) shouldBe expectedLogs
   }
@@ -154,8 +145,7 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfigRequiredHeaders
-      )
+        elasticSearchConfig = defaultConfigRequiredHeaders)
 
     await(esLogStore.fetchLogs(activation, defaultContext)) shouldBe expectedLogs
   }
@@ -169,21 +159,17 @@ class ElasticSearchLogStoreTests
       List(
         Accept(MediaTypes.`application/json`),
         RawHeader("x-auth-token", authToken),
-        RawHeader("x-auth-project-id", authProjectId)
-      ),
-      HttpEntity(ContentTypes.`application/json`, defaultPayload)
-    )
+        RawHeader("x-auth-project-id", authProjectId)),
+      HttpEntity(ContentTypes.`application/json`, defaultPayload))
     val esLogStore =
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, httpRequest)),
-        elasticSearchConfig = defaultConfigRequiredHeaders
-      )
+        elasticSearchConfig = defaultConfigRequiredHeaders)
     val requiredHeadersHttpRequest = HttpRequest(
       uri = "https://some.url",
       headers = List(RawHeader("x-auth-token", authToken), RawHeader("x-auth-project-id", authProjectId)),
-      entity = HttpEntity.Empty
-    )
+      entity = HttpEntity.Empty)
     val context = UserContext(user, requiredHeadersHttpRequest)
 
     await(esLogStore.fetchLogs(activation.withoutLogs, context)) shouldBe expectedLogs
@@ -196,13 +182,11 @@ class ElasticSearchLogStoreTests
       POST,
       Uri(s"/elasticsearch/logstash-${user.namespace.uuid.asString}*/_search"),
       List(Accept(MediaTypes.`application/json`)),
-      HttpEntity(ContentTypes.`application/json`, defaultPayload)
-    )
+      HttpEntity(ContentTypes.`application/json`, defaultPayload))
     val esLogStore = new ElasticSearchLogStore(
       system,
       Some(testFlow(defaultHttpResponse, httpRequest)),
-      elasticSearchConfig = dynamicPathConfig
-    )
+      elasticSearchConfig = dynamicPathConfig)
 
     await(esLogStore.fetchLogs(activation.withoutLogs, defaultContext)) shouldBe expectedLogs
   }
@@ -219,8 +203,7 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(httpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfig
-      )
+        elasticSearchConfig = defaultConfig)
 
     a[RuntimeException] should be thrownBy await(esLogStore.fetchLogs(activation, defaultContext))
   }
@@ -231,8 +214,7 @@ class ElasticSearchLogStoreTests
 
     a[IllegalArgumentException] should be thrownBy new ElasticSearchLogStore(
       system,
-      elasticSearchConfig = invalidHostConfig
-    )
+      elasticSearchConfig = invalidHostConfig)
   }
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStoreTests.scala
@@ -44,12 +44,12 @@ import scala.util.{Success, Try}
 
 @RunWith(classOf[JUnitRunner])
 class ElasticSearchLogStoreTests
-    extends TestKit(ActorSystem("ElasticSearchLogStore"))
-    with FlatSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with StreamLogging {
+  extends TestKit(ActorSystem("ElasticSearchLogStore"))
+  with FlatSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaFutures
+  with StreamLogging {
 
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val materializer: ActorMaterializer = ActorMaterializer()
@@ -70,30 +70,38 @@ class ElasticSearchLogStoreTests
       443,
       "/whisk_user_logs/_search",
       defaultLogSchema,
-      Seq("x-auth-token", "x-auth-project-id"))
+      Seq("x-auth-token", "x-auth-project-id")
+    )
 
   private val defaultHttpResponse = HttpResponse(
     StatusCodes.OK,
     entity = HttpEntity(
       ContentTypes.`application/json`,
-      s"""{"took":799,"timed_out":false,"_shards":{"total":204,"successful":204,"failed":0},"hits":{"total":2,"max_score":null,"hits":[{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196689522Z","accountId":null,"message":"some log stuff\\n","type":"user_logs","event_uuid":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenantId","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.687Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897687]},{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"14c2a5b7-8cad-4ec0-992e-70fab1996465","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196754258Z","accountId":null,"message":"more logs\\n","type":"user_logs","event_uuid":"14c2a5b7-8cad-4ec0-992e-70fab1996465","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenant","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.701Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897701]}]}}"""))
+      s"""{"took":799,"timed_out":false,"_shards":{"total":204,"successful":204,"failed":0},"hits":{"total":2,"max_score":null,"hits":[{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196689522Z","accountId":null,"message":"some log stuff\\n","type":"user_logs","event_uuid":"1c00007f-ecb9-4083-8d2e-4d5e2849621f","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenantId","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.687Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897687]},{"_index":"logstash-2018.03.05.02","_type":"user_logs","_id":"14c2a5b7-8cad-4ec0-992e-70fab1996465","_score":null,"_source":{"time_date":"2018-03-05T02:10:38.196754258Z","accountId":null,"message":"more logs\\n","type":"user_logs","event_uuid":"14c2a5b7-8cad-4ec0-992e-70fab1996465","activationId_str":"$activationId","action_str":"user@email.com/logs","tenantId":"tenant","logmet_cluster":"topic1-elasticsearch_1","@timestamp":"2018-03-05T02:11:37.701Z","@version":"1","stream_str":"stdout","timestamp":"2018-03-05T02:10:39.131Z"},"sort":[1520215897701]}]}}"""
+    )
+  )
   private val defaultPayload = JsObject(
     "query" -> JsObject(
       "query_string" -> JsObject("query" -> JsString(
-        s"_type: ${defaultConfig.logSchema.userLogs} AND ${defaultConfig.logSchema.activationId}: $activationId"))),
+        s"_type: ${defaultConfig.logSchema.userLogs} AND ${defaultConfig.logSchema.activationId}: $activationId"
+      ))
+    ),
     "sort" -> JsArray(JsObject(defaultConfig.logSchema.time -> JsObject("order" -> JsString("asc")))),
-    "from" -> JsNumber(0)).compactPrint
+    "from" -> JsNumber(0)
+  ).compactPrint
   private val defaultHttpRequest = HttpRequest(
     POST,
     Uri(s"/whisk_user_logs/_search"),
     List(Accept(MediaTypes.`application/json`)),
-    HttpEntity(ContentTypes.`application/json`, defaultPayload))
+    HttpEntity(ContentTypes.`application/json`, defaultPayload)
+  )
   private val defaultLogStoreHttpRequest =
     HttpRequest(method = GET, uri = "https://some.url", entity = HttpEntity.Empty)
   private val defaultContext = UserContext(user, defaultLogStoreHttpRequest)
 
   private val expectedLogs = ActivationLogs(
-    Vector("2018-03-05T02:10:38.196689522Z stdout: some log stuff", "2018-03-05T02:10:38.196754258Z stdout: more logs"))
+    Vector("2018-03-05T02:10:38.196689522Z stdout: some log stuff", "2018-03-05T02:10:38.196754258Z stdout: more logs")
+  )
 
   private val activation = WhiskActivation(
     namespace = EntityPath("namespace"),
@@ -104,15 +112,17 @@ class ElasticSearchLogStoreTests
     end = ZonedDateTime.now.toInstant,
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
     logs = expectedLogs,
-    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson))
+    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu =
+      CPULimit(0.1))
+      .toJson)
+  )
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
 
-  private def testFlow(httpResponse: HttpResponse = HttpResponse(), httpRequest: HttpRequest = HttpRequest())
-    : Flow[(HttpRequest, Promise[HttpResponse]), (Try[HttpResponse], Promise[HttpResponse]), NotUsed] =
+  private def testFlow(httpResponse: HttpResponse = HttpResponse(), httpRequest: HttpRequest = HttpRequest()): Flow[(HttpRequest, Promise[HttpResponse]), (Try[HttpResponse], Promise[HttpResponse]), NotUsed] =
     Flow[(HttpRequest, Promise[HttpResponse])]
       .mapAsyncUnordered(1) {
         case (request, userContext) =>
@@ -133,7 +143,8 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfig)
+        elasticSearchConfig = defaultConfig
+      )
 
     await(esLogStore.fetchLogs(activation.withoutLogs, defaultContext)) shouldBe expectedLogs
   }
@@ -143,7 +154,8 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfigRequiredHeaders)
+        elasticSearchConfig = defaultConfigRequiredHeaders
+      )
 
     await(esLogStore.fetchLogs(activation, defaultContext)) shouldBe expectedLogs
   }
@@ -157,17 +169,21 @@ class ElasticSearchLogStoreTests
       List(
         Accept(MediaTypes.`application/json`),
         RawHeader("x-auth-token", authToken),
-        RawHeader("x-auth-project-id", authProjectId)),
-      HttpEntity(ContentTypes.`application/json`, defaultPayload))
+        RawHeader("x-auth-project-id", authProjectId)
+      ),
+      HttpEntity(ContentTypes.`application/json`, defaultPayload)
+    )
     val esLogStore =
       new ElasticSearchLogStore(
         system,
         Some(testFlow(defaultHttpResponse, httpRequest)),
-        elasticSearchConfig = defaultConfigRequiredHeaders)
+        elasticSearchConfig = defaultConfigRequiredHeaders
+      )
     val requiredHeadersHttpRequest = HttpRequest(
       uri = "https://some.url",
       headers = List(RawHeader("x-auth-token", authToken), RawHeader("x-auth-project-id", authProjectId)),
-      entity = HttpEntity.Empty)
+      entity = HttpEntity.Empty
+    )
     val context = UserContext(user, requiredHeadersHttpRequest)
 
     await(esLogStore.fetchLogs(activation.withoutLogs, context)) shouldBe expectedLogs
@@ -180,11 +196,13 @@ class ElasticSearchLogStoreTests
       POST,
       Uri(s"/elasticsearch/logstash-${user.namespace.uuid.asString}*/_search"),
       List(Accept(MediaTypes.`application/json`)),
-      HttpEntity(ContentTypes.`application/json`, defaultPayload))
+      HttpEntity(ContentTypes.`application/json`, defaultPayload)
+    )
     val esLogStore = new ElasticSearchLogStore(
       system,
       Some(testFlow(defaultHttpResponse, httpRequest)),
-      elasticSearchConfig = dynamicPathConfig)
+      elasticSearchConfig = dynamicPathConfig
+    )
 
     await(esLogStore.fetchLogs(activation.withoutLogs, defaultContext)) shouldBe expectedLogs
   }
@@ -201,7 +219,8 @@ class ElasticSearchLogStoreTests
       new ElasticSearchLogStore(
         system,
         Some(testFlow(httpResponse, defaultHttpRequest)),
-        elasticSearchConfig = defaultConfig)
+        elasticSearchConfig = defaultConfig
+      )
 
     a[RuntimeException] should be thrownBy await(esLogStore.fetchLogs(activation, defaultContext))
   }
@@ -212,7 +231,8 @@ class ElasticSearchLogStoreTests
 
     a[IllegalArgumentException] should be thrownBy new ElasticSearchLogStore(
       system,
-      elasticSearchConfig = invalidHostConfig)
+      elasticSearchConfig = invalidHostConfig
+    )
   }
 
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -46,12 +46,12 @@ import scala.util.{Failure, Success, Try}
 
 @RunWith(classOf[JUnitRunner])
 class SplunkLogStoreTests
-  extends TestKit(ActorSystem("SplunkLogStore"))
-  with FlatSpecLike
-  with Matchers
-  with BeforeAndAfterAll
-  with ScalaFutures
-  with StreamLogging {
+    extends TestKit(ActorSystem("SplunkLogStore"))
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with StreamLogging {
 
   def await[T](awaitable: Future[T], timeout: FiniteDuration = 10.seconds) = Await.result(awaitable, timeout)
 
@@ -72,8 +72,7 @@ class SplunkLogStoreTests
     "activation_id",
     "somefield::somevalue",
     22,
-    disableSNI = false
-  )
+    disableSNI = false)
 
   behavior of "Splunk LogStore"
 
@@ -88,8 +87,7 @@ class SplunkLogStoreTests
     method = POST,
     uri = "https://some.url",
     headers = List(RawHeader("key", "value")),
-    entity = HttpEntity(MediaTypes.`application/json`, JsObject.empty.compactPrint)
-  )
+    entity = HttpEntity(MediaTypes.`application/json`, JsObject.empty.compactPrint))
 
   val activation = WhiskActivation(
     namespace = EntityPath("ns"),
@@ -99,9 +97,10 @@ class SplunkLogStoreTests
     start = ZonedDateTime.parse(startTime).toInstant,
     end = ZonedDateTime.parse(endTime).toInstant,
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
-    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu = CPULimit(0.1)).toJson),
-    duration = Some(123)
-  )
+    annotations = Parameters(
+      "limits",
+      ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu = CPULimit(0.1)).toJson),
+    duration = Some(123))
 
   val context = UserContext(user, request)
 
@@ -129,8 +128,7 @@ class SplunkLogStoreTests
               outputMode shouldBe Some("json")
               execMode shouldBe Some("oneshot")
               search shouldBe Some(
-                s"""search index="${testConfig.index}"| spath ${testConfig.logMessageField}| search ${testConfig.queryConstraints} ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse"""
-              )
+                s"""search index="${testConfig.index}"| spath ${testConfig.logMessageField}| search ${testConfig.queryConstraints} ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse""")
 
               (
                 Success(
@@ -138,12 +136,8 @@ class SplunkLogStoreTests
                     StatusCodes.OK,
                     entity = HttpEntity(
                       ContentTypes.`application/json`,
-                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"},{},{"log_timestamp": "2007-12-03T10:15:32Z", "log_stream":"stderr"}], "highlighted":{}}"""
-                    )
-                  )
-                ),
-                  userContext
-              )
+                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"},{},{"log_timestamp": "2007-12-03T10:15:32Z", "log_stream":"stderr"}], "highlighted":{}}"""))),
+                userContext)
             }
             .recover {
               case e =>
@@ -172,9 +166,7 @@ class SplunkLogStoreTests
         "2007-12-03T10:15:30Z           stdout: some log message",
         "2007-12-03T10:15:31Z           stderr: some other log message",
         "The log message can't be retrieved, key not found: log_timestamp",
-        "The log message can't be retrieved, key not found: log_message"
-      )
-    )
+        "The log message can't be retrieved, key not found: log_message"))
   }
 
   it should "fail to connect to bogus host" in {
@@ -188,5 +180,4 @@ class SplunkLogStoreTests
     val splunkStore = new SplunkLogStore(system, Some(failFlow), testConfig)
     a[RuntimeException] should be thrownBy await(splunkStore.fetchLogs(activation, context))
   }
-
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStoreTests.scala
@@ -46,12 +46,12 @@ import scala.util.{Failure, Success, Try}
 
 @RunWith(classOf[JUnitRunner])
 class SplunkLogStoreTests
-    extends TestKit(ActorSystem("SplunkLogStore"))
-    with FlatSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with StreamLogging {
+  extends TestKit(ActorSystem("SplunkLogStore"))
+  with FlatSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaFutures
+  with StreamLogging {
 
   def await[T](awaitable: Future[T], timeout: FiniteDuration = 10.seconds) = Await.result(awaitable, timeout)
 
@@ -72,7 +72,8 @@ class SplunkLogStoreTests
     "activation_id",
     "somefield::somevalue",
     22,
-    disableSNI = false)
+    disableSNI = false
+  )
 
   behavior of "Splunk LogStore"
 
@@ -87,7 +88,8 @@ class SplunkLogStoreTests
     method = POST,
     uri = "https://some.url",
     headers = List(RawHeader("key", "value")),
-    entity = HttpEntity(MediaTypes.`application/json`, JsObject.empty.compactPrint))
+    entity = HttpEntity(MediaTypes.`application/json`, JsObject.empty.compactPrint)
+  )
 
   val activation = WhiskActivation(
     namespace = EntityPath("ns"),
@@ -97,8 +99,9 @@ class SplunkLogStoreTests
     start = ZonedDateTime.parse(startTime).toInstant,
     end = ZonedDateTime.parse(endTime).toInstant,
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1)))),
-    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB)).toJson),
-    duration = Some(123))
+    annotations = Parameters("limits", ActionLimits(TimeLimit(1.second), MemoryLimit(128.MB), LogLimit(1.MB), cpu = CPULimit(0.1)).toJson),
+    duration = Some(123)
+  )
 
   val context = UserContext(user, request)
 
@@ -126,7 +129,8 @@ class SplunkLogStoreTests
               outputMode shouldBe Some("json")
               execMode shouldBe Some("oneshot")
               search shouldBe Some(
-                s"""search index="${testConfig.index}"| spath ${testConfig.logMessageField}| search ${testConfig.queryConstraints} ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse""")
+                s"""search index="${testConfig.index}"| spath ${testConfig.logMessageField}| search ${testConfig.queryConstraints} ${testConfig.activationIdField}=${activation.activationId.toString}| table ${testConfig.logTimestampField}, ${testConfig.logStreamField}, ${testConfig.logMessageField}| reverse"""
+              )
 
               (
                 Success(
@@ -134,8 +138,12 @@ class SplunkLogStoreTests
                     StatusCodes.OK,
                     entity = HttpEntity(
                       ContentTypes.`application/json`,
-                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"},{},{"log_timestamp": "2007-12-03T10:15:32Z", "log_stream":"stderr"}], "highlighted":{}}"""))),
-                userContext)
+                      """{"preview":false,"init_offset":0,"messages":[],"fields":[{"name":"log_message"}],"results":[{"log_timestamp": "2007-12-03T10:15:30Z", "log_stream":"stdout", "log_message":"some log message"},{"log_timestamp": "2007-12-03T10:15:31Z", "log_stream":"stderr", "log_message":"some other log message"},{},{"log_timestamp": "2007-12-03T10:15:32Z", "log_stream":"stderr"}], "highlighted":{}}"""
+                    )
+                  )
+                ),
+                  userContext
+              )
             }
             .recover {
               case e =>
@@ -164,7 +172,9 @@ class SplunkLogStoreTests
         "2007-12-03T10:15:30Z           stdout: some log message",
         "2007-12-03T10:15:31Z           stderr: some other log message",
         "The log message can't be retrieved, key not found: log_timestamp",
-        "The log message can't be retrieved, key not found: log_message"))
+        "The log message can't be retrieved, key not found: log_message"
+      )
+    )
   }
 
   it should "fail to connect to bogus host" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -67,6 +67,7 @@ class ContainerPoolTests
   // the values is done properly.
   val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
   val memoryLimit = 256.MB
+  val cpuLimit = (0.2).toFloat
 
   /** Creates a `Run` message */
   def createRunMessage(action: ExecutableWhiskAction, invocationNamespace: EntityName) = {
@@ -109,8 +110,8 @@ class ContainerPoolTests
   val runMessageConcurrentDifferentNamespace = createRunMessage(concurrentAction, differentInvocationNamespace)
 
   /** Helper to create PreWarmedData */
-  def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) =
-    PreWarmedData(stub[Container], kind, memoryLimit)
+  def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit, cpuLimit: Float = cpuLimit) =
+    PreWarmedData(stub[Container], kind, memoryLimit, cpuLimit)
 
   /** Helper to create WarmedData */
   def warmedData(action: ExecutableWhiskAction = action,
@@ -604,7 +605,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     WarmingColdData(EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create PreWarmedData with sensible defaults */
-  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
+  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB, (0.2).toFloat)
 
   /** Helper to create NoData */
   def noData() = NoData()

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1182,7 +1182,7 @@ class ContainerProxyTests
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
 
-    val memData = MemoryData(action.limits.memory.megabytes.MB)
+    val memData = ResourcesData(action.limits.memory.megabytes.MB)
     memData.nextRun(Run(action, message)) should matchPattern {
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -147,7 +147,7 @@ class ContainerProxyTests
 
   /** Expect a NeedWork message with prewarmed data */
   def expectPreWarmed(kind: String) = expectMsgPF() {
-    case NeedWork(PreWarmedData(_, kind, memoryLimit, cpuCoresLimit, _)) => true
+    case NeedWork(PreWarmedData(_, kind, memoryLimit, cpuThreadsLimit, _)) => true
   }
 
   /** Expect a NeedWork message with warmed data */
@@ -1182,11 +1182,11 @@ class ContainerProxyTests
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
 
-    val memData = ResourcesData(action.limits.memory.megabytes.MB, action.limits.cpu.cores)
+    val memData = ResourcesData(action.limits.memory.megabytes.MB, action.limits.cpu.threads)
     memData.nextRun(Run(action, message)) should matchPattern {
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
-    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB, action.limits.cpu.cores)
+    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB, action.limits.cpu.threads)
     pwData.nextRun(Run(action, message)) should matchPattern {
       case WarmingData(pwData.container, message.user.namespace.name, action, _, 1) =>
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -618,7 +618,8 @@ class ContainerProxyTests
     timeout) {
     val container = new TestContainer {
       override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-        implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+        implicit
+        transid: TransactionId): Future[(Interval, ActivationResponse)] = {
         atomicRunCount.incrementAndGet()
         //every other run fails
         if (runCount % 2 == 0) {
@@ -766,7 +767,8 @@ class ContainerProxyTests
     timeout) {
     val container = new TestContainer {
       override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-        implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+        implicit
+        transid: TransactionId): Future[(Interval, ActivationResponse)] = {
         atomicRunCount.incrementAndGet()
         Future.successful((initInterval, ActivationResponse.developerError(("boom"))))
       }
@@ -1073,7 +1075,8 @@ class ContainerProxyTests
     memData.nextRun(Run(action, message)) should matchPattern {
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
-    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB, action.limits.cpu.threads)
+    val pwData =
+      PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB, action.limits.cpu.threads)
     pwData.nextRun(Run(action, message)) should matchPattern {
       case WarmingData(pwData.container, message.user.namespace.name, action, _, 1) =>
     }
@@ -1159,7 +1162,8 @@ class ContainerProxyTests
       super.destroy()
     }
     override def initialize(initializer: JsObject, timeout: FiniteDuration, concurrent: Int)(
-      implicit transid: TransactionId): Future[Interval] = {
+      implicit
+      transid: TransactionId): Future[Interval] = {
       initializeCount += 1
       initializer shouldBe action.containerInitializer {
         activationArguments.fields.filter(k => filterEnvVar(k._1))
@@ -1169,7 +1173,8 @@ class ContainerProxyTests
       initPromise.map(_.future).getOrElse(Future.successful(initInterval))
     }
     override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-      implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+      implicit
+      transid: TransactionId): Future[(Interval, ActivationResponse)] = {
 
       // the "init" arguments are not passed on run
       parameters shouldBe JsObject(activationArguments.fields.filter(k => !filterEnvVar(k._1)))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -147,7 +147,7 @@ class ContainerProxyTests
 
   /** Expect a NeedWork message with prewarmed data */
   def expectPreWarmed(kind: String) = expectMsgPF() {
-    case NeedWork(PreWarmedData(_, kind, memoryLimit, _)) => true
+    case NeedWork(PreWarmedData(_, kind, memoryLimit, cpuCoresLimit, _)) => true
   }
 
   /** Expect a NeedWork message with warmed data */
@@ -1182,11 +1182,11 @@ class ContainerProxyTests
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
 
-    val memData = ResourcesData(action.limits.memory.megabytes.MB)
+    val memData = ResourcesData(action.limits.memory.megabytes.MB, action.limits.cpu.cores)
     memData.nextRun(Run(action, message)) should matchPattern {
       case WarmingColdData(message.user.namespace.name, action, _, 1) =>
     }
-    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB)
+    val pwData = PreWarmedData(new TestContainer(), action.exec.kind, action.limits.memory.megabytes.MB, action.limits.cpu.cores)
     pwData.nextRun(Run(action, message)) should matchPattern {
       case WarmingData(pwData.container, message.user.namespace.name, action, _, 1) =>
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -142,7 +142,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   }
 
   // ?docs disabled
-  ignore should "list action by default namespace with full docs" in {
+  it should "list action by default namespace with full docs" in {
     implicit val tid = transid()
     val actions = (1 to 2).map { i =>
       WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
@@ -1320,7 +1320,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             content.limits.get.timeout.get,
             content.limits.get.memory.get,
             content.limits.get.logs.get,
-            content.limits.get.concurrency.get),
+            content.limits.get.concurrency.get,
+            content.limits.get.cpu.get),
           version = action.version.upPatch,
           annotations = action.annotations ++ systemAnnotations(NODEJS10, create = false))
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -741,7 +741,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(action.limits.timeout),
           Some(action.limits.memory),
           Some(action.limits.logs),
-          Some(action.limits.concurrency))))
+          Some(action.limits.concurrency),
+          Some(action.limits.cpu))))
     Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)) ~> check {
       deleteAction(action.docid)
       status should be(OK)
@@ -775,7 +776,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               Some(action.limits.timeout),
               Some(action.limits.memory),
               Some(action.limits.logs),
-              Some(action.limits.concurrency))))
+              Some(action.limits.concurrency),
+              Some(action.limits.cpu))))
 
         // first request invalidates any previous entries and caches new result
         Put(s"$collectionPath/${action.name}", content) ~> Route.seal(routes(creds)(transid())) ~> check {
@@ -877,7 +879,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               Some(action.limits.timeout),
               Some(action.limits.memory),
               Some(action.limits.logs),
-              Some(action.limits.concurrency))))
+              Some(action.limits.concurrency),
+              Some(action.limits.cpu))))
         val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
 
         val expectedPutLog =
@@ -965,7 +968,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(action.limits.timeout),
           Some(action.limits.memory),
           Some(action.limits.logs),
-          Some(action.limits.concurrency))))
+          Some(action.limits.concurrency),
+          Some(action.limits.cpu))))
     val name = action.name
     val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
     val notExpectedGetLog = Seq(
@@ -1048,7 +1052,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               Some(action.limits.timeout),
               Some(action.limits.memory),
               Some(action.limits.logs),
-              Some(action.limits.concurrency))))
+              Some(action.limits.concurrency),
+              Some(action.limits.cpu))))
         val name = action.name
         val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
         val expectedGetLog = Seq(
@@ -1095,7 +1100,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(action.limits.timeout),
           Some(action.limits.memory),
           Some(action.limits.logs),
-          Some(action.limits.concurrency))))
+          Some(action.limits.concurrency),
+          Some(action.limits.cpu))))
     val name = action.name
     val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
     val expectedGetLog = Seq(
@@ -1154,7 +1160,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
               Some(action.limits.timeout),
               Some(action.limits.memory),
               Some(action.limits.logs),
-              Some(action.limits.concurrency))))
+              Some(action.limits.concurrency),
+              Some(action.limits.cpu))))
         val name = action.name
         val cacheKey = s"${CacheKey(action)}".replace("(", "\\(").replace(")", "\\)")
         val expectedPutLog =
@@ -1219,7 +1226,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(actionOldSchema.limits.timeout),
           Some(actionOldSchema.limits.memory),
           Some(actionOldSchema.limits.logs),
-          Some(actionOldSchema.limits.concurrency))))
+          Some(actionOldSchema.limits.concurrency),
+          Some(actionOldSchema.limits.cpu))))
     val expectedPutLog =
       Seq(s"uploading attachment '[\\w-/:]+' of document 'id: ${actionOldSchema.namespace}/${actionOldSchema.name}")
         .mkString("(?s).*")
@@ -1295,7 +1303,8 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           Some(TimeLimit(TimeLimit.MAX_DURATION)),
           Some(MemoryLimit(MemoryLimit.MAX_MEMORY)),
           Some(LogLimit(LogLimit.MAX_LOGSIZE)),
-          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)))))
+          Some(ConcurrencyLimit(ConcurrencyLimit.MAX_CONCURRENT)),
+          Some(CPULimit(CPULimit.MAX_CPU)))))
     put(entityStore, action)
     Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
       deleteAction(action.docid)

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerApiTests.scala
@@ -63,7 +63,7 @@ class ControllerApiTests extends FlatSpec with RestUtil with Matchers with Strea
     limits.fields("max_action_duration") shouldBe TimeLimit.config.max.toMillis.toJson
     limits.fields("min_action_memory") shouldBe MemoryLimit.config.min.toBytes.toJson
     limits.fields("max_action_memory") shouldBe MemoryLimit.config.max.toBytes.toJson
-    limits.fields("min_action_logs") shouldBe LogLimit.config.max.toBytes.toJson
+    limits.fields("min_action_logs") shouldBe LogLimit.config.min.toBytes.toJson
     limits.fields("max_action_logs") shouldBe LogLimit.config.max.toBytes.toJson
     limits.fields("cpu_limit_enabled") shouldBe CPULimit.config.controlEnabled.toJson
     // CPU was float number

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -155,7 +155,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             duration = Some(101L),
             annotations = Parameters("kind", "nodejs:6") ++ Parameters(
               "limits",
-              ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
+              ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB), cpu = CPULimit(0.2)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
               Parameters("initTime", 44.toJson))
           val docInfo = await(activationStore.store(activation, context))
@@ -206,7 +206,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             duration = Some(101L),
             annotations = Parameters("kind", "nodejs:6") ++ Parameters(
               "limits",
-              ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
+              ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB), cpu = CPULimit(0.2)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
               Parameters("initTime", 44.toJson))
           val docInfo = await(activationStore.store(activation, context))

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -274,7 +274,8 @@ class ArtifactWithFileStorageActivationStoreTests()
         // other simple example for the flag: (includeResult && !activation.response.isSuccess)
 
         override def store(activation: WhiskActivation, context: UserContext)(
-          implicit transid: TransactionId,
+          implicit
+          transid: TransactionId,
           notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
 
           val additionalFields = Map(config.userIdField -> context.user.namespace.uuid.toJson)

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -770,6 +770,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
   behavior of "ActionLimits"
 
   it should "properly deserialize JSON" in {
+    // would only pass in memory limit mode. CPU limit number is float, could not be compared by ==
+    assume(!CPULimit.config.controlEnabled)
     val json = Seq[JsValue](
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -771,29 +771,31 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
 
   it should "properly deserialize JSON" in {
     // would only pass in memory limit mode. CPU limit number is float, could not be compared by ==
-    assume(!CPULimit.config.controlEnabled)
-    val json = Seq[JsValue](
+    val json = Seq[JsObject](
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
         "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
+        "cpu" -> CPULimit.STD_CPU.toJson,
         "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson,
         "concurrency" -> ConcurrencyLimit.STD_CONCURRENT.toInt.toJson),
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
         "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
+        "cpu" -> CPULimit.STD_CPU.toJson,
         "logs" -> LogLimit.STD_LOGSIZE.toMB.toInt.toJson,
         "concurrency" -> ConcurrencyLimit.STD_CONCURRENT.toInt.toJson,
         "foo" -> "bar".toJson),
       JsObject(
         "timeout" -> TimeLimit.STD_DURATION.toMillis.toInt.toJson,
-        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson))
+        "memory" -> MemoryLimit.STD_MEMORY.toMB.toInt.toJson,
+        "cpu" -> CPULimit.STD_CPU.toJson))
     val limits = json.map(ActionLimits.serdes.read)
     assert(limits(0) == ActionLimits())
     assert(limits(1) == ActionLimits())
     assert(limits(2) == ActionLimits())
     assert(limits(0).toJson == json(0))
-    assert(limits(1).toJson == json(0)) // drops unknown prop "foo"
-    assert(limits(1).toJson != json(1)) // drops unknown prop "foo"
+    assert(limits(1).toJson == json(0))
+    assert(limits(1).toJson != json(1))
   }
 
   it should "reject malformed JSON" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -43,11 +43,11 @@ import org.apache.openwhisk.core.entity.{
   ActivationEntityLimit,
   ActivationResponse,
   ByteSize,
+  CPULimit,
   ConcurrencyLimit,
   Exec,
   LogLimit,
   MemoryLimit,
-  CPULimit,
   TimeLimit
 }
 import org.apache.openwhisk.core.entity.size._
@@ -177,8 +177,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       PermutationTestParameter(None, None, Some(CPULimit.MAX_CPU + 1.toFloat), None, None, BAD_REQUEST), // cpu limit that is slightly higher than allowed
       PermutationTestParameter(None, None, Some(CPULimit.MAX_CPU * 5), None, None, BAD_REQUEST), // cpu limit that is slightly higher than allowed
       PermutationTestParameter(None, None, None, Some((LogLimit.MAX_LOGSIZE.toMB * 5).MB), None, BAD_REQUEST), // log size limit that is much higher than allowed
-      PermutationTestParameter(None, None, None, None, Some(Int.MaxValue), BAD_REQUEST)
-    ) // concurrency limit that is much higher than allowed
+      PermutationTestParameter(None, None, None, None, Some(Int.MaxValue), BAD_REQUEST)) // concurrency limit that is much higher than allowed
 
   /**
    * Integration test to verify that valid timeout, memory, cpu, log size, and concurrency limits are accepted

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
@@ -41,6 +41,7 @@ import org.scalatest.tagobjects.Slow
  */
 @RunWith(classOf[JUnitRunner])
 class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskActorSystem {
+
   /**
    * Purpose of the following integration test is to verify that the action proxy
    * supports the configured maximum action time limit and does not interrupt a
@@ -58,45 +59,40 @@ class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskAct
    * With default settings, this is around 6 minutes.
    */
   "node-, python, and java-action" should s"run up to the max allowed duration (${TimeLimit.MAX_DURATION})" taggedAs (Slow) in withAssetCleaner(
-    WskProps()
-  ) { (wskProps, assetHelper) =>
-      implicit val props = wskProps
+    WskProps()) { (wskProps, assetHelper) =>
+    implicit val props = wskProps
 
-      val wsk = new WskRestOperations
+    val wsk = new WskRestOperations
 
-      // When you add more runtimes, keep in mind, how many actions can be processed in parallel by the Invokers!
-      Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar").par.foreach {
-        case (k, name) =>
-          println(s"Testing action kind '${k}' with action '${name}'")
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            val main = if (k == "java") Some("Sleep") else None
-            action.create(
-              name,
-              Some(TestUtils.getTestActionFilename(name)),
-              timeout = Some(TimeLimit.MAX_DURATION),
-              main = main
-            )
-          }
-
-          val run = wsk.action.invoke(
+    // When you add more runtimes, keep in mind, how many actions can be processed in parallel by the Invokers!
+    Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar").par.foreach {
+      case (k, name) =>
+        println(s"Testing action kind '${k}' with action '${name}'")
+        assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+          val main = if (k == "java") Some("Sleep") else None
+          action.create(
             name,
-            Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson)
-          )
-          withActivation(
-            wsk.activation,
-            run,
-            initialWait = 1.minute,
-            pollPeriod = 1.minute,
-            totalWait = TimeLimit.MAX_DURATION + 2.minutes
-          ) { activation =>
-            withClue("Activation result not as expected:") {
-              activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-              activation.response.result shouldBe Some(
-                JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson)
-              )
-              activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
-            }
+            Some(TestUtils.getTestActionFilename(name)),
+            timeout = Some(TimeLimit.MAX_DURATION),
+            main = main)
+        }
+
+        val run = wsk.action.invoke(
+          name,
+          Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson))
+        withActivation(
+          wsk.activation,
+          run,
+          initialWait = 1.minute,
+          pollPeriod = 1.minute,
+          totalWait = TimeLimit.MAX_DURATION + 2.minutes) { activation =>
+          withClue("Activation result not as expected:") {
+            activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+            activation.response.result shouldBe Some(
+              JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson))
+            activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
           }
-      }
+        }
     }
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
@@ -41,10 +41,6 @@ import org.scalatest.tagobjects.Slow
  */
 @RunWith(classOf[JUnitRunner])
 class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskActorSystem {
-
-  implicit val wskprops = WskProps()
-  val wsk = new WskRestOperations
-
   /**
    * Purpose of the following integration test is to verify that the action proxy
    * supports the configured maximum action time limit and does not interrupt a
@@ -62,37 +58,45 @@ class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskAct
    * With default settings, this is around 6 minutes.
    */
   "node-, python, and java-action" should s"run up to the max allowed duration (${TimeLimit.MAX_DURATION})" taggedAs (Slow) in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
-    // When you add more runtimes, keep in mind, how many actions can be processed in parallel by the Invokers!
-    Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar").par.map {
-      case (k, name) =>
-        println(s"Testing action kind '${k}' with action '${name}'")
-        assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-          val main = if (k == "java") Some("Sleep") else None
-          action.create(
-            name,
-            Some(TestUtils.getTestActionFilename(name)),
-            timeout = Some(TimeLimit.MAX_DURATION),
-            main = main)
-        }
+    WskProps()
+  ) { (wskProps, assetHelper) =>
+      implicit val props = wskProps
 
-        val run = wsk.action.invoke(
-          name,
-          Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson))
-        withActivation(
-          wsk.activation,
-          run,
-          initialWait = 1.minute,
-          pollPeriod = 1.minute,
-          totalWait = TimeLimit.MAX_DURATION + 2.minutes) { activation =>
-          withClue("Activation result not as expected:") {
-            activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-            activation.response.result shouldBe Some(
-              JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson))
-            activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
+      val wsk = new WskRestOperations
+
+      // When you add more runtimes, keep in mind, how many actions can be processed in parallel by the Invokers!
+      Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar").par.foreach {
+        case (k, name) =>
+          println(s"Testing action kind '${k}' with action '${name}'")
+          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+            val main = if (k == "java") Some("Sleep") else None
+            action.create(
+              name,
+              Some(TestUtils.getTestActionFilename(name)),
+              timeout = Some(TimeLimit.MAX_DURATION),
+              main = main
+            )
           }
-        }
-        () // explicitly map to Unit
+
+          val run = wsk.action.invoke(
+            name,
+            Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson)
+          )
+          withActivation(
+            wsk.activation,
+            run,
+            initialWait = 1.minute,
+            pollPeriod = 1.minute,
+            totalWait = TimeLimit.MAX_DURATION + 2.minutes
+          ) { activation =>
+            withClue("Activation result not as expected:") {
+              activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+              activation.response.result shouldBe Some(
+                JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson)
+              )
+              activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
+            }
+          }
+      }
     }
-  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -78,11 +78,11 @@ import org.apache.openwhisk.core.loadBalancer._
  */
 @RunWith(classOf[JUnitRunner])
 class ShardingContainerPoolBalancerTests
-  extends FlatSpec
-  with Matchers
-  with StreamLogging
-  with ExecHelpers
-  with MockFactory {
+    extends FlatSpec
+    with Matchers
+    with StreamLogging
+    with ExecHelpers
+    with MockFactory {
   behavior of "ShardingContainerPoolBalancerState"
 
   val defaultUserMemory: ByteSize = 1024.MB
@@ -249,8 +249,7 @@ class ShardingContainerPoolBalancerTests
       IndexedSeq.empty,
       MemoryLimit.MIN_MEMORY.toMB.toInt,
       index = 0,
-      step = 2
-    ) shouldBe None
+      step = 2) shouldBe None
   }
 
   it should "return None if no invokers are healthy" in {
@@ -265,8 +264,7 @@ class ShardingContainerPoolBalancerTests
       invokerSlots,
       MemoryLimit.MIN_MEMORY.toMB.toInt,
       index = 0,
-      step = 2
-    ) shouldBe None
+      step = 2) shouldBe None
   }
 
   it should "choose the first available invoker, jumping in stepSize steps, falling back to randomized scheduling once all invokers are full" in {
@@ -420,8 +418,7 @@ class ShardingContainerPoolBalancerTests
       namespace,
       name,
       js10MetaData(Some("jsMain"), false),
-      limits = actionLimits(actionMem, concurrency)
-    )
+      limits = actionLimits(actionMem, concurrency))
   val maxContainers = invokerMem.toMB.toInt / actionMetaData.limits.memory.megabytes
   val numInvokers = 3
   val maxActivations = maxContainers * numInvokers * concurrency
@@ -472,12 +469,11 @@ class ShardingContainerPoolBalancerTests
     }
     val invokerPoolProbe = new InvokerPoolFactory {
       override def createInvokerPool(
-        actorRefFactory:         ActorRefFactory,
-        messagingProvider:       MessagingProvider,
-        messagingProducer:       MessageProducer,
+        actorRefFactory: ActorRefFactory,
+        messagingProvider: MessagingProvider,
+        messagingProducer: MessageProducer,
         sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
-        monitor:                 Option[ActorRef]
-      ): ActorRef =
+        monitor: Option[ActorRef]): ActorRef =
         TestProbe().testActor
     }
     val balancer =
@@ -508,8 +504,7 @@ class ShardingContainerPoolBalancerTests
         ControllerInstanceId("0"),
         blocking = false,
         content = None,
-        initArgs = Set.empty
-      )
+        initArgs = Set.empty)
 
       //send activation to loadbalancer
       aid -> balancer.publish(actionMetaData.toExecutableWhiskAction.get, msg)

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -37,7 +37,7 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import org.apache.openwhisk.common.Logging
-import org.apache.openwhisk.common.NestedSemaphore
+import org.apache.openwhisk.common.NestedMemorySemaphore
 import org.apache.openwhisk.core.entity.FullyQualifiedEntityName
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
@@ -78,11 +78,11 @@ import org.apache.openwhisk.core.loadBalancer._
  */
 @RunWith(classOf[JUnitRunner])
 class ShardingContainerPoolBalancerTests
-    extends FlatSpec
-    with Matchers
-    with StreamLogging
-    with ExecHelpers
-    with MockFactory {
+  extends FlatSpec
+  with Matchers
+  with StreamLogging
+  with ExecHelpers
+  with MockFactory {
   behavior of "ShardingContainerPoolBalancerState"
 
   val defaultUserMemory: ByteSize = 1024.MB
@@ -92,8 +92,8 @@ class ShardingContainerPoolBalancerTests
   def unhealthy(i: Int) = new InvokerHealth(InvokerInstanceId(i, userMemory = defaultUserMemory), Unhealthy)
   def offline(i: Int) = new InvokerHealth(InvokerInstanceId(i, userMemory = defaultUserMemory), Offline)
 
-  def semaphores(count: Int, max: Int): IndexedSeq[NestedSemaphore[FullyQualifiedEntityName]] =
-    IndexedSeq.fill(count)(new NestedSemaphore[FullyQualifiedEntityName](max))
+  def semaphores(count: Int, max: Int): IndexedSeq[NestedMemorySemaphore[FullyQualifiedEntityName]] =
+    IndexedSeq.fill(count)(new NestedMemorySemaphore[FullyQualifiedEntityName](max))
 
   def lbConfig(blackboxFraction: Double, managedFraction: Option[Double] = None) =
     ShardingContainerPoolBalancerConfig(managedFraction.getOrElse(1.0 - blackboxFraction), blackboxFraction, 1)
@@ -249,7 +249,8 @@ class ShardingContainerPoolBalancerTests
       IndexedSeq.empty,
       MemoryLimit.MIN_MEMORY.toMB.toInt,
       index = 0,
-      step = 2) shouldBe None
+      step = 2
+    ) shouldBe None
   }
 
   it should "return None if no invokers are healthy" in {
@@ -264,7 +265,8 @@ class ShardingContainerPoolBalancerTests
       invokerSlots,
       MemoryLimit.MIN_MEMORY.toMB.toInt,
       index = 0,
-      step = 2) shouldBe None
+      step = 2
+    ) shouldBe None
   }
 
   it should "choose the first available invoker, jumping in stepSize steps, falling back to randomized scheduling once all invokers are full" in {
@@ -418,7 +420,8 @@ class ShardingContainerPoolBalancerTests
       namespace,
       name,
       js10MetaData(Some("jsMain"), false),
-      limits = actionLimits(actionMem, concurrency))
+      limits = actionLimits(actionMem, concurrency)
+    )
   val maxContainers = invokerMem.toMB.toInt / actionMetaData.limits.memory.megabytes
   val numInvokers = 3
   val maxActivations = maxContainers * numInvokers * concurrency
@@ -469,11 +472,12 @@ class ShardingContainerPoolBalancerTests
     }
     val invokerPoolProbe = new InvokerPoolFactory {
       override def createInvokerPool(
-        actorRefFactory: ActorRefFactory,
-        messagingProvider: MessagingProvider,
-        messagingProducer: MessageProducer,
+        actorRefFactory:         ActorRefFactory,
+        messagingProvider:       MessagingProvider,
+        messagingProducer:       MessageProducer,
         sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
-        monitor: Option[ActorRef]): ActorRef =
+        monitor:                 Option[ActorRef]
+      ): ActorRef =
         TestProbe().testActor
     }
     val balancer =
@@ -504,7 +508,8 @@ class ShardingContainerPoolBalancerTests
         ControllerInstanceId("0"),
         blocking = false,
         content = None,
-        initArgs = Set.empty)
+        initArgs = Set.empty
+      )
 
       //send activation to loadbalancer
       aid -> balancer.publish(actionMetaData.toExecutableWhiskAction.get, msg)

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -96,7 +96,7 @@ class ShardingContainerPoolBalancerTests
     IndexedSeq.fill(count)(new NestedMemorySemaphore[FullyQualifiedEntityName](max))
 
   def lbConfig(blackboxFraction: Double, managedFraction: Option[Double] = None) =
-    ShardingContainerPoolBalancerConfig(managedFraction.getOrElse(1.0 - blackboxFraction), blackboxFraction, 1)
+    ContainerPoolBalancerConfig(managedFraction.getOrElse(1.0 - blackboxFraction), blackboxFraction, 1)
 
   it should "update invoker's state, growing the slots data and keeping valid old data" in {
     // start empty

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
@@ -23,11 +23,25 @@ import org.scalatest.junit.JUnitRunner
 import system.basic.WskRestBasicTests
 
 @RunWith(classOf[JUnitRunner])
-class StandaloneKafkaTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
+class StandaloneKCFTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
   override implicit val wskprops = WskProps().copy(apihost = serverUrl)
 
-  override protected def supportedTests: Set[String] =
-    Set("Wsk Action REST should invoke a blocking action and get only the result")
+  //Turn on to debug locally easily
+  override protected val dumpLogsAlways = false
 
-  override protected def extraArgs: Seq[String] = Seq("--dev-mode", "--kafka")
+  override protected val dumpStartupLogs = false
+
+  override protected def supportedTests = Set("Wsk Action REST should invoke a blocking action and get only the result")
+
+  override protected def extraArgs: Seq[String] = Seq("--dev-mode", "--dev-kcf")
+
+  override def beforeAll(): Unit = {
+    val kubeconfig = sys.env.get("KUBECONFIG")
+    require(kubeconfig.isDefined, "KUBECONFIG env must be defined")
+    println(s"Using kubeconfig from ${kubeconfig.get}")
+
+    //Note the context need to specify default namespace
+    //kubectl config set-context --current --namespace=default
+    super.beforeAll()
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
@@ -54,6 +54,10 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   protected def waitForOtherThings(): Unit = {}
 
+  protected def dumpLogsAlways: Boolean = false
+
+  protected def dumpStartupLogs: Boolean = false
+
   protected val dataDirPath: String = FilenameUtils.concat(FileUtils.getTempDirectoryPath, "standalone")
 
   override def beforeAll(): Unit = {
@@ -85,6 +89,9 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
         serverStartedForTest = true
         println(s"Started test server at $serverUrl in [$w]")
         waitForOtherThings()
+        if (dumpStartupLogs) {
+          println(logLines.mkString("\n"))
+        }
     }
   }
 
@@ -102,7 +109,7 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   override def withFixture(test: NoArgTest) = {
     val outcome = super.withFixture(test)
-    if (outcome.isFailed) {
+    if (outcome.isFailed || (outcome.isSucceeded && dumpLogsAlways)) {
       println(logLines.mkString("\n"))
     }
     stream.reset()

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -30,6 +30,21 @@ $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
 $ANSIBLE_CMD downloadcli-github.yml
 
+# Install kubectl
+curl -Lo ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo cp kubectl /usr/local/bin/kubectl
+
+# Install kind
+curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64
+chmod +x kind
+sudo cp kind /usr/local/bin/kind
+
+kind create cluster --wait 5m
+export KUBECONFIG="$(kind get kubeconfig-path)"
+kubectl config set-context --current --namespace=default
+
+
 cd $ROOTDIR
 TERM=dumb ./gradlew :core:standalone:build \
   :core:monitoring:user-events:distDocker


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

### Goals

Currently, the container scheduling strategy is CPU share, using `docker run --cpu-shares`. 
And we use `poolConfig.userMemory` to specify **every** `Invoker` node's memory pool size. *(Did I miss sth? Do me a favor to correct me if needed.)*
It's easy to understand, and robust enough to fit most of the deployment case.

But what if we wanna deploy `Invoker` in some resource-limited machine (eg. 4 cores CPU and 8 GB memory, only use 4 cores and 4GB memory), or K8S nodes with different memory resource?
And How to figure out the best `userMemory` in a cluster without boiling CPUs and saving testing time, if most of the actions are CPU consuming, such as AI functions?

### Details

Add **CPU limit mode** to make things happened.

* Add a configuration `whisk.cpu.control-enabled` to `application.conf`.
    * `false` by **default**, which means we use the good old way.
    * `true` to turn on the scheduling feature.
* When turned on
   * Each invoker would report its CPU threads info (number of CPU logic cores) when registering.
   * `ShardingContainerPoolBalancer` use CPU slots the same behavior as memory slots.
   * `ContainerPool` use CPU (first) and memory (second) for pool space calculation.
   * `ContainerFactory` add a new method `createCPUContainer()`.
   * `DockerContainer` add `createByCPU()` with `docker run --cpus` implementation.
   * `Action` add CPU limit annotations, `min/std/max`.
* Add CLI supporting
    * Add `--cpu` parameter to `wsk` CLI.
    * The commit done and tested.
    * The PR not uploaded yet.
* Add K8S deploy options
    * Add `whisk.limits.actions.cpu` configuration.
    * The commit done and tested.
    * The PR not uploaded yet.

### Tests

* Done locally and in a 4-cloud-nodes K8S cluster.
    * Invoker node with 4 CPUs and 4 GB memory as most.
    * AI function. `--docker` creation, `blackbox` run type, which take 300 MB.
    * **Almost identical** as the best deployment setting case.

### TODO:

* [ ] More documentation on this topic.
* [ ] Coverage tests.
* [ ] More measurement tests.
* [ ] Sequence action behavior tests.
    * Not familiar with these concepts and execution process.

***Issue needed? Slack talk needed?***

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4650)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.