### PR TITLE
KubernetesContainerFactory: security context for user actions

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -132,11 +132,17 @@ class KubernetesClient(
         .build()
       podBuilder.withAffinity(invokerNodeAffinity)
     }
+    val secContext = new SecurityContextBuilder()
+      .withNewCapabilities()
+      .addToDrop("NET_RAW", "NET_ADMIN")
+      .endCapabilities()
+      .build()
     val pod = podBuilder
       .addNewContainer()
       .withNewResources()
       .withLimits(Map("memory" -> new Quantity(memory.toMB + "Mi")).asJava)
       .endResources()
+      .withSecurityContext(secContext)
       .withName("user-action")
       .withImage(image)
       .withEnv(envVars.asJava)


### PR DESCRIPTION
Drop the NET_RAW and NET_ADMIN capabilities from the containers
created to execute user actions (matches DockerContainerFactory).
