### PR TITLE
Unify Alpakka Kafka version across modules

### DIFF
--- a/core/cosmosdb/cache-invalidator/build.gradle
+++ b/core/cosmosdb/cache-invalidator/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         exclude group: 'junit'
         exclude group: 'commons-logging'
     }
-    compile 'com.typesafe.akka:akka-stream-kafka_2.12:1.0'
+    compile "com.typesafe.akka:akka-stream-kafka_2.12:${gradle.akka_kafka.version}"
 }
 
 tasks.withType(ScalaCompile) {

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -34,17 +34,17 @@ dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
 
-    compile 'com.typesafe.akka:akka-stream-kafka_2.12:0.22'
+    compile "com.typesafe.akka:akka-stream-kafka_2.12:${gradle.akka_kafka.version}"
 
     compile 'io.prometheus:simpleclient:0.6.0'
     compile 'io.prometheus:simpleclient_common:0.6.0'
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'
-    testCompile 'net.manub:scalatest-embedded-kafka_2.12:2.0.0'
-    testCompile 'com.typesafe.akka:akka-testkit_2.12:2.5.17'
-    testCompile 'com.typesafe.akka:akka-stream-testkit_2.12:2.5.17'
-    testCompile 'com.typesafe.akka:akka-http-testkit_2.12:10.1.5'
+    compile "com.typesafe.akka:akka-stream-kafka-testkit_2.12:${gradle.akka_kafka.version}"
+    testCompile "com.typesafe.akka:akka-testkit_2.12:${gradle.akka.version}"
+    testCompile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
+    testCompile "com.typesafe.akka:akka-http-testkit_2.12:${gradle.akka_http.version}"
 }
 
 tasks.withType(ScalaCompile) {

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -52,3 +52,13 @@ tasks.withType(ScalaCompile) {
 }
 
 mainClassName = "org.apache.openwhisk.core.monitoring.metrics.Main"
+
+gradle.projectsEvaluated {
+    tasks.withType(Test) {
+        testLogging {
+            events "passed", "skipped", "failed"
+            showStandardStreams = true
+            exceptionFormat = 'full'
+        }
+    }
+}

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KafkaSpecBase.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KafkaSpecBase.scala
@@ -17,40 +17,25 @@
 
 package org.apache.openwhisk.core.monitoring.metrics
 
-import akka.actor.ActorSystem
+import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import akka.stream.ActorMaterializer
-import akka.testkit.TestKit
 import net.manub.embeddedkafka.EmbeddedKafka
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 abstract class KafkaSpecBase
-    extends TestKit(ActorSystem("test"))
-    with Suite
+    extends ScalatestKafkaSpec(6065)
     with Matchers
     with ScalaFutures
     with FlatSpecLike
     with EmbeddedKafka
+    with EmbeddedKafkaLike
     with IntegrationPatience
-    with BeforeAndAfterAll
-    with BeforeAndAfterEach
     with Eventually
     with EventsTestHelper { this: Suite =>
-  val log: Logger = LoggerFactory.getLogger(getClass)
-  implicit val timeoutConfig = PatienceConfig(1.minute)
-
-  implicit val materializer = ActorMaterializer()
-
-  def sleep(time: FiniteDuration, msg: String = ""): Unit = {
-    log.info(s"sleeping $time $msg")
-    Thread.sleep(time.toMillis)
-  }
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    shutdown()
-  }
+  implicit val timeoutConfig: PatienceConfig = PatienceConfig(1.minute)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  override val sleepAfterProduce: FiniteDuration = 10.seconds
 }

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
@@ -23,18 +23,16 @@ import com.typesafe.config.{Config, ConfigFactory}
 import kamon.metric.{PeriodSnapshot, PeriodSnapshotAccumulator}
 import kamon.util.Registration
 import kamon.{Kamon, MetricReporter}
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import org.apache.openwhisk.core.connector.{Activation, EventMessage}
+import org.apache.openwhisk.core.entity.{ActivationResponse, Subject, UUID}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
-import org.apache.openwhisk.core.connector.{Activation, EventMessage}
-import org.apache.openwhisk.core.entity.{ActivationResponse, Subject, UUID}
 
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
 class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with KamonMetricNames {
-  val sleepAfterProduce: FiniteDuration = 4.seconds
   var reporterReg: Registration = _
 
   override protected def beforeEach(): Unit = {
@@ -66,46 +64,43 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
   val memory = 256
 
   it should "push user events to kamon" in {
-    val kconfig = EmbeddedKafkaConfig(kafkaPort = 0, zooKeeperPort = 0)
-    withRunningKafkaOnFoundPort(kconfig) { implicit actualConfig =>
-      createCustomTopic(EventConsumer.userEventTopic)
+    createCustomTopic(EventConsumer.userEventTopic)
 
-      val consumer = createConsumer(actualConfig.kafkaPort, system.settings.config, KamonRecorder)
+    val consumer = createConsumer(kafkaPort, system.settings.config, KamonRecorder)
 
-      publishStringMessageToKafka(
-        EventConsumer.userEventTopic,
-        newActivationEvent(s"$namespace/$actionWithCustomPackage").serialize)
+    publishStringMessageToKafka(
+      EventConsumer.userEventTopic,
+      newActivationEvent(s"$namespace/$actionWithCustomPackage").serialize)
 
-      publishStringMessageToKafka(
-        EventConsumer.userEventTopic,
-        newActivationEvent(s"$namespace/$actionWithDefaultPackage").serialize)
+    publishStringMessageToKafka(
+      EventConsumer.userEventTopic,
+      newActivationEvent(s"$namespace/$actionWithDefaultPackage").serialize)
 
-      sleep(sleepAfterProduce, "sleeping post produce")
-      consumer.shutdown().futureValue
-      sleep(4.second, "sleeping for Kamon reporters to get invoked")
+    sleep(sleepAfterProduce, "sleeping post produce")
+    consumer.shutdown().futureValue
+    sleep(4.second, "sleeping for Kamon reporters to get invoked")
 
-      // Custom package
-      TestReporter.counter(activationMetric, actionWithCustomPackage).size shouldBe 1
-      TestReporter
-        .counter(activationMetric, actionWithCustomPackage)
-        .filter((t) => t.tags.get(actionMemory).get == memory.toString)
-        .size shouldBe 1
-      TestReporter
-        .counter(activationMetric, actionWithCustomPackage)
-        .filter((t) => t.tags.get(actionKind).get == kind)
-        .size shouldBe 1
-      TestReporter
-        .counter(statusMetric, actionWithCustomPackage)
-        .filter((t) => t.tags.get(actionStatus).get == ActivationResponse.statusDeveloperError)
-        .size shouldBe 1
-      TestReporter.counter(coldStartMetric, actionWithCustomPackage).size shouldBe 1
-      TestReporter.histogram(waitTimeMetric, actionWithCustomPackage).size shouldBe 1
-      TestReporter.histogram(initTimeMetric, actionWithCustomPackage).size shouldBe 1
-      TestReporter.histogram(durationMetric, actionWithCustomPackage).size shouldBe 1
+    // Custom package
+    TestReporter.counter(activationMetric, actionWithCustomPackage).size shouldBe 1
+    TestReporter
+      .counter(activationMetric, actionWithCustomPackage)
+      .filter((t) => t.tags.get(actionMemory).get == memory.toString)
+      .size shouldBe 1
+    TestReporter
+      .counter(activationMetric, actionWithCustomPackage)
+      .filter((t) => t.tags.get(actionKind).get == kind)
+      .size shouldBe 1
+    TestReporter
+      .counter(statusMetric, actionWithCustomPackage)
+      .filter((t) => t.tags.get(actionStatus).get == ActivationResponse.statusDeveloperError)
+      .size shouldBe 1
+    TestReporter.counter(coldStartMetric, actionWithCustomPackage).size shouldBe 1
+    TestReporter.histogram(waitTimeMetric, actionWithCustomPackage).size shouldBe 1
+    TestReporter.histogram(initTimeMetric, actionWithCustomPackage).size shouldBe 1
+    TestReporter.histogram(durationMetric, actionWithCustomPackage).size shouldBe 1
 
-      // Default package
-      TestReporter.histogram(durationMetric, actionWithDefaultPackage).size shouldBe 1
-    }
+    // Default package
+    TestReporter.histogram(durationMetric, actionWithDefaultPackage).size shouldBe 1
   }
 
   private def newActivationEvent(name: String) =

--- a/settings.gradle
+++ b/settings.gradle
@@ -45,6 +45,7 @@ gradle.ext.scalafmt = [
 ]
 
 gradle.ext.akka = [version : '2.5.22']
+gradle.ext.akka_kafka = [version : '1.0.5']
 gradle.ext.akka_http = [version : '10.1.8']
 
 gradle.ext.curator = [version:'4.0.0']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -199,7 +199,7 @@ dependencies {
     compile 'io.opentracing:opentracing-mock:0.31.0'
     compile "org.apache.curator:curator-test:${gradle.curator.version}"
     compile 'com.atlassian.oai:swagger-request-validator-core:1.4.5'
-    compile 'com.typesafe.akka:akka-stream-kafka-testkit_2.12:1.0'
+    compile "com.typesafe.akka:akka-stream-kafka-testkit_2.12:${gradle.akka_kafka.version}"
     compile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
 
     compile "com.amazonaws:aws-java-sdk-s3:1.11.295"

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
@@ -17,7 +17,6 @@
 
 package org.apache.openwhisk.core.database.cosmosdb.cache
 import akka.actor.CoordinatedShutdown
-import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
@@ -44,7 +43,6 @@ import org.scalatest.{Matchers, TryValues}
 import scala.concurrent.duration._
 import scala.util.Random
 
-//TODO Make test port dynamic
 @RunWith(classOf[JUnitRunner])
 class CacheInvalidatorTests
     extends ScalatestKafkaSpec(6061)
@@ -55,7 +53,6 @@ class CacheInvalidatorTests
     with ScalaFutures
     with IntegrationPatience
     with TryValues
-    with TestFrameworkInterface.Scalatest
     with StreamLogging {
 
   implicit val materializer: ActorMaterializer = ActorMaterializer()

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -31,11 +31,13 @@ $ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.j
 $ANSIBLE_CMD downloadcli-github.yml
 
 cd $ROOTDIR
-TERM=dumb ./gradlew :core:standalone:build
-TERM=dumb ./gradlew :core:monitoring:user-events:distDocker
+TERM=dumb ./gradlew :core:standalone:build \
+  :core:monitoring:user-events:distDocker
 
 cd $ROOTDIR/tools/travis
 ./runTests.sh
 
 cd $ROOTDIR
-TERM=dumb ./gradlew :core:standalone:cleanTest :core:standalone:test
+TERM=dumb ./gradlew :core:standalone:cleanTest \
+  :core:standalone:test \
+  :core:monitoring:user-events:reportTestScoverage

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -34,10 +34,11 @@ cd $ROOTDIR
 TERM=dumb ./gradlew :core:standalone:build \
   :core:monitoring:user-events:distDocker
 
-cd $ROOTDIR/tools/travis
-./runTests.sh
-
 cd $ROOTDIR
 TERM=dumb ./gradlew :core:standalone:cleanTest \
   :core:standalone:test \
   :core:monitoring:user-events:reportTestScoverage
+
+# Run test in end as it publishes the coverage also
+cd $ROOTDIR/tools/travis
+./runTests.sh


### PR DESCRIPTION
Currently [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/home.html) is used in 2 places cache invalidator and user event service.

This PR unifies the version and updates it to 1.0.5. 

Further it also enables test for user-event which were so far not enabled as they were part of the module itself. These tests are enabled in new Standalone Mode profile in Travis

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

