### PR TITLE
Dump complete exception stacktrace upon failure in StoreUtil

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/StoreUtils.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/StoreUtils.scala
@@ -23,6 +23,7 @@ import akka.event.Logging.ErrorLevel
 import akka.stream.SinkShape
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Keep, Sink}
 import akka.util.ByteString
+import com.google.common.base.Throwables
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsObject, JsValue, RootJsonFormat}
 import org.apache.openwhisk.common.{Logging, StartMarker, TransactionId}
@@ -41,7 +42,11 @@ private[database] object StoreUtils {
     f.failed.foreach {
       case _: ArtifactStoreException => // These failures are intentional and shouldn't trigger the catcher.
       case x =>
-        transid.failed(this, start, s"${failureMessage(x)} [${x.getClass.getSimpleName}]", ErrorLevel)
+        transid.failed(
+          this,
+          start,
+          s"${failureMessage(x)} [${x.getClass.getSimpleName}]\n" + Throwables.getStackTraceAsString(x),
+          ErrorLevel)
     }
     f
   }


### PR DESCRIPTION
At times we are seeing some failures in AryifactStore operations where real cause is a nested exception. 

```
[2019-09-30T13:35:36.747Z] [ERROR] [#tid_fpdgvAqVk3C2AHr1oWhrD0XSJM9mjgP3] [StoreUtils] [GET] 'whisks' internal error, doc: 'id: someaction, rev: "3b00580c-0000-0100-0000-5d91f9f40000"', failure: 'Boxed Error' [ExecutionException] [marker:database_getDocument_error:9:5]
```

This PR now also includes the complete stacktrace as string after a new line (so as to preserve semantics for any log based triggers/alerts). With this the log looks like below

```
[2019-10-01T04:41:19.247Z] [ERROR] [#tid_sid_testing] [StoreUtils] [GET] 'whisks' internal error, doc: 'id: someAction, rev: 3b00580c-0000-0100-0000-5d91f9f40000', failure: 'Boxed Error' [ExecutionException]
java.util.concurrent.ExecutionException: Boxed Error
    at scala.concurrent.impl.Promise$.resolver(Promise.scala:87)
    at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolveTry(Promise.scala:79)
    at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:284)
    at scala.concurrent.Promise.complete(Promise.scala:53)
    at scala.concurrent.Promise.complete$(Promise.scala:52)
    at scala.concurrent.impl.Promise$DefaultPromise.complete(Promise.scala:187)
    at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
    at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
    at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
    at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92)
    at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:41)
    at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:49)
    at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
    at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
    at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
    at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.lang.AssertionError: assertion failed: Returned revision should match original argument
    at scala.Predef$.assert(Predef.scala:223)
    at org.apache.openwhisk.core.database.StoreUtils$.deserialize(StoreUtils.scala:77)
    at org.apache.openwhisk.core.database.cosmosdb.CosmosDBArtifactStore.$anonfun$get$3(CosmosDBArtifactStore.scala:225)
    at scala.concurrent.Future.$anonfun$transform$2(Future.scala:244)
    at scala.concurrent.Future.$anonfun$transform$1(Future.scala:244)
    at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
    ... 13 more
 [marker:database_getDocument_error:8049:840]
```


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

