### PR TITLE
Expose Kafka metrics for User Event consumer as json endpoint

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -183,10 +183,19 @@ whisk {
 
         metrics {
             // Name of metrics which should be tracked via Kamon
+            // https://docs.confluent.io/current/kafka/monitoring.html
             names = [
                 // consumer-fetch-manager-metrics
                 "records-lag-max", // The maximum lag in terms of number of records for any partition in this window
-                "records-consumed-total" // The total number of records consumed
+                "records-consumed-total", // The total number of records consumed
+
+                //producer-topic-metrics
+                "record-send-total",
+                "byte-total",
+
+                //producer-metrics
+                "request-total",
+                "request-size-avg"
             ]
 
             report-interval = 10 seconds

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMetrics.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMetrics.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.connector.kafka
+
+import akka.http.scaladsl.server.{Directives, Route}
+import org.apache.kafka.common.{Metric, MetricName => JMetricName}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Success, Try}
+
+trait KafkaMetricsProvider {
+  def metrics(): Future[Map[JMetricName, Metric]]
+}
+
+/**
+ * Utility to convert a map of Kafka metrics to JSON
+ */
+object KafkaMetrics {
+  private case class MetricName(name: String, group: String, description: String, tags: Map[String, String])
+
+  private object MetricName extends DefaultJsonProtocol {
+    implicit val serdes = jsonFormat4(MetricName.apply)
+    def apply(m: JMetricName): MetricName = new MetricName(m.name(), m.group(), m.description(), m.tags().asScala.toMap)
+  }
+
+  def toJson(metrics: Map[JMetricName, Metric]): JsValue = {
+    val result = metrics.values.flatMap { m =>
+      getValue(m).map { v =>
+        val json = MetricName(m.metricName()).toJson.asJsObject
+        JsObject(json.fields + ("value" -> v))
+      }
+    }.toSeq
+    result.toJson
+  }
+
+  private def getValue(m: Metric): Option[JsValue] = {
+    Try(m.metricValue()) match {
+      case Success(v: java.lang.Double) => Some(JsNumber(v.toDouble))
+      case Success(v: String)           => Some(JsString(v))
+      case _                            => None
+    }
+  }
+}
+
+/**
+ * Exposes the Kafka metrics as a json endpoint `/metrics/kafka`. This can be used
+ * to expose metrics of a specific consumer or producer like in User Event service
+ */
+object KafkaMetricRoute extends Directives {
+  def apply(provider: KafkaMetricsProvider)(implicit ec: ExecutionContext): Route = {
+    path("metrics" / "kafka") {
+      val metrics = provider.metrics().map(m => KafkaMetrics.toJson(m))
+      complete(metrics)
+    }
+  }
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
@@ -78,6 +78,7 @@ class KamonMetricsReporter extends MetricsReporter {
 }
 
 object KamonMetricsReporter {
+  val name = classOf[KamonMetricsReporter].getName
   private val excludedTopicAttributes = Set("records-lag-max", "records-consumed-total", "bytes-consumed-total")
 
   case class KafkaMetricConfig(names: Set[String], reportInterval: FiniteDuration)

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
@@ -29,7 +29,7 @@ import kamon.system.SystemMetrics
 import org.apache.kafka.common.serialization.StringDeserializer
 import pureconfig.loadConfigOrThrow
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object OpenWhiskEvents extends SLF4JLogging {
 
@@ -37,6 +37,7 @@ object OpenWhiskEvents extends SLF4JLogging {
 
   def start(config: Config)(implicit system: ActorSystem,
                             materializer: ActorMaterializer): Future[Http.ServerBinding] = {
+    implicit val ec: ExecutionContext = system.dispatcher
     Kamon.reconfigure(config)
     val prometheusReporter = new PrometheusReporter()
     Kamon.addReporter(prometheusReporter)

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
@@ -21,6 +21,9 @@ import akka.http.scaladsl.model.StatusCodes.ServiceUnavailable
 import akka.http.scaladsl.model.{ContentType, MessageEntity}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import org.apache.openwhisk.connector.kafka.KafkaMetricRoute
+
+import scala.concurrent.ExecutionContext
 
 trait PrometheusExporter {
   def getReport(): MessageEntity
@@ -30,7 +33,7 @@ object PrometheusExporter {
   val textV4: ContentType = ContentType.parse("text/plain; version=0.0.4; charset=utf-8").right.get
 }
 
-class PrometheusEventsApi(consumer: EventConsumer, prometheus: PrometheusExporter) {
+class PrometheusEventsApi(consumer: EventConsumer, prometheus: PrometheusExporter)(implicit ec: ExecutionContext) {
   val routes: Route = {
     get {
       path("ping") {
@@ -43,7 +46,7 @@ class PrometheusEventsApi(consumer: EventConsumer, prometheus: PrometheusExporte
         encodeResponse {
           complete(prometheus.getReport())
         }
-      }
+      } ~ KafkaMetricRoute(consumer)
     }
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/connector/kafka/KafkaMetricsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/connector/kafka/KafkaMetricsTests.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.connector.kafka
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.{KafkaMetric, Measurable, MetricConfig}
+import org.apache.kafka.common.utils.Time
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+@RunWith(classOf[JUnitRunner])
+class KafkaMetricsTests extends FlatSpec with Matchers with ScalatestRouteTest {
+  behavior of "KafkaMetrics"
+
+  it should "render metrics as json" in {
+    val metricName = new MetricName(
+      "bytes-consumed-total",
+      "consumer-fetch-manager-metrics",
+      "The total number of bytes consumed",
+      Map("client-id" -> "event-consumer").asJava)
+    val valueProvider: Measurable = (config: MetricConfig, now: Long) => 42
+    val metrics = new KafkaMetric(this, metricName, valueProvider, new MetricConfig(), Time.SYSTEM)
+
+    val route = KafkaMetricRoute(() => Future.successful(Map(metricName -> metrics)))
+    Get("/metrics/kafka") ~> route ~> check {
+      //Due to retries using a random port does not immediately result in failure
+      handled shouldBe true
+      responseAs[JsArray].elements.size shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
This PR expose the metrics related to specific Kafka producer or consumer over `/metrics/kafka` endpoint. 

## Description

For now this feature is enabled for User Event service where the event consumer's Kafka consumer instance  metrics are exposed. Such metrics can provide insight into the Kafka consumers processing stats.

The http endpoint is not exposed to end user and meant for developers and system admins to understand the performance characteristics of the consumer at any given time by direct access

It also registers the `KamonMetricsReporter` (introduced via #4481) with the User Event consumer to expose some of those metrics as Kamon metrics

A typical response for the `/metrics/kafka` endpoint is like below ( > 100 entries)

```json
[
  {
    "description": "The number of responses received per second",
    "group": "consumer-node-metrics",
    "name": "response-rate",
    "tags": {
      "client-id": "event-consumer",
      "node-id": "node--1"
    },
    "value": 0.05848409232688709
  },
  {
    "description": "The total number of connections with successful authentication",
    "group": "consumer-metrics",
    "name": "successful-authentication-total",
    "tags": {
      "client-id": "event-consumer"
    },
    "value": 0
  },
  {
    "description": "The maximum size of any request sent.",
    "group": "consumer-metrics",
    "name": "request-size-max",
    "tags": {
      "client-id": "event-consumer"
    },
    "value": 179
  },
  {
    "description": "The total number of bytes consumed",
    "group": "consumer-fetch-manager-metrics",
    "name": "bytes-consumed-total",
    "tags": {
      "client-id": "event-consumer"
    },
    "value": 0
  }
]
```
Later we plan to enable this feature with Activation Persister Service (#4632) also

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

