### PR TITLE
Capture document size, RU usage, retry stats for get and put in CosmosDB

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -70,6 +70,14 @@ kamon {
     prometheus {
         # We expose the metrics endpoint over akka http. So default server is disabled
         start-embedded-http-server = no
+
+        buckets {
+            custom {
+                //By default retry are configured upto 9. However for certain setups we may increase
+                //it to higher values
+                "histogram.cosmosdb_retry_success" = [1, 2, 3, 5, 7, 10, 12, 15, 20]
+            }
+        }
     }
 
     reporters = [
@@ -264,6 +272,8 @@ whisk {
             retry-options {
                 # Sets the maximum number of retries in the case where the request fails
                 # because the service has applied rate limiting on the client.
+
+                # If this value is changed then adjust the buckets under `kamon.prometehus`
                 max-retry-attempts-on-throttled-requests = 9
 
                 # Sets the maximum retry time

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -244,6 +244,10 @@ whisk {
         # and exposed as metrics. If any reindexing is in progress then its progress would be logged with this frequency
         record-usage-frequency = 10 m
 
+        # Flag to enable collection of retry stats. This feature works by registering with Logback to intercept
+        # log messages and based on that collect stats
+        retry-stats-enabled = true
+
         connection-policy {
             max-pool-size = 1000
             # When the value of this property is true, the SDK will direct write operations to

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.core.database.cosmosdb
 
 import _root_.rx.RxReactiveStreams
 import akka.actor.ActorSystem
+import akka.event.Logging.InfoLevel
 import akka.http.scaladsl.model.{ContentType, StatusCodes, Uri}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
@@ -99,7 +100,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
   override protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo] = {
     val asJson = d.toDocumentRecord
 
-    val doc = toCosmosDoc(asJson)
+    val (doc, docSize) = toCosmosDoc(asJson)
     val id = doc.getId
     val docinfoStr = s"id: $id, rev: ${doc.getETag}"
     val start = transid.started(this, LoggingMarkers.DATABASE_SAVE, s"[PUT] '$collName' saving document: '$docinfoStr'")
@@ -136,7 +137,11 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       }
       .transform(
         { r =>
-          transid.finished(this, start, s"[PUT] '$collName' completed document: '$docinfoStr'")
+          transid.finished(
+            this,
+            start,
+            s"[PUT] '$collName' completed document: '$docinfoStr', size=$docSize, ru=${r.getRequestCharge}",
+            InfoLevel)
           collectMetrics(putToken, r.getRequestCharge)
           toDocInfo(r.getResource)
         }, {
@@ -194,7 +199,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
 
   private def softDeletePut(docInfo: DocInfo, js: JsObject)(implicit transid: TransactionId) = {
     val deletedJs = transform(js, Seq((deleted, Some(JsTrue))))
-    val doc = toCosmosDoc(deletedJs)
+    val (doc, _) = toCosmosDoc(deletedJs)
     softDeleteTTL.foreach(doc.setTimeToLive(_))
     val f = client.replaceDocument(doc, matchRevOption(docInfo)).head()
     f.foreach(r => collectMetrics(putToken, r.getRequestCharge))
@@ -220,8 +225,13 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
               // for compatibility
               throw NoDocumentException("not found on 'get'")
             } else {
-              val js = getResultToWhiskJsonDoc(rr.getResource)
-              transid.finished(this, start, s"[GET] '$collName' completed: found document '$doc'")
+              val (js, docSize) = getResultToWhiskJsonDoc(rr.getResource)
+              transid
+                .finished(
+                  this,
+                  start,
+                  s"[GET] '$collName' completed: found document '$doc',size=$docSize, ru=${rr.getRequestCharge}",
+                  InfoLevel)
               deserialize[A, DocumentAbstraction](doc, js)
             }
           }, {
@@ -254,7 +264,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
           transid.finished(this, start, s"[GET_BY_ID] '$collName' completed: '$id' not found")
           None
         } else {
-          val js = getResultToWhiskJsonDoc(rr.getResource)
+          val (js, _) = getResultToWhiskJsonDoc(rr.getResource)
           transid.finished(this, start, s"[GET_BY_ID] '$collName' completed: found document '$id'")
           Some(js)
         }
@@ -292,7 +302,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .readDocument(selfLinkOf(id), newRequestOption(id))
       .head()
       .map { rr =>
-        val js = getResultToWhiskJsonDoc(rr.getResource)
+        val (js, _) = getResultToWhiskJsonDoc(rr.getResource)
         collectMetrics(getToken, rr.getRequestCharge)
         js
       }
@@ -358,7 +368,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
             this,
             s"[QueryMetricsEnabled] Collection [$collName] - Query [${querySpec.getQueryText}].\nQueryMetrics\n[$combinedMetrics]")
         }
-        transid.finished(this, start, s"[QUERY] '$collName' completed: matched ${out.size}")
+        transid.finished(this, start, s"[QUERY] '$collName' completed: matched ${out.size}", InfoLevel)
     }
     reportFailure(g, start, failure => s"[QUERY] '$collName' internal error, failure: '${failure.getMessage}'")
   }
@@ -465,7 +475,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     e.getStatusCode == StatusCodes.Conflict.intValue || e.getStatusCode == StatusCodes.PreconditionFailed.intValue
   }
 
-  private def toCosmosDoc(json: JsObject): Document = {
+  private def toCosmosDoc(json: JsObject): (Document, Int) = {
     val computedJs = documentHandler.computedFields(json)
     val computedOpt = if (computedJs.fields.nonEmpty) Some(computedJs) else None
     val fieldsToAdd =
@@ -476,10 +486,11 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
         (clusterId, clusterIdValue))
     val fieldsToRemove = Seq(_id, _rev)
     val mapped = transform(json, fieldsToAdd, fieldsToRemove)
+    val jsonString = mapped.compactPrint
     val doc = new Document(mapped.compactPrint)
     doc.set(selfLink, createSelfLink(doc.getId))
     doc.setTimeToLive(null) //Disable any TTL if in effect for earlier revision
-    doc
+    (doc, jsonString.length)
   }
 
   private def queryResultToWhiskJsonDoc(doc: Document): JsObject = {
@@ -490,10 +501,12 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     toWhiskJsonDoc(js, id, None)
   }
 
-  private def getResultToWhiskJsonDoc(doc: Document): JsObject = {
+  private def getResultToWhiskJsonDoc(doc: Document): (JsObject, Int) = {
     checkDoc(doc)
-    val js = doc.toJson.parseJson.asJsObject
-    toWhiskJsonDoc(js, doc.getId, Some(JsString(doc.getETag)))
+    val jsString = doc.toJson
+    val js = jsString.parseJson.asJsObject
+    val whiskDoc = toWhiskJsonDoc(js, doc.getId, Some(JsString(doc.getETag)))
+    (whiskDoc, jsString.length)
   }
 
   private def toDocInfo[T <: Resource](doc: T) = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -489,7 +489,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     val fieldsToRemove = Seq(_id, _rev)
     val mapped = transform(json, fieldsToAdd, fieldsToRemove)
     val jsonString = mapped.compactPrint
-    val doc = new Document(mapped.compactPrint)
+    val doc = new Document(jsonString)
     doc.set(selfLink, createSelfLink(doc.getId))
     doc.setTimeToLive(null) //Disable any TTL if in effect for earlier revision
     (doc, jsonString.length)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -41,6 +41,8 @@ object CosmosDBArtifactStoreProvider extends ArtifactStoreProvider {
   type DocumentClientRef = ReferenceCounted[ClientHolder]#CountedReference
   private val clients = collection.mutable.Map[CosmosDBConfig, ReferenceCounted[ClientHolder]]()
 
+  RetryMetricsCollector.registerIfEnabled()
+
   override def makeStore[D <: DocumentSerializer: ClassTag](useBatching: Boolean)(
     implicit jsonFormat: RootJsonFormat[D],
     docReader: DocumentReader,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.cosmosdb
+
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+import com.microsoft.azure.cosmosdb.rx.internal.ResourceThrottleRetryPolicy
+import kamon.metric.{Counter, MeasurementUnit}
+import org.apache.openwhisk.common.{LogMarkerToken, TransactionId}
+import org.apache.openwhisk.core.ConfigKeys
+import org.slf4j.LoggerFactory
+import pureconfig._
+
+import scala.util.Try
+
+object CosmosDBAction extends Enumeration {
+  val Create, Query, Get, Others = Value
+}
+
+object RetryMetricsCollector extends AppenderBase[ILoggingEvent] {
+  import CosmosDBAction._
+  private val tokens =
+    Map(Create -> Token(Create), Query -> Token(Query), Get -> Token(Get), Others -> Token(Others))
+
+  private[cosmosdb] def registerIfEnabled(): Unit = {
+    val enabled = loadConfigOrThrow[Boolean](s"${ConfigKeys.cosmosdb}.retry-stats-enabled")
+    if (enabled) register()
+  }
+
+  /**
+   * CosmosDB uses below log message
+   * ```
+   * logger.warn(
+   * "Operation will be retried after {} milliseconds. Current attempt {}, Cumulative delay {}",
+   *                     retryDelay.toMillis(),
+   *                     this.currentAttemptCount,
+   *                     this.cumulativeRetryDelay,
+   * exception);
+   * ```
+   *
+   */
+  override def append(e: ILoggingEvent): Unit = {
+    val msg = e.getMessage
+    val errorMsg = Option(e.getThrowableProxy).map(_.getMessage).getOrElse(msg)
+    for {
+      success <- isSuccessOrFailedRetry(msg)
+      token <- tokens.get(operationType(errorMsg))
+    } {
+      if (success) {
+        token.success.counter.increment()
+        //Element 1 has the count
+        val attemptCount = getRetryAttempt(e.getArgumentArray, 1)
+        token.success.histogram.record(attemptCount)
+      } else {
+        token.failed.counter.increment()
+      }
+    }
+  }
+
+  def getCounter(opType: CosmosDBAction.Value, retryPassed: Boolean = true): Option[Counter] = {
+    tokens.get(opType).map(t => if (retryPassed) t.success else t.failed).map { _.counter }
+  }
+
+  private def getRetryAttempt(args: Array[AnyRef], index: Int) = {
+    val t = Try {
+      if (args != null & args.length >= 2) {
+        args(index) match {
+          case n: Number => n.intValue()
+          case _         => 0
+        }
+      } else 0
+    }
+    t.getOrElse(0)
+  }
+
+  private def register(): Unit = {
+    val logCtx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+    val retryLogger = logCtx.getLogger(classOf[ResourceThrottleRetryPolicy].getName)
+    start()
+    retryLogger.addAppender(this)
+  }
+
+  private def isSuccessOrFailedRetry(msg: String) = {
+    if (msg.startsWith("Operation will be retried after")) Some(true)
+    else if (msg.startsWith("Operation will NOT be retried")) Some(false)
+    else None
+  }
+
+  private def operationType(errorMsg: String) = {
+    if (errorMsg.contains("OperationType: Query")) Query
+    else if (errorMsg.contains("OperationType: Create")) Create
+    else if (errorMsg.contains("OperationType: Get")) Get
+    else Others
+  }
+
+  private def createToken(opType: String, retryPassed: Boolean): LogMarkerToken = {
+    val action = if (retryPassed) "success" else "failed"
+    val tags = Map("type" -> opType)
+    if (TransactionId.metricsKamonTags) LogMarkerToken("cosmosdb", "retry", action, tags = tags)(MeasurementUnit.none)
+    else LogMarkerToken("cosmosdb", "retry", action, Some(opType))(MeasurementUnit.none)
+  }
+
+  private case class Token(success: LogMarkerToken, failed: LogMarkerToken)
+
+  private object Token {
+    def apply(opType: CosmosDBAction.Value): Token =
+      new Token(createToken(opType.toString, retryPassed = true), createToken(opType.toString, retryPassed = false))
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
@@ -79,7 +79,7 @@ object RetryMetricsCollector extends AppenderBase[ILoggingEvent] {
 
   private def getRetryAttempt(args: Array[AnyRef], index: Int) = {
     val t = Try {
-      if (args != null & args.length >= 2) {
+      if (args != null & args.length > index) {
         args(index) match {
           case n: Number => n.intValue()
           case _         => 0

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
@@ -17,6 +17,7 @@
 
 package org.apache.openwhisk.core.database.cosmosdb
 
+import akka.event.slf4j.SLF4JLogging
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
@@ -33,14 +34,17 @@ object CosmosDBAction extends Enumeration {
   val Create, Query, Get, Others = Value
 }
 
-object RetryMetricsCollector extends AppenderBase[ILoggingEvent] {
+object RetryMetricsCollector extends AppenderBase[ILoggingEvent] with SLF4JLogging {
   import CosmosDBAction._
   private val tokens =
     Map(Create -> Token(Create), Query -> Token(Query), Get -> Token(Get), Others -> Token(Others))
 
   private[cosmosdb] def registerIfEnabled(): Unit = {
     val enabled = loadConfigOrThrow[Boolean](s"${ConfigKeys.cosmosdb}.retry-stats-enabled")
-    if (enabled) register()
+    if (enabled) {
+      log.info("Enabling retry metrics collector")
+      register()
+    }
   }
 
   /**

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreTests.scala
@@ -17,9 +17,13 @@
 
 package org.apache.openwhisk.core.database.cosmosdb
 
+import java.util.concurrent.CountDownLatch
+
+import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import io.netty.util.ResourceLeakDetector
 import io.netty.util.ResourceLeakDetector.Level
+import kamon.metric.LongAdderCounter
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.database.DocumentSerializer
 import org.apache.openwhisk.core.database.memory.MemoryAttachmentStoreProvider
@@ -28,6 +32,7 @@ import org.apache.openwhisk.core.entity.WhiskQueries.TOP
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.entity.{
   DocumentReader,
+  Parameters,
   WhiskActivation,
   WhiskDocumentReader,
   WhiskEntity,
@@ -35,14 +40,11 @@ import org.apache.openwhisk.core.entity.{
   WhiskPackage
 }
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
 import spray.json.JsString
-import org.apache.openwhisk.core.entity.size._
-import org.junit.runner.RunWith
-import org.scalatest.FlatSpec
-import org.scalatest.junit.JUnitRunner
 
+import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 @RunWith(classOf[JUnitRunner])
@@ -153,5 +155,35 @@ class CosmosDBArtifactStoreTests extends FlatSpec with CosmosDBStoreBehaviorBase
       List(entityPath, TOP, TOP))(debugTid)
     stream.toString should include("[QueryMetricsEnabled]")
 
+  }
+
+  behavior of "CosmosDB retry metrics"
+
+  it should "capture success retries" in {
+    implicit val tid: TransactionId = TransactionId.testing
+    val bigPkg = WhiskPackage(newNS(), aname(), parameters = Parameters("foo", "x" * 1024 * 1024))
+    val latch = new CountDownLatch(1)
+    val f = Source(1 to 500)
+      .mapAsync(100) { i =>
+        latch.countDown()
+        if (i % 5 == 0) println(i)
+        require(retryCount == 0)
+        entityStore.put(bigPkg)
+      }
+      .runForeach { doc =>
+        docsToDelete += ((entityStore, doc))
+      }
+
+    //Wait for one save operation before checking for stats
+    latch.await()
+    retry(() => f, 500.millis)
+    retryCount should be > 0
+  }
+
+  private def retryCount: Int = {
+    RetryMetricsCollector.getCounter(CosmosDBAction.Create) match {
+      case Some(x: LongAdderCounter) => x.snapshot(false).value.toInt
+      case _                         => 0
+    }
   }
 }


### PR DESCRIPTION
This PR enables capturing stats related to document size and RU used for get and put operation. 

## Description

### Document Size Stats

With this PR the `get` and `put` operation would include the document size and RU used

```
[2019-09-30T11:29:53.553Z] [INFO] [#tid_1] [CosmosDBArtifactStore] [PUT] 'subjects' completed document: 'id: anon-OIPNjW7IigJetLxDwwlPwlcG2Fl, rev: null', size=235, ru=7.05 [marker:database_saveDocument_finish:9308:685]
```
Further the PR also add a histogram for document size.

```
# TYPE histogram_cosmosdb_doc_size_bytes histogram
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="512.0"} 0.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="1024.0"} 0.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="2048.0"} 0.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="4096.0"} 0.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="16384.0"} 0.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="65536.0"} 3815.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="524288.0"} 3815.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="1048576.0"} 3815.0
histogram_cosmosdb_doc_size_bytes_bucket{collection="activations",le="+Inf"} 3815.0
histogram_cosmosdb_doc_size_bytes_count{collection="activations"} 3815.0
histogram_cosmosdb_doc_size_bytes_sum{collection="activations"} 192398080.0
```

### Client Diagnostic Stats

If the `TransactionId` has debug mode enabled (extension of support added in #4275) then it would also include some client side diagnostic info generated by CosmosDB when using `Direct` mode

```
[2019-09-30T11:50:34.472Z] [INFO] [#tid_42] [CosmosDBArtifactStore] [PUT] 'subjects' completed document: 'id: anon-MZIVqUOiMiyxxYXJTyLxYnihVNI, rev: null', size=235, ru=7.05 RequestStartTime: "30 Sep 2019 11:50:30.908", RequestEndTime: "30 Sep 2019 11:50:34.464", Duration: 3556 ms, Number of regions attempted: 1 StoreResponseStatistics{requestResponseTime="30 Sep 2019 11:50:33.281", storeResult=storePhysicalAddress: rntbd://cdb-ms-prod-eastus1-fd18.documents.azure.com:14047/apps/a12ab0b2-98f6-4f5a-a7d4-f67e3a08d496/services/e50f5eae-0700-4539-9323-e4a587786587/partitions/eaa72284-4d0b-4ddf-a919-c890c12803a3/replicas/132138294859720735p/, lsn: 1177, globalCommittedLsn: 1176, partitionKeyRangeId: 0, isValid: true, statusCode: 201, subStatusCode: 0, isGone: false, isNotFound: false, isInvalidPartition: false, requestCharge: 7.05, itemLSN: -1, sessionToken: -1#1177, exception: null, requestResourceType=Document, requestOperationType=Create} AddressResolutionStatistics{startTime="30 Sep 2019 11:50:31.471", endTime="30 Sep 2019 11:50:31.705", targetEndpoint='https://foo-eastus.documents.azure.com:443/addresses/?$resolveFor=dbs%2FXk1oAA%3D%3D%2Fcolls%2FXk1oAKUKbiU%3D%2Fdocs&$filter=protocol%20eq%20rntbd&$partitionKeyRangeIds=0'} StoreResponseStatistics{requestResponseTime="30 Sep 2019 11:50:34.464", storeResult=storePhysicalAddress: rntbd://cdb-ms-prod-eastus1-fd18.documents.azure.com:14064/apps/a12ab0b2-98f6-4f5a-a7d4-f67e3a08d496/services/e50f5eae-0700-4539-9323-e4a587786587/partitions/eaa72284-4d0b-4ddf-a919-c890c12803a3/replicas/132119752170912464s/, lsn: 1177, globalCommittedLsn: 1177, partitionKeyRangeId: 0, isValid: true, statusCode: 204, subStatusCode: 0, isGone: false, isNotFound: false, isInvalidPartition: false, requestCharge: 0.0, itemLSN: 660, sessionToken: -1#1177, exception: null, requestResourceType=DocumentCollection, requestOperationType=Head} [marker:database_saveDocument_finish:15080:3568]
```

### Retry stats

The PR also enabled to capture the internal retry done by SDK upon throttling. Currently there is no direct support to capture such stats (Azure/azure-cosmosdb-java#262). So this PR makes use of Logback to capture the stats by intercepting the warning log message generated upon a 429 response

```
[2019-09-27T07:57:15.161Z] [WARN] Operation will be retried after 6 milliseconds. [2019-09-27T07:57:15.161Z] [WARN] Operation will be retried after 6 milliseconds. Current attempt 1, Cumulative delay PT0.006S
com.microsoft.azure.cosmosdb.DocumentClientException: Message: {"Errors":["Request rate is large"]}
ActivityId: 28ebd9fc-2615-4e9f-b4a7-ec3ebb464b36, Request URI: /apps/cebf41ab-a2c2-4055-b592-9887b5c5a634/services/91918f88-9f66-459c-93cf-53644d05f280/partitions/2baa1e8f-3751-444c-8be7-f831dc692a63/replicas/132121471945325759p/, RequestStats:
RequestStartTime: 2019-09-27T07:57:14.6731085Z, RequestEndTime: 2019-09-27T07:57:14.6731085Z, Number of regions attempted: 1
ResponseTime: 2019-09-27T07:57:14.6731085Z, StoreResult: StorePhysicalAddress: rntbd://cdb-ms-prod-eastus1-fd34.documents.azure.com:16701/apps/cebf41ab-a2c2-4055-b592-9887b5c5a634/services/91918f88-9f66-459c-93cf-53644d05f280/partitions/2baa1e8f-3751-444c-8be7-f831dc692a63/replicas/132121471945325759p/, LSN: 1898, GlobalCommittedLsn: 1897, PartitionKeyRangeId: , IsValid: True, StatusCode: 429, SubStatusCode: 3200, RequestCharge: 0.38, ItemLSN: -1, SessionToken: , UsingLocalLSN: False, TransportException: null, ResourceType: Document, OperationType: Create
, SDK: Microsoft.Azure.Documents.Common/2.5.1, StatusCode: TooManyRequests
    at com.microsoft.azure.cosmosdb.rx.internal.RxGatewayStoreModel.validateOrThrow(RxGatewayStoreModel.java:444)
    at com.microsoft.azure.cosmosdb.rx.internal.RxGatewayStoreModel.lambda$null$8(RxGatewayStoreModel.java:382)
```

A typical log message looks like above which has info related to 

1. Attempt count
2. If retry would be done or it was the last retry
3. Operation type like Get or Create etc

Prometheus metrics for retry

```
counter_cosmosdb_retry_success_total{type="Create"} 164.0
```

Prometheus histogram for retry attempt

```
# TYPE histogram_cosmosdb_retry_success histogram
histogram_cosmosdb_retry_success_bucket{type="Create",le="1.0"} 0.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="2.0"} 0.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="3.0"} 0.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="5.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="7.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="10.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="12.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="15.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="20.0"} 1.0
histogram_cosmosdb_retry_success_bucket{type="Create",le="+Inf"} 1.0
histogram_cosmosdb_retry_success_count{type="Create"} 1.0
histogram_cosmosdb_retry_success_sum{type="Create"} 4.0
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

