### PR TITLE
Fix invalid environment variable for User Events JVM option

### DIFF
--- a/core/monitoring/user-events/init.sh
+++ b/core/monitoring/user-events/init.sh
@@ -19,7 +19,7 @@
 
 ./copyJMXFiles.sh
 
-export CACHE_INVALIDATOR_OPTS
-CACHE_INVALIDATOR_OPTS="$CACHE_INVALIDATOR_OPTS $(./transformEnvironment.sh)"
+export USER_EVENTS_OPTS
+USER_EVENTS_OPTS="$USER_EVENTS_OPTS $(./transformEnvironment.sh)"
 
 exec user-events/bin/user-events "$@"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

JVM option does not affect the user-events application, because the environment variable is invalid

So I changed the name from `CACHE_INVALIDATOR_OPTS` to `USER_EVENTS_OPTS`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] User events

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

