### PR TITLE
add config to allow removal of Activation result before storing in some cases

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -326,6 +326,11 @@ whisk {
         #           instance                    64
         #           uniqueName + displayName    253 (max pod name length in Kube)
         serdes-overhead = 6036 // 3018 bytes of metadata * 2 for extra headroom
+
+        activation-response {
+            exclude-blocking-result = false //in case activation was blocking + successful + !debug + !timeout, exclude result from Activation record in db (to save storage costs).
+            blocking-timeout = 45 seconds //only exclude results when blocking response returns within this timeout, to avoid case where blocking turns non-blocking (hard coded to 60s)
+        }
     }
 
     # action timelimit configuration

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -264,5 +264,7 @@ object ConfigKeys {
   val whiskConfig = "whisk.config"
   val swaggerUi = "whisk.swagger-ui"
 
+  val activationResultConfig = s"$activation.activation-response"
+
   val apacheClientConfig = "whisk.apache-client"
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -54,7 +54,8 @@ case class ActivationMessage(override val transid: TransactionId,
                              content: Option[JsObject],
                              initArgs: Set[String] = Set.empty,
                              cause: Option[ActivationId] = None,
-                             traceContext: Option[Map[String, String]] = None)
+                             traceContext: Option[Map[String, String]] = None,
+                             debug: Boolean = false)
     extends Message {
 
   override def serialize = ActivationMessage.serdes.write(this).compactPrint
@@ -167,7 +168,7 @@ object ActivationMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
 
   private implicit val fqnSerdes = FullyQualifiedEntityName.serdes
-  implicit val serdes = jsonFormat11(ActivationMessage.apply)
+  implicit val serdes = jsonFormat12(ActivationMessage.apply)
 }
 
 object CombinedCompletionAndResultMessage extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -131,8 +131,7 @@ class DockerToActivationFileLogStore(system: ActorSystem, destinationDirectory: 
 
     val additionalMetadata = Map(
       "activationId" -> activation.activationId.asString.toJson,
-      "action" -> action.fullyQualifiedName(false).asString.toJson,
-      "namespace" -> user.namespace.name.asString.toJson) ++ userIdField
+      "action" -> action.fullyQualifiedName(false).asString.toJson) ++ userIdField
 
     val augmentedActivation = JsObject(activation.toJson.fields ++ userIdField)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
