### PR TITLE
User Events support in OpenWhisk Standalone mode

### DIFF
--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -96,6 +96,8 @@ $ java -jar openwhisk-standalone.jar -h
       --kafka-ui                   Enable Kafka UI
   -m, --manifest  <arg>            Manifest json defining the supported runtimes
   -p, --port  <arg>                Server port
+      --user-events                Enable User Events along with Prometheus and
+                                   Grafana
   -v, --verbose
       --zk-port  <arg>             Zookeeper port. If not specified then 2181 or
                                    some random free port (if 2181 is busy) would
@@ -236,7 +238,7 @@ java -jar openwhisk-standalone.jar --kafka --kafka-ui
 ```
 
 By default the ui server would be accessible at http://localhost:9000. In case 9000 port is busy then a random port would
-be selected. TO find out the port look for message in log like below (or grep for `whisk-kafka-drop-ui`)
+be selected. To find out the port look for message in log like below (or grep for `whisk-kafka-drop-ui`)
 
 ```
 [ 9092  ] localhost:9092 (kafka)
@@ -245,9 +247,33 @@ be selected. TO find out the port look for message in log like below (or grep fo
 [ 9000  ] http://localhost:9000 (whisk-kafka-drop-ui)
 ```
 
+#### User Events
+
+Standalone OpenWhisk supports emitting [user events][7] and displaying them via Grafana Dashboard. The metrics are
+consumed by [User Event Service][8] which converts them into metrics consumed via Prometheus.
+
+```
+java -jar openwhisk-standalone.jar --user-events
+```
+
+This mode would launch an embedded Kafka, User Event service, Prometheus and Grafana with preconfigured dashboards.
+
+```
+Launched service details
+
+[ 9092  ] localhost:9092 (kafka)
+[ 9091  ] 192.168.65.2:9091 (kafka-docker)
+[ 2181  ] Zookeeper (zookeeper)
+[ 3235  ] http://localhost:3235 (whisk-user-events)
+[ 9090  ] http://localhost:9090 (whisk-prometheus)
+[ 3000  ] http://localhost:3000 (whisk-grafana)
+```
+
 [1]: https://github.com/apache/incubator-openwhisk/blob/master/docs/cli.md
 [2]: https://github.com/apache/incubator-openwhisk/blob/master/docs/samples.md
 [3]: https://github.com/apache/incubator-openwhisk-apigateway
 [4]: https://github.com/apache/incubator-openwhisk/blob/master/docs/apigateway.md
 [5]: https://github.com/embeddedkafka/embedded-kafka
 [6]: https://github.com/obsidiandynamics/kafdrop
+[7]: https://github.com/apache/openwhisk/blob/master/docs/metrics.md#user-specific-metrics
+[8]: https://github.com/apache/openwhisk/blob/master/core/monitoring/user-events/README.md

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -80,8 +80,24 @@ task copyGWActions() {
     }
 }
 
+task copyGrafanaConfig() {
+    doLast {
+        def grafanaDir = new File(project.rootProject.getProjectDir(), "core/monitoring/user-events/compose/grafana")
+        def grafanaBuildDir = mkdir("$buildDir/tmp/grafana")
+        def zipFileName = "grafana-config.zip"
+        def zipFile = new File(grafanaBuildDir, zipFileName)
+        if (!zipFile.exists()) {
+            ant.zip(destfile:zipFile){
+                fileset(dir:grafanaDir)
+            }
+            logger.info("Create action zip $zipFileName")
+        }
+    }
+}
+
 processResources.dependsOn copySwagger
 processResources.dependsOn copyGWActions
+processResources.dependsOn copyGrafanaConfig
 
 processResources {
     from(new File(project.rootProject.projectDir, "ansible/files/runtimes.json")) {
@@ -90,6 +106,9 @@ processResources {
     from(new File(project.rootProject.projectDir, "ansible/files")) {
         include "*.json"
         into("couch")
+    }
+    from(file("$buildDir/tmp/grafana/grafana-config.zip")){
+        into(".")
     }
     //Implement the logic present in controller Docker file
     from(project.swaggerUiDir) {

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -110,6 +110,9 @@ processResources {
     from(file("$buildDir/tmp/grafana/grafana-config.zip")){
         into(".")
     }
+    from(new File(project.rootProject.getProjectDir(), "core/monitoring/user-events/compose/prometheus/prometheus.yml")){
+        into(".")
+    }
     //Implement the logic present in controller Docker file
     from(project.swaggerUiDir) {
         include "index.html"

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -90,7 +90,7 @@ task copyGrafanaConfig() {
             ant.zip(destfile:zipFile){
                 fileset(dir:grafanaDir)
             }
-            logger.info("Create action zip $zipFileName")
+            logger.info("Created grafana config zip $zipFileName")
         }
     }
 }

--- a/core/standalone/src/main/resources/standalone.conf
+++ b/core/standalone/src/main/resources/standalone.conf
@@ -114,8 +114,15 @@ whisk {
         "logCleanup_design_document_for_activations_db.json"
       ]
     }
+
+    user-events {
+      image = "openwhisk/user-events:nightly"
+      prometheus-image = "prom/prometheus:v2.5.0"
+      grafana-image = "grafana/grafana:6.1.6"
+    }
   }
   apache-client {
     retry-no-http-response-exception = true
   }
+
 }

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/Unzip.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/Unzip.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.standalone
+
+import java.io.{File, FileOutputStream, InputStream}
+import java.util.zip.ZipInputStream
+
+object Unzip {
+
+  def apply(is: InputStream, dir: File): Unit = {
+    //Based on https://stackoverflow.com/a/40547896/1035417
+    val zis = new ZipInputStream((is))
+    val dest = dir.toPath
+    Stream.continually(zis.getNextEntry).takeWhile(_ != null).foreach { zipEntry =>
+      if (!zipEntry.isDirectory) {
+        val outPath = dest.resolve(zipEntry.getName)
+        val outPathParent = outPath.getParent
+        if (!outPathParent.toFile.exists()) {
+          outPathParent.toFile.mkdirs()
+        }
+
+        val outFile = outPath.toFile
+        val out = new FileOutputStream(outFile)
+        val buffer = new Array[Byte](4096)
+        Stream.continually(zis.read(buffer)).takeWhile(_ != -1).foreach(out.write(buffer, 0, _))
+        out.close()
+      }
+    }
+    zis.close()
+  }
+
+}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
@@ -82,7 +82,6 @@ class UserEventLauncher(docker: StandaloneDockerClient, owPort: Int, kafkaDocker
 
     val volParams = Map(
       "-v" -> Set(s"${promDataDir.getAbsolutePath}:/prometheus", s"${promConfigDir.getAbsolutePath}:/etc/prometheus/"))
-    val cmd = Seq("--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus")
     val name = containerName("prometheus")
     val args = createRunCmd(name, Map.empty, baseParams ++ volParams)
     val f = docker.runDetached(userEventConfig.prometheusImage, args, shouldPull = true)

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
@@ -133,11 +133,17 @@ class UserEventLauncher(docker: StandaloneDockerClient, owPort: Int, kafkaDocker
 
   private def unzipGrafanaConfig(configDir: File, promUrl: String): Unit = {
     val is = getClass.getResourceAsStream("/grafana-config.zip")
-    Unzip(is, configDir)
-    val configFile = new File(configDir, "provisioning/datasources/datasource.yml")
-    val config = FileUtils.readFileToString(configFile, UTF_8)
-    val updatedConfig = config.replace("http://prometheus:9090", promUrl)
-    FileUtils.write(configFile, updatedConfig, UTF_8)
+    if (is != null) {
+      Unzip(is, configDir)
+      val configFile = new File(configDir, "provisioning/datasources/datasource.yml")
+      val config = FileUtils.readFileToString(configFile, UTF_8)
+      val updatedConfig = config.replace("http://prometheus:9090", promUrl)
+      FileUtils.write(configFile, updatedConfig, UTF_8)
+    } else {
+      logging.warn(
+        this,
+        "Did not found the grafana-config.zip in classpath. Make sure its packaged and present in classpath")
+    }
   }
 
   private def newDir(baseDir: File, name: String) = {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.standalone
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.apache.commons.io.FileUtils
+import org.apache.openwhisk.common.{Logging, TransactionId}
+import org.apache.openwhisk.standalone.StandaloneDockerSupport.{checkOrAllocatePort, containerName, createRunCmd}
+import pureconfig.loadConfigOrThrow
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserEventLauncher(docker: StandaloneDockerClient, owPort: Int, kafkaDockerPort: Int, workDir: File, dataDir: File)(
+  implicit logging: Logging,
+  ec: ExecutionContext,
+  actorSystem: ActorSystem,
+  materializer: ActorMaterializer,
+  tid: TransactionId) {
+
+  //owPort+1 is used by Api Gateway
+  private val userEventPort = checkOrAllocatePort(owPort + 2)
+  private val prometheusPort = checkOrAllocatePort(9090)
+  private val grafanaPort = checkOrAllocatePort(3000)
+
+  case class UserEventConfig(image: String, prometheusImage: String, grafanaImage: String)
+
+  private val userEventConfig = loadConfigOrThrow[UserEventConfig](StandaloneConfigKeys.userEventConfigKey)
+
+  private val hostIp = StandaloneDockerSupport.getLocalHostIp()
+
+  def run(): Future[Seq[ServiceContainer]] = {
+    for {
+      userEvent <- runUserEvents()
+      (promContainer, promSvc) <- runPrometheus()
+    } yield Seq(userEvent, promSvc)
+  }
+
+  def runUserEvents(): Future[ServiceContainer] = {
+    val env = Map("KAFKA_HOSTS" -> s"$hostIp:$kafkaDockerPort")
+
+    logging.info(this, s"Starting User Events: $userEventPort")
+    val name = containerName("user-events")
+    val params = Map("-p" -> Set(s"$userEventPort:9095"))
+    val args = createRunCmd(name, env, params)
+
+    val f = docker.runDetached(userEventConfig.image, args, true)
+    f.map(_ => ServiceContainer(userEventPort, s"http://localhost:$userEventPort", name))
+  }
+
+  def runPrometheus(): Future[(StandaloneDockerContainer, ServiceContainer)] = {
+    logging.info(this, s"Starting Prometheus at $prometheusPort")
+    val baseParams = Map("-p" -> Set(s"$prometheusPort:9090"))
+    val promConfigDir = newDir(workDir, "prometheus")
+    val promDataDir = newDir(dataDir, "prometheus")
+
+    val configFile = new File(promConfigDir, "prometheus.yml")
+    FileUtils.write(configFile, prometheusConfig, UTF_8)
+
+    val volParams = Map(
+      "-v" -> Set(s"${promDataDir.getAbsolutePath}:/prometheus", s"${promConfigDir.getAbsolutePath}:/etc/prometheus/"))
+    val cmd = Seq("--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus")
+    val name = containerName("prometheus")
+    val args = createRunCmd(name, Map.empty, baseParams ++ volParams)
+    val f = docker.runDetached(userEventConfig.prometheusImage, args, shouldPull = true)
+    val sc = ServiceContainer(prometheusPort, s"http://localhost:$prometheusPort", name)
+    f.map(c => (c, sc))
+  }
+
+  def runGrafana(promContainer: StandaloneDockerContainer): Future[ServiceContainer] = {
+    logging.info(this, s"Starting Grafana at $grafanaPort")
+    val baseParams = Map("-p" -> Set(s"$grafanaPort:3000"))
+    val grafanaConfigDir = newDir(workDir, "grafana")
+    val grafanaDataDir = newDir(dataDir, "grafana")
+
+    unzipGrafanaConfig(grafanaConfigDir)
+
+    val env = Map(
+      "GF_PATHS_PROVISIONING" -> "/etc/grafana/provisioning",
+      "GF_USERS_ALLOW_SIGN_UP" -> "false",
+      "GF_AUTH_ANONYMOUS_ENABLED" -> "true",
+      "GF_AUTH_ANONYMOUS_ORG_NAME" -> "Main Org.",
+      "GF_AUTH_ANONYMOUS_ORG_ROLE" -> "Admin")
+
+    val volParams = Map(
+      "-v" -> Set(
+        s"${grafanaDataDir.getAbsolutePath}:/var/lib/grafanas",
+        s"${grafanaConfigDir.getAbsolutePath}/provisioning/:/etc/grafana/provisioning/",
+        s"${grafanaConfigDir.getAbsolutePath}/dashboards/:/var/lib/grafana/dashboards/"))
+    val name = containerName("grafana")
+    val args = createRunCmd(name, env, baseParams ++ volParams)
+    val f = docker.runDetached(userEventConfig.grafanaImage, args, shouldPull = true)
+    val sc = ServiceContainer(grafanaPort, s"http://localhost:$grafanaPort", name)
+    f.map(_ => sc)
+  }
+
+  private def prometheusConfig =
+    s"""global:
+  |  scrape_interval: 10s
+  |  evaluation_interval: 10s
+  |
+  |scrape_configs:
+  |  - job_name: 'prometheus-server'
+  |    static_configs:
+  |      - targets: ['localhost:9090']
+  |
+  |  - job_name: 'openwhisk-metrics'
+  |    static_configs:
+  |      - targets: ['$hostIp:$userEventPort', '$hostIp:$owPort']""".stripMargin
+
+  private def unzipGrafanaConfig(configDir: File): Unit = {
+    //TODO Update prometheus url in config
+    //TODO
+  }
+
+  private def newDir(baseDir: File, name: String) = {
+    val dir = new File(baseDir, name)
+    FileUtils.forceMkdir(dir)
+    dir
+  }
+}


### PR DESCRIPTION
Adds support for launching User Event service along with preconfigured Grafana and Prometheus instances. 

## Description

This PR adds support for launching [User Event service](https://github.com/apache/openwhisk/blob/master/core/monitoring/user-events/README.md) with pre configured Grafana dashboard

To give it a try download a [pre built jar](https://github.com/chetanmeh/incubator-openwhisk/releases/download/v0.13/openwhisk-standalone.jar) and then launch it as below and access http://localhost:3000 to see the dashboards

```
java -jar openwhisk-standalone.jar --user-events
```

Key aspects

1. Launches a User Event service which listens to `events` topic
2. Launches a Prometheus server with default at http://localhost:9090
3. Launches a Grafana server with default at http://localhost:3000

The Grafana server is pre-configured with various dashboards. 

```
===================================================
Launched service details

[ 3233  ] http://localhost:3233 (Controller)
[ 9092  ] localhost:9092 (kafka)
[ 9091  ] 192.168.65.2:9091 (kafka-docker)
[ 2181  ] Zookeeper (zookeeper)
[ 9000  ] http://localhost:9000 (whisk-kafka-drop-ui)
[ 3235  ] http://localhost:3235 (whisk-user-events)
[ 9090  ] http://localhost:9090 (whisk-prometheus)
[ 3000  ] http://localhost:3000 (whisk-grafana)

===================================================
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

