### PR TITLE
Make package object as simple object

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
@@ -40,7 +40,7 @@ import org.apache.openwhisk.spi.SpiLoader
 import pureconfig._
 import scala.reflect.classTag
 
-package object types {
+object types {
   type AuthStore = ArtifactStore[WhiskAuth]
   type EntityStore = ArtifactStore[WhiskEntity]
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala
@@ -70,7 +70,7 @@ protected[core] object RejectRequest {
  * A convenient typedef for functions that post process an entity
  * on an operation and terminate the HTTP request.
  */
-package object PostProcess {
+object PostProcess {
   type PostProcessEntity[A] = A => RequestContext => Future[RouteResult]
 }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
@@ -39,7 +39,7 @@ import org.apache.openwhisk.core.connector.MessagingProvider
 import org.apache.openwhisk.spi.SpiLoader
 import org.apache.openwhisk.spi.Spi
 
-package object types {
+object types {
   type Entitlements = TrieMap[(Subject, String), Set[Privilege]]
 }
 


### PR DESCRIPTION
In some places we were using `package` object but not placing them in `package.scala` files. This PR makes them as normal object

## Description

Due to the way currently some package objects were defined they were causing warnings to be issued from the [Hydra Scala Compiler](https://triplequote.com/hydra)

```
Information:scalac: Using 2 Hydra workers to compile Scala sources.
Information:02/10/19, 4:18 PM - Build completed with 8 errors and 2 warnings in 11 s 498 ms
Warning:scalac: /path/to/openwhisk/core/controller/src/main/scala/org/apache/openwhisk/core/controller/ApiUtils.scala:73: warning: package object PostProcess must be placed inside org/apache/openwhisk/core/controller/PostProcess/package.scala
package object PostProcess {
               ^
Warning:scalac: /path/to/openwhisk/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala:42: warning: package object types must be placed inside org/apache/openwhisk/core/entitlement/types/package.scala
package object types {
               ^
```

This was later causing issue with incremental compilation. @dragos  suggested to make them as normal object or place them in respective `package.scala` per [recommendation](https://www.scala-lang.org/docu/files/packageobjects/packageobjects_1.html). 

Here just making them as normal object seems to work.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

