### PR TITLE
Move out standalone server tests to a new Travis profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ jobs:
       - ./tools/travis/checkAndUploadLogs.sh multi-runtime
       name: "Multi-Runtime Tests"
     - script:
+        - ./tools/travis/runStandaloneTests.sh
+        - ./tools/travis/checkAndUploadLogs.sh standalone
+      name: "Standalone Tests"
+    - script:
         - ./tests/performance/preparation/deploy.sh
         - TERM=dumb ./tests/performance/wrk_tests/latency.sh "https://172.17.0.1:10001" "$(cat ansible/files/auth.guest)" ./tests/performance/preparation/actions/noop.js 2m
         - TERM=dumb ./tests/performance/wrk_tests/latency.sh "https://172.17.0.1:10001" "$(cat ansible/files/auth.guest)" ./tests/performance/preparation/actions/async.js 2m

--- a/ansible/downloadcli-github.yml
+++ b/ansible/downloadcli-github.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# This playbook is used to download cli from Github and copy directly to bin
+
+- hosts: ansible
+  tasks:
+  - name: grab the local CLI from the Github
+    unarchive:
+      src: "{{ openwhisk_cli.remote.location }}/{{ openwhisk_cli.archive_name}}-{{ openwhisk_cli_tag }}-{{os}}-{{arch}}.{{ext}}"
+      dest: "{{ openwhisk_home }}/bin"
+      mode: "0755"
+      remote_src: yes
+    vars:
+      arch: "{{ ansible_machine | replace ('x86_64', 'amd64') }}"
+      os: "{{ ansible_system | lower | replace('darwin', 'mac') }}"
+      ext: "{{ ( ansible_system in ['Windows', 'Darwin']) | ternary('zip', 'tgz') }}"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -81,9 +81,7 @@ ext.testSets = [
         ]
     ],
     "REQUIRE_SYSTEM" : [
-        "includes" : systemIncludes + [
-            "org/apache/openwhisk/standalone/**"
-        ],
+        "includes" : systemIncludes,
         "excludes": [
             "system/basic/WskMultiRuntimeTests*",
             'invokerShoot/**'
@@ -112,6 +110,11 @@ ext.testSets = [
             "**/*KafkaConnectorTests*",
             "system/basic/WskMultiRuntimeTests*",
             "invokerShoot/**"
+        ]
+    ],
+    "REQUIRE_STANDALONE" : [
+        "includes" : [
+            "org/apache/openwhisk/standalone/**"
         ]
     ]
 ]

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+ROOTDIR="$SCRIPTDIR/../.."
+
+export ORG_GRADLE_PROJECT_testSetName="REQUIRE_STANDALONE"
+export GRADLE_COVERAGE=true
+
+cd $ROOTDIR/ansible
+$ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
+$ANSIBLE_CMD downloadcli-github.yml
+
+
+cd $ROOTDIR
+TERM=dumb ./gradlew :core:standalone:build
+TERM=dumb ./gradlew :core:monitoring:user-events:distDocker
+
+cd $ROOTDIR/tools/travis
+./runTests.sh

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -25,12 +25,11 @@ ROOTDIR="$SCRIPTDIR/../.."
 export ORG_GRADLE_PROJECT_testSetName="REQUIRE_STANDALONE"
 export GRADLE_COVERAGE=true
 
-cd $ROOTDIR/ansible
-$ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
-$ANSIBLE_CMD downloadcli-github.yml
-
-
 cd $ROOTDIR
+
+ansible-playbook -i ansible/environments/local ansible/properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
+ansible-playbook -i ansible/environments/local ansible/downloadcli-github.yml
+
 TERM=dumb ./gradlew :core:standalone:build
 TERM=dumb ./gradlew :core:monitoring:user-events:distDocker
 

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -26,9 +26,9 @@ export ORG_GRADLE_PROJECT_testSetName="REQUIRE_STANDALONE"
 export GRADLE_COVERAGE=true
 
 cd $ROOTDIR/ansible
-$ANSIBLE_CMD ansible/setup.yml
-$ANSIBLE_CMD ansible/properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
-$ANSIBLE_CMD ansible/downloadcli-github.yml
+$ANSIBLE_CMD setup.yml
+$ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
+$ANSIBLE_CMD downloadcli-github.yml
 
 cd $ROOTDIR
 TERM=dumb ./gradlew :core:standalone:build

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -25,11 +25,12 @@ ROOTDIR="$SCRIPTDIR/../.."
 export ORG_GRADLE_PROJECT_testSetName="REQUIRE_STANDALONE"
 export GRADLE_COVERAGE=true
 
+cd $ROOTDIR/ansible
+$ANSIBLE_CMD ansible/setup.yml
+$ANSIBLE_CMD ansible/properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
+$ANSIBLE_CMD ansible/downloadcli-github.yml
+
 cd $ROOTDIR
-
-ansible-playbook -i ansible/environments/local ansible/properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
-ansible-playbook -i ansible/environments/local ansible/downloadcli-github.yml
-
 TERM=dumb ./gradlew :core:standalone:build
 TERM=dumb ./gradlew :core:monitoring:user-events:distDocker
 

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -36,3 +36,6 @@ TERM=dumb ./gradlew :core:monitoring:user-events:distDocker
 
 cd $ROOTDIR/tools/travis
 ./runTests.sh
+
+cd $ROOTDIR
+TERM=dumb ./gradlew :core:standalone:cleanTest :core:standalone:test

--- a/tools/travis/runUnitTests.sh
+++ b/tools/travis/runUnitTests.sh
@@ -34,7 +34,3 @@ cat "$ROOTDIR/tests/src/test/resources/application.conf"
 ./distDocker.sh
 
 ./runTests.sh
-
-cd $ROOTDIR
-TERM=dumb ./gradlew :core:standalone:cleanTest :core:standalone:test
-


### PR DESCRIPTION
Currently the system test profile time is hovering around 50 mins. This PR moves out the standalo ne test to a new profile

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