@@ -55,15 +55,9 @@ class ArtifactWithFileStorageActivationStore(
   override def store(activation: WhiskActivation, context: UserContext)(
     implicit transid: TransactionId,
     notifier: Option[CacheChangeNotification]): Future[DocInfo] = {
-    val additionalFieldsForLogs =
-      Map(config.userIdField -> context.user.namespace.uuid.toJson, "namespace" -> context.user.namespace.name.toJson)
-    val additionalFieldsForActivation = Map(config.userIdField -> context.user.namespace.uuid.toJson)
+    val additionalFields = Map(config.userIdField -> context.user.namespace.uuid.toJson)
 
-    activationFileStorage.activationToFileExtended(
-      activation,
-      context,
-      additionalFieldsForLogs,
-      additionalFieldsForActivation)
+    activationFileStorage.activationToFile(activation, context, additionalFields)
     super.store(activation, context)
   }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PostActionActivation.scala
@@ -49,15 +49,17 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
+    debug: Boolean,
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     action.toExecutableWhiskAction match {
       // this is a topmost sequence
       case None =>
         val SequenceExecMetaData(components) = action.exec
-        invokeSequence(user, action, components, payload, waitForResponse, cause, topmost = true, 0).map(r => r._1)
+        invokeSequence(user, action, components, payload, waitForResponse, debug, cause, topmost = true, 0).map(r =>
+          r._1)
       // a non-deprecated ExecutableWhiskAction
       case Some(executable) if !executable.exec.deprecated =>
-        invokeSingleAction(user, executable, payload, waitForResponse, cause)
+        invokeSingleAction(user, executable, payload, waitForResponse, debug, cause)
       // a deprecated exec
       case _ =>
         Future.failed(RejectRequest(BadRequest, Messages.runtimeDeprecated(action.exec)))

--- a/tests/src/test/scala/common/WskCliOperations.scala
+++ b/tests/src/test/scala/common/WskCliOperations.scala
@@ -281,6 +281,7 @@ class CliActionOperations(override val wsk: RunCliCmd)
                       parameterFile: Option[String] = None,
                       blocking: Boolean = false,
                       result: Boolean = false,
+                      debug: Boolean = false,
                       expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult = {
     val params = Seq(noun, "invoke", "--auth", wp.authKey, fqn(name)) ++ {
       parameters flatMap { p =>

--- a/tests/src/test/scala/common/WskOperations.scala
+++ b/tests/src/test/scala/common/WskOperations.scala
@@ -251,6 +251,7 @@ trait ActionOperations extends DeleteFromCollectionOperations with ListOrGetFrom
              parameterFile: Option[String] = None,
              blocking: Boolean = false,
              result: Boolean = false,
+             debug: Boolean = false,
              expectedExitCode: Int = SUCCESS_EXIT)(implicit wp: WskProps): RunResult
 }
 

--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -380,8 +380,9 @@ class RestActionOperations(implicit val actorSystem: ActorSystem)
                       parameterFile: Option[String] = None,
                       blocking: Boolean = false,
                       result: Boolean = false,
+                      debug: Boolean = false,
                       expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
-    super.invokeAction(name, parameters, parameterFile, blocking, result, expectedExitCode = expectedExitCode)
+    super.invokeAction(name, parameters, parameterFile, blocking, result, debug, expectedExitCode = expectedExitCode)
   }
 
   private def readCodeFromFile(artifact: Option[String]): Option[String] = {
@@ -1329,6 +1330,7 @@ trait RunRestCmd extends Matchers with ScalaFutures with SwaggerValidator {
                    parameterFile: Option[String] = None,
                    blocking: Boolean = false,
                    result: Boolean = false,
+                   debug: Boolean = false,
                    web: Boolean = false,
                    expectedExitCode: Int = Accepted.intValue)(implicit wp: WskProps): RestResult = {
     val (ns, actName) = getNamespaceEntityName(name)
@@ -1337,7 +1339,9 @@ trait RunRestCmd extends Matchers with ScalaFutures with SwaggerValidator {
       if (web) Path(s"$basePath/web/$systemNamespace/$actName.http")
       else Path(s"$basePath/namespaces/$ns/actions/$actName")
 
-    val paramMap = Map("blocking" -> blocking.toString, "result" -> result.toString)
+    val paramMap = Map("blocking" -> blocking.toString, "result" -> result.toString) ++ {
+      if (debug) Map("debug" -> debug.toString) else Map.empty
+    }
 
     val input = parameterFile map { pf =>
       Some(FileUtils.readFileToString(new File(pf), StandardCharsets.UTF_8))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/logging/test/DockerToActivationFileLogStoreTests.scala
@@ -47,12 +47,12 @@ class DockerToActivationFileLogStoreTests
   override def createStore() = new TestLogStoreTo(Sink.ignore)
 
   def toLoggedEvent(line: LogLine,
-                    namespace: Namespace,
+                    userId: UUID,
                     activationId: ActivationId,
                     actionName: FullyQualifiedEntityName): String = {
     val event = line.toJson.compactPrint
     val concatenated =
-      s""","activationId":"${activationId.asString}","action":"${actionName.asString}","namespace":"${namespace.name.asString}","namespaceId":"${namespace.uuid.asString}""""
+      s""","activationId":"${activationId.asString}","action":"${actionName.asString}","namespaceId":"${userId.asString}""""
 
     event.dropRight(1) ++ concatenated ++ "}\n"
   }
@@ -78,7 +78,7 @@ class DockerToActivationFileLogStoreTests
     await(collected) shouldBe ActivationLogs(logs.map(_.toFormattedString).toVector)
     logs.foreach { line =>
       testActor.expectMsg(
-        toLoggedEvent(line, user.namespace, successfulActivation.activationId, action.fullyQualifiedName(false)))
+        toLoggedEvent(line, user.namespace.uuid, successfulActivation.activationId, action.fullyQualifiedName(false)))
     }
 
     // Last message should be the full activation
@@ -111,7 +111,11 @@ class DockerToActivationFileLogStoreTests
     withClue("Provided logs should be received by log store:") {
       logs.foreach { line =>
         testActor.expectMsg(
-          toLoggedEvent(line, user.namespace, developerErrorActivation.activationId, action.fullyQualifiedName(false)))
+          toLoggedEvent(
+            line,
+            user.namespace.uuid,
+            developerErrorActivation.activationId,
+            action.fullyQualifiedName(false)))
       }
     }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiWithDbPollingTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiWithDbPollingTests.scala
@@ -24,7 +24,6 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.core.controller.WhiskActionsApi
-import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
 import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.core.entity._
 import org.junit.runner.RunWith

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiWithoutDbPollingTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiWithoutDbPollingTests.scala
@@ -24,7 +24,6 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.core.controller.WhiskActionsApi
-import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
 import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.core.entity._
 import org.junit.runner.RunWith

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ConductorsApiWithoutDbPollingTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ConductorsApiWithoutDbPollingTests.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller.test
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.Route
+import java.time.Instant
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.connector.ActivationMessage
+import org.apache.openwhisk.core.controller.WhiskActionsApi
+import org.apache.openwhisk.core.database.UserContext
+import org.apache.openwhisk.core.entity._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.language.postfixOps
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+/**
+ * Tests Conductor API - stand-alone tests that require only the controller to be up
+ */
+@RunWith(classOf[JUnitRunner])
+class ConductorsApiWithoutDbPollingTests extends ControllerTestCommon with WhiskActionsApi {
+
+  behavior of "Conductor API"
+
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  val creds = WhiskAuthHelpers.newIdentity()
+  val context = UserContext(creds)
+  val namespace = EntityPath(creds.subject.asString)
+  val defaultNamespace = EntityPath.DEFAULT
+  val alternateCreds = WhiskAuthHelpers.newIdentity()
+  val alternateNamespace = EntityPath(alternateCreds.subject.asString)
+
+  val allowedActionDuration = 120 seconds
+  val maxBlockingWait = 1.seconds
+
+  // test actions
+  val echo = MakeName.next("echo")
+  val conductor = MakeName.next("conductor")
+  val step = MakeName.next("step")
+  val slow = MakeName.next("slow")
+  val missing = MakeName.next("missingAction") // undefined
+  val invalid = "invalid#Action" // invalid name
+
+  val testString = "this is a test"
+  val duration = 42
+  override val controllerActivationConfig = ControllerActivationConfig(false, maxBlockingWait)
+  override val activationResponseConfig =
+    ActivationResponseConfig(
+      true,
+      maxBlockingWait - 500.milliseconds,
+      controllerActivationConfig = controllerActivationConfig)
+  override val loadBalancer = new FakeLoadBalancerService(whiskConfig)
+  override val activationIdFactory = new ActivationId.ActivationIdGenerator() {}
+
+  it should "invoke a blocking conductor and exclude the result " in {
+    implicit val tid = transid()
+    put(entityStore, WhiskAction(namespace, conductor, jsDefault("??"), annotations = Parameters("conductor", "true")))
+    put(entityStore, WhiskAction(namespace, step, jsDefault("??")))
+    put(entityStore, WhiskAction(namespace, slow, jsDefault("??")))
+    put(entityStore, WhiskAction(alternateNamespace, step, jsDefault("??"))) // forbidden action
+    val forbidden = s"/$alternateNamespace/$step" // forbidden action name
+
+    // dynamically invoke step action
+    Post(
+      s"$collectionPath/${conductor}?blocking=true",
+      JsObject("action" -> step.toJson, "params" -> JsObject("n" -> 1.toJson))) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response.fields("response").asJsObject.fields("result") shouldBe JsObject("n" -> 2.toJson)
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 3
+      response.fields("duration") shouldBe (3 * duration).toJson
+
+      //verify that result is not in db record
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+      dbActivation.response.result shouldBe None
+    }
+
+    // dynamically invoke step action with an error result
+    Post(s"$collectionPath/${conductor}?blocking=true", JsObject("action" -> step.toJson)) ~> Route.seal(routes(creds)) ~> check {
+      status should not be (OK)
+      val response = responseAs[JsObject]
+      response.fields("response").asJsObject.fields("status") shouldBe "application error".toJson
+      response.fields("response").asJsObject.fields("result") shouldBe JsObject("error" -> "missing parameter".toJson)
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 3
+      response.fields("duration") shouldBe (3 * duration).toJson
+
+      //verify that result is in db record (since this was an error)
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+      dbActivation.response.result shouldBe Some(JsObject("error" -> "missing parameter".toJson))
+    }
+
+    // dynamically invoke step action with debug
+    Post(
+      s"$collectionPath/${conductor}?blocking=true&debug=true",
+      JsObject("action" -> step.toJson, "params" -> JsObject("n" -> 1.toJson))) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response.fields("response").asJsObject.fields("result") shouldBe JsObject("n" -> 2.toJson)
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 3
+      response.fields("duration") shouldBe (3 * duration).toJson
+
+      //verify that result is not in db record
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+      dbActivation.response.result shouldBe Some(JsObject("n" -> 2.toJson))
+    }
+
+    // dynamically invoke step action exceeding blocking timeout
+    Post(
+      s"$collectionPath/${conductor}?blocking=true",
+      JsObject("action" -> slow.toJson, "params" -> JsObject("n" -> 1.toJson))) ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[JsObject]
+      response.fields("response").asJsObject.fields("result") shouldBe JsObject("slowfield" -> "slowvalue".toJson)
+      response.fields("logs").convertTo[JsArray].elements.size shouldBe 3
+
+      //verify that result is in db record
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+      dbActivation.response.result shouldBe Some(JsObject("slowfield" -> "slowvalue".toJson))
+    }
+
+  }
+
+  // fake load balancer to emulate a handful of actions
+  class FakeLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionContext)
+      extends DegenerateLoadBalancerService(config) {
+
+    private def respond(action: ExecutableWhiskActionMetaData,
+                        msg: ActivationMessage,
+                        result: JsObject,
+                        duration: FiniteDuration = 42.milliseconds) = {
+      val response =
+        if (result.fields.get("error") isDefined) ActivationResponse(ActivationResponse.ApplicationError, Some(result))
+        else ActivationResponse.success(Some(result))
+      val start = Instant.now
+      WhiskActivation(
+        action.namespace,
+        action.name,
+        msg.user.subject,
+        msg.activationId,
+        start,
+        end = start.plusMillis(duration.toMillis),
+        duration = Some(duration.toMillis),
+        response = response)
+    }
+
+    override def publish(action: ExecutableWhiskActionMetaData, msg: ActivationMessage)(
+      implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
+      msg.content map { args =>
+        Future.successful {
+          action.name match {
+            case `echo` => // echo action
+              Future(Right(respond(action, msg, args)))
+            case `conductor` => // see tests/dat/actions/conductor.js
+              val result =
+                if (args.fields.get("error") isDefined) args
+                else {
+                  val action = args.fields.get("action") map { action =>
+                    Map("action" -> action)
+                  } getOrElse Map.empty
+                  val state = args.fields.get("state") map { state =>
+                    Map("state" -> state)
+                  } getOrElse Map.empty
+                  val wrappedParams = args.fields.getOrElse("params", JsObject.empty).asJsObject.fields
+                  val escapedParams = args.fields - "action" - "state" - "params"
+                  val params = Map("params" -> JsObject(wrappedParams ++ escapedParams))
+                  JsObject(params ++ action ++ state)
+                }
+              Future(Right(respond(action, msg, result)))
+            case `step` => // see tests/dat/actions/step.js
+              val result = args.fields.get("n") map { n =>
+                JsObject("n" -> (n.convertTo[BigDecimal] + 1).toJson)
+              } getOrElse {
+                JsObject("error" -> "missing parameter".toJson)
+              }
+              Future(Right(respond(action, msg, result)))
+            case `slow` => // see tests/dat/actions/step.js
+              Future(
+                Right(
+                  respond(
+                    action,
+                    msg,
+                    Map("slowfield" -> "slowvalue".toJson).toJson.asJsObject,
+                    maxBlockingWait + 100.milliseconds)))
+            case _ =>
+              Future.failed(new IllegalArgumentException("Unkown action invoked in conductor test"))
+          }
+        }
+      } getOrElse Future.failed(new IllegalArgumentException("No invocation parameters in conductor test"))
+  }
+
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ControllerTestCommon.scala
@@ -73,7 +73,7 @@ protected trait ControllerTestCommon
   override lazy val entitlementProvider: EntitlementProvider =
     new LocalEntitlementProvider(whiskConfig, loadBalancer, instance)
 
-  override val activationIdFactory = new ActivationId.ActivationIdGenerator() {
+  override val activationIdFactory: ActivationId.ActivationIdGenerator = new ActivationId.ActivationIdGenerator {
     // need a static activation id to test activations api
     private val fixedId = ActivationId.generate()
     override def make = fixedId
@@ -235,6 +235,52 @@ protected trait ControllerTestCommon
   protected object BadEntity extends DocumentFactory[BadEntity] with DefaultJsonProtocol {
     implicit val serdes = jsonFormat5(BadEntity.apply)
     override val cacheEnabled = true
+  }
+
+  /**
+   * Makes a simple sequence action and installs it in the db (no call to wsk api/cli).
+   * All actions are in the default package.
+   *
+   * @param sequenceName the name of the sequence
+   * @param ns           the namespace to be used when creating the component actions and the sequence action
+   * @param components   the names of the actions (entity names, no namespace)
+   */
+  protected def putSimpleSequenceInDB(sequenceName: String, ns: EntityPath, components: Vector[String])(
+    implicit tid: TransactionId) = {
+    val seqAction = makeSimpleSequence(sequenceName, ns, components)
+    put(entityStore, seqAction)
+  }
+
+  /**
+   * Returns a WhiskAction that can be used to create/update a sequence.
+   * If instructed to do so, installs the component actions in the db.
+   * All actions are in the default package.
+   *
+   * @param sequenceName   the name of the sequence
+   * @param ns             the namespace to be used when creating the component actions and the sequence action
+   * @param componentNames the names of the actions (entity names, no namespace)
+   * @param installDB      if true, installs the component actions in the db (default true)
+   */
+  protected def makeSimpleSequence(sequenceName: String,
+                                   ns: EntityPath,
+                                   componentNames: Vector[String],
+                                   installDB: Boolean = true)(implicit tid: TransactionId): WhiskAction = {
+    if (installDB) {
+      // create bogus wsk actions
+      val wskActions = componentNames.toSet[String] map { c =>
+        WhiskAction(ns, EntityName(c), jsDefault("??"))
+      }
+      // add them to the db
+      wskActions.foreach {
+        put(entityStore, _)
+      }
+    }
+    // add namespace to component names
+    val components = componentNames map { c =>
+      stringToFullyQualifiedName(s"/$ns/$c")
+    }
+    // create wsk action for the sequence
+    WhiskAction(ns, EntityName(sequenceName), sequence(components))
   }
 }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiTests.scala
@@ -27,7 +27,6 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.server.Route
 import spray.json._
 import spray.json.DefaultJsonProtocol._
-import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.controller.WhiskActionsApi
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.http.{ErrorResponse, Messages}
@@ -429,52 +428,6 @@ class SequenceApiTests extends ControllerTestCommon with WhiskActionsApi {
       }
       logContains("atomic action count 6")(stream)
     }
-  }
-
-  /**
-   * Makes a simple sequence action and installs it in the db (no call to wsk api/cli).
-   * All actions are in the default package.
-   *
-   * @param sequenceName the name of the sequence
-   * @param ns           the namespace to be used when creating the component actions and the sequence action
-   * @param components   the names of the actions (entity names, no namespace)
-   */
-  private def putSimpleSequenceInDB(sequenceName: String, ns: EntityPath, components: Vector[String])(
-    implicit tid: TransactionId) = {
-    val seqAction = makeSimpleSequence(sequenceName, ns, components)
-    put(entityStore, seqAction)
-  }
-
-  /**
-   * Returns a WhiskAction that can be used to create/update a sequence.
-   * If instructed to do so, installs the component actions in the db.
-   * All actions are in the default package.
-   *
-   * @param sequenceName   the name of the sequence
-   * @param ns             the namespace to be used when creating the component actions and the sequence action
-   * @param componentNames the names of the actions (entity names, no namespace)
-   * @param installDB      if true, installs the component actions in the db (default true)
-   */
-  private def makeSimpleSequence(sequenceName: String,
-                                 ns: EntityPath,
-                                 componentNames: Vector[String],
-                                 installDB: Boolean = true)(implicit tid: TransactionId): WhiskAction = {
-    if (installDB) {
-      // create bogus wsk actions
-      val wskActions = componentNames.toSet[String] map { c =>
-        WhiskAction(ns, EntityName(c), jsDefault("??"))
-      }
-      // add them to the db
-      wskActions.foreach {
-        put(entityStore, _)
-      }
-    }
-    // add namespace to component names
-    val components = componentNames map { c =>
-      stringToFullyQualifiedName(s"/$ns/$c")
-    }
-    // create wsk action for the sequence
-    WhiskAction(namespace, EntityName(sequenceName), sequence(components))
   }
 
   private def logContains(w: String)(implicit stream: java.io.ByteArrayOutputStream): Boolean = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiWithoutDbPollingTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiWithoutDbPollingTests.scala
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller.test
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Route
+import java.time.Instant
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.connector.ActivationMessage
+import org.apache.openwhisk.core.controller.WhiskActionsApi
+import org.apache.openwhisk.core.database.UserContext
+import org.apache.openwhisk.core.entity._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.FiniteDuration
+import scala.language.postfixOps
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+/**
+ * Tests Sequence API - stand-alone tests that require only the controller to be up
+ */
+@RunWith(classOf[JUnitRunner])
+class SequenceApiWithoutDbPollingTests extends ControllerTestCommon with WhiskActionsApi {
+
+  behavior of "Sequence API"
+
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+  val creds = WhiskAuthHelpers.newIdentity()
+  val context = UserContext(creds)
+  val namespace = EntityPath(creds.subject.asString)
+  val defaultNamespace = EntityPath.DEFAULT
+  def aname() = MakeName.next("sequence_tests")
+
+  val allowedActionDuration = 120 seconds
+  val maxBlockingWait = 1.seconds
+  override val controllerActivationConfig = ControllerActivationConfig(false, maxBlockingWait)
+  override val sequenceActivationResponseConfig =
+    ActivationResponseConfig(
+      true,
+      maxBlockingWait - 500.milliseconds,
+      controllerActivationConfig = controllerActivationConfig)
+  override val loadBalancer = new FakeLoadBalancerService(whiskConfig)
+  override val activationIdFactory = new ActivationId.ActivationIdGenerator() {}
+
+  it should "invoke a blocking sequence and exclude the result " in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_seq"
+    val compName1 = s"${aname()}_comp1"
+    val compName2 = s"${aname()}_comp2"
+
+    putSimpleSequenceInDB(seqName, namespace, Vector(compName1, compName2))
+
+    Post(s"$collectionPath/${seqName}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+      // status should be accepted because there is no active ack response and
+      // db polling will fail since there is no record of the activation
+      // as a result, the api handler will convert this to a non-blocking request
+      status should be(OK)
+      val response = responseAs[JsObject]
+
+      response.fields.size shouldBe 12
+      response.fields("activationId") should not be None
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+
+      headers should contain(RawHeader(ActivationIdHeader, activationId.toString))
+
+      //verify that result is not in db record
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+
+      dbActivation.response.result shouldBe None
+    }
+  }
+
+  it should "invoke a blocking sequence exceeds timeout and includes result in db" in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_seq"
+    val compName1 = s"${aname()}_comp1_slow"
+    val compName2 = s"${aname()}_comp2"
+
+    putSimpleSequenceInDB(seqName, namespace, Vector(compName1, compName2))
+
+    Post(s"$collectionPath/${seqName}?blocking=true") ~> Route.seal(routes(creds)) ~> check {
+      // status should be accepted because there is no active ack response and
+      // db polling will fail since there is no record of the activation
+      // as a result, the api handler will convert this to a non-blocking request
+      status should be(Accepted)
+      val response = responseAs[JsObject]
+
+      response.fields.size shouldBe 1
+      response.fields("activationId") should not be None
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+
+      headers should contain(RawHeader(ActivationIdHeader, activationId.toString))
+
+      //verify that result is not in db record
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(400.milliseconds))
+
+      dbActivation.response.result shouldBe Some(Map("slowfield" -> "slowvalue".toJson).toJson)
+    }
+  }
+  it should "invoke a blocking sequence with debug and includes result in db" in {
+    implicit val tid = transid()
+    val seqName = s"${aname()}_seq"
+    val compName1 = s"${aname()}_comp1"
+    val compName2 = s"${aname()}_comp2"
+
+    putSimpleSequenceInDB(seqName, namespace, Vector(compName1, compName2))
+
+    Post(s"$collectionPath/${seqName}?blocking=true&debug=true") ~> Route.seal(routes(creds)) ~> check {
+      // status should be accepted because there is no active ack response and
+      // db polling will fail since there is no record of the activation
+      // as a result, the api handler will convert this to a non-blocking request
+      status should be(OK)
+      val response = responseAs[JsObject]
+
+      response.fields.size shouldBe 12
+      response.fields("activationId") should not be None
+      val activationId = ActivationId(response.fields("activationId").convertTo[String])
+
+      headers should contain(RawHeader(ActivationIdHeader, activationId.toString))
+
+      //verify that result is not in db record
+      val activationDoc = DocId(WhiskEntity.qualifiedName(namespace, activationId))
+      val dbActivation = org.apache.openwhisk.utils.retry({
+        //do not perform assertions here since they will be swallowed by retry()
+        val activation = getActivation(ActivationId(activationDoc.asString), context)
+        deleteActivation(ActivationId(activationDoc.asString), context)
+        activation
+      }, 30, Some(200.milliseconds))
+
+      dbActivation.response.result shouldBe Some(JsObject())
+    }
+  }
+
+  // fake load balancer to emulate a handful of actions
+  class FakeLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionContext)
+      extends DegenerateLoadBalancerService(config) {
+
+    private def respond(action: ExecutableWhiskActionMetaData,
+                        msg: ActivationMessage,
+                        result: JsObject,
+                        duration: FiniteDuration = 42.milliseconds) = {
+      val response =
+        if (result.fields.get("error") isDefined) ActivationResponse(ActivationResponse.ApplicationError, Some(result))
+        else ActivationResponse.success(Some(result))
+      val start = Instant.now
+      println("emitting activation ")
+      WhiskActivation(
+        action.namespace,
+        action.name,
+        msg.user.subject,
+        msg.activationId,
+        start,
+        end = start.plusMillis(duration.toMillis),
+        duration = Some(duration.toMillis),
+        response = response)
+    }
+
+    val Fast = "(.*comp[0-9])".r
+    val Slow = "(.*comp[0-9]_slow)".r
+    override def publish(action: ExecutableWhiskActionMetaData, msg: ActivationMessage)(
+      implicit transid: TransactionId): Future[Future[Either[ActivationId, WhiskActivation]]] =
+      msg.content map { args =>
+        println(s"action ${action.name}  responding to activation id ${msg.activationId} ${msg.cause}")
+
+        Future.successful {
+//          Future(Right(respond(action, msg, Map("somefield" -> "somevalue".toJson).toJson.asJsObject)))
+          action.name.toString match {
+            case Fast(actionName) => // echo action
+              println("running fast")
+              Future(Right(respond(action, msg, args)))
+            case Slow(actionName) => // echo action
+              println("running slow")
+              Thread.sleep((maxBlockingWait + 100.milliseconds).toMillis)
+              Future(
+                Right(
+                  respond(
+                    action,
+                    msg,
+                    Map("slowfield" -> "slowvalue".toJson).toJson.asJsObject,
+                    maxBlockingWait + 100.milliseconds)))
+//            case "conductor" => // see tests/dat/actions/conductor.js
+//              val result =
+//                if (args.fields.get("error") isDefined) args
+//                else {
+//                  val action = args.fields.get("action") map { action =>
+//                    Map("action" -> action)
+//                  } getOrElse Map.empty
+//                  val state = args.fields.get("state") map { state =>
+//                    Map("state" -> state)
+//                  } getOrElse Map.empty
+//                  val wrappedParams = args.fields.getOrElse("params", JsObject.empty).asJsObject.fields
+//                  val escapedParams = args.fields - "action" - "state" - "params"
+//                  val params = Map("params" -> JsObject(wrappedParams ++ escapedParams))
+//                  JsObject(params ++ action ++ state)
+//                }
+//              Future(Right(respond(action, msg, result)))
+//            case "step" => // see tests/dat/actions/step.js
+//              val result = args.fields.get("n") map { n =>
+//                JsObject("n" -> (n.convertTo[BigDecimal] + 1).toJson)
+//              } getOrElse {
+//                JsObject("error" -> "missing parameter".toJson)
+//              }
+//              Future(Right(respond(action, msg, result)))
+            case _ =>
+              Future.failed(new IllegalArgumentException("Unkown action invoked in conductor test"))
+          }
+        }
+      } getOrElse Future.failed(new IllegalArgumentException("No invocation parameters in conductor test"))
+  }
+
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -264,6 +264,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
     action: WhiskActionMetaData,
     payload: Option[JsObject],
     waitForResponse: Option[FiniteDuration],
