### PR TITLE
Rephrase description of `provide-api-key`

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -61,7 +61,7 @@ The annotations are _not_ checked. So while it is conceivable to use the annotat
 
 The following annotations on an action are available.
 
-* `provide-api-key`: This annotation may be attached to actions which require an API key, for example to make REST API calls to the OpenWhisk host. For newly created actions, if not specified, it defaults to a false value. For existing actions, the absence of this annotation, or its presence with a value that is not _falsy_ (i.e., a value that is different from zero, null, false, and the empty string) will cause an API key to be present in the [action execution context](./actions.md#accessing-action-metadata-within-the-action-body). 
+* `provide-api-key`: This annotation may be attached to actions which require an API key, for example to make REST API calls to the OpenWhisk host. For newly created actions, if not specified, it defaults to a false value. For existing actions, the absence of this annotation, or its presence with a value that is not _falsy_ (i.e., a value that is different from zero, null, false, and the empty string) will cause an API key to be present in the [action execution context](./actions.md#accessing-action-metadata-within-the-action-body).
 
 # Annotations specific to web actions
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -61,10 +61,7 @@ The annotations are _not_ checked. So while it is conceivable to use the annotat
 
 The following annotations on an action are available.
 
-* `provide-api-key`: This annotation may be attached to actions which require an API key, for example to make REST API calls to the OpenWhisk host.
-The absence of this annotation, or its presence with a value that is not _falsy_ (i.e., a value that is different from zero, null, false, and the empty string)
-will cause an API key to be present in the [action execution context](./actions.md#accessing-action-metadata-within-the-action-body). This annotation is added
-to newly created actions, if not already specified, with a default false value.
+* `provide-api-key`: This annotation may be attached to actions which require an API key, for example to make REST API calls to the OpenWhisk host. For newly created actions, if not specified, it defaults to a false value. For existing actions, the absence of this annotation, or its presence with a value that is not _falsy_ (i.e., a value that is different from zero, null, false, and the empty string) will cause an API key to be present in the [action execution context](./actions.md#accessing-action-metadata-within-the-action-body). 
 
 # Annotations specific to web actions
 


### PR DESCRIPTION
Move the description of the default value of `provide-api-key` for new actions to the beginning of the description, before explaining the behavior when not specified in an existing action. This is to avoid confusion about the value of `provide-api-key` when not provided.

Related to [this suggestion](https://github.com/apache/openwhisk-catalog/issues/309#issuecomment-536907037) (not a direct issue).

