### PR TITLE
GoLang docker image: actionloop-golang ==> action-golang

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -183,7 +183,7 @@
                 },
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "actionloop-golang-v1.11",
+                    "name": "action-golang-v1.11",
                     "tag": "nightly"
                 }
             }

--- a/docs/actions-go.md
+++ b/docs/actions-go.md
@@ -21,7 +21,7 @@
 
 # Creating and Invoking Go Actions
 
-The `actionloop-golang-v1.11` runtime can execute actions written in the Go programming language in OpenWhisk, either as precompiled binary or compiling sources on the fly.
+The `action-golang-v1.11` runtime can execute actions written in the Go programming language in OpenWhisk, either as precompiled binary or compiling sources on the fly.
 
 ## Entry Point
 
@@ -68,7 +68,7 @@ You can also have multiple source files in an action, packages and vendor folder
 
 ## Deployment
 
-The runtime `actionloop-golang-v1.11` accepts:
+The runtime `action-golang-v1.11` accepts:
 
 - executable binaries in Linux ELF executable compiled for the AMD64 architecture
 - zip files containing a binary executable named `exec` at the top level, again a Linux ELF executable compiled for the AMD64 architecture
@@ -166,13 +166,13 @@ If you need to use vendor folder in the main package, you need to create a direc
 
 ## Precompiling Go Sources Offline
 
-Compiling sources on the image can take some time when the images is initialized. You can speed up precompiling the sources using the image `actionloop-golang-v1.11` as an offline compiler. You need `docker` for doing that.
+Compiling sources on the image can take some time when the images is initialized. You can speed up precompiling the sources using the image `action-golang-v1.11` as an offline compiler. You need `docker` for doing that.
 
 The images accepts a `-compile <main>` flag, and expects you provide sources in standard input. It will then compile them, emit the binary in standard output and errors in stderr. The output is always a zip file containing an executable.
 
 If you have a single source maybe in file `main.go`, with a function named `Main` just do this:
 
-`docker run openwhisk/actionloop-golang-v1.11 -compile main <main.go >main.zip`
+`docker run openwhisk/action-golang-v1.11 -compile main <main.go >main.zip`
 
 If you have multiple sources in current directory, even with a subfolder with sources, you can compile it all with:
 
@@ -180,7 +180,7 @@ If you have multiple sources in current directory, even with a subfolder with so
 cd src
 zip -r ../src.zip *
 cd ..
-docker run openwhisk/actionloop-golang-v1.11 -compile main <src.zip >exec.zip
+docker run openwhisk/action-golang-v1.11 -compile main <src.zip >exec.zip
 ```
 
 Note that the output is always a zip file in  Linux AMD64 format so the executable can be run only inside a Docker Linux container.


### PR DESCRIPTION
openwhisk-runtime-go PR#109 changed the name used to publish docker
images from actionloop-golang-VERSION to action-golang-VERSION. This
PR updates the core system runtime.json and documentation to use the
new names. All old images are still available on dockerhub and will
not be removed or renamed, so this should be a non-disruptive change.