+    debug: Boolean,
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     invocationCount = invocationCount + 1
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -59,7 +59,7 @@ class ArtifactWithFileStorageActivationStoreTests()
   private val uuid = UUID()
   private val subject = Subject()
   private val user =
-    Identity(subject, Namespace(EntityName(subject.asString), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
+    Identity(subject, Namespace(EntityName("testSpace"), uuid), BasicAuthenticationAuthKey(uuid, Secret()))
   private val context = UserContext(user, HttpRequest())
 
   override def afterAll(): Unit = {
@@ -99,9 +99,9 @@ class ArtifactWithFileStorageActivationStoreTests()
             "type" -> "user_log".toJson,
             "message" -> log.toJson,
             "activationId" -> activation.activationId.toJson,
-            "namespace" -> activation.namespace.asString.toJson,
             "namespaceId" -> user.namespace.uuid.toJson)
             ++ additionalFieldsForLogs: _*)
+
       }
     }
     val expectedResult = if (includeResult) {
@@ -282,7 +282,7 @@ class ArtifactWithFileStorageActivationStoreTests()
           activationFileStorage.activationToFileExtended(
             activation,
             context,
-            additionalFields ++ additionalFieldsForLogs ++ Map("namespace" -> JsString(subject.asString)),
+            additionalFields ++ additionalFieldsForLogs,
             additionalFields ++ additionalFieldsForActivation,
             shallResultBeIncluded)
 


### PR DESCRIPTION
In some very specific cases, we can save some db size bloat by not storing Activation result along with Activation record in db.
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
When enabled via config, if the following are true, the result portion of Activation document will not be included in db record that is stored (no change in response seen by client):
* Activation is blocking
* Activation response is successful
* ?debug=true parameter was not included by client
* timeout not exceeded (a new timeout, specific to this configuration)

In these cases, results are very unlikely to ever be accessed in database, so this will save space. It can be useful for cases where there are a large number of significant size results created (>500k?) which can accumulate 100s of GB or TB of space.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4626 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

