### PR TITLE
Add NoopActivationStore to simplify local performance testing

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/NoopActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/NoopActivationStore.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.memory
+
+import java.time.Instant
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.apache.openwhisk.common.{Logging, TransactionId, WhiskInstants}
+import org.apache.openwhisk.core.database.{
+  ActivationStore,
+  ActivationStoreProvider,
+  CacheChangeNotification,
+  UserContext
+}
+import org.apache.openwhisk.core.entity.{ActivationId, DocInfo, EntityName, EntityPath, Subject, WhiskActivation}
+import spray.json.{JsNumber, JsObject}
+
+import scala.concurrent.Future
+
+object NoopActivationStore extends ActivationStore with WhiskInstants {
+  private val emptyInfo = DocInfo("foo")
+  private val emptyCount = JsObject("activations" -> JsNumber(0))
+  private val dummyActivation = WhiskActivation(
+    EntityPath("testnamespace"),
+    EntityName("activation"),
+    Subject(),
+    ActivationId.generate(),
+    start = Instant.now.inMills,
+    end = Instant.now.inMills)
+
+  override def store(activation: WhiskActivation, context: UserContext)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[DocInfo] = Future.successful(emptyInfo)
+
+  override def get(activationId: ActivationId, context: UserContext)(
+    implicit transid: TransactionId): Future[WhiskActivation] = {
+    val activation = dummyActivation.copy(activationId = activationId)
+    Future.successful(activation)
+  }
+
+  override def delete(activationId: ActivationId, context: UserContext)(
+    implicit transid: TransactionId,
+    notifier: Option[CacheChangeNotification]): Future[Boolean] = Future.successful(true)
+
+  override def countActivationsInNamespace(namespace: EntityPath,
+                                           name: Option[EntityPath],
+                                           skip: Int,
+                                           since: Option[Instant],
+                                           upto: Option[Instant],
+                                           context: UserContext)(implicit transid: TransactionId): Future[JsObject] =
+    Future.successful(emptyCount)
+
+  override def listActivationsMatchingName(
+    namespace: EntityPath,
+    name: EntityPath,
+    skip: Int,
+    limit: Int,
+    includeDocs: Boolean,
+    since: Option[Instant],
+    upto: Option[Instant],
+    context: UserContext)(implicit transid: TransactionId): Future[Either[List[JsObject], List[WhiskActivation]]] =
+    Future.successful(Right(List.empty))
+
+  override def listActivationsInNamespace(
+    namespace: EntityPath,
+    skip: Int,
+    limit: Int,
+    includeDocs: Boolean,
+    since: Option[Instant],
+    upto: Option[Instant],
+    context: UserContext)(implicit transid: TransactionId): Future[Either[List[JsObject], List[WhiskActivation]]] =
+    Future.successful(Right(List.empty))
+}
+
+object NoopActivationStoreProvider extends ActivationStoreProvider {
+  override def instance(actorSystem: ActorSystem, actorMaterializer: ActorMaterializer, logging: Logging) =
+    NoopActivationStore
+}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/LogbackConfigurator.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/LogbackConfigurator.scala
@@ -39,7 +39,10 @@ object LogbackConfigurator {
 
   def initLogging(conf: Conf): Unit = {
     val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).setLevel(toLevel(conf.verbose()))
+    //Only tweak the log level if verbose option is used
+    if (conf.verbose() != 0) {
+      ctx.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).setLevel(toLevel(conf.verbose()))
+    }
   }
 
   private def toLevel(v: Int) = {


### PR DESCRIPTION
Adds a `NoopActivationStore` which does not store the activation and acts like `/dev/null` for the activation response. 

## Description

To simplify local performance testing of the overhead of the control plane flow (invocation logic path in Controller/Invoker) it would be useful have an `ActivationStore` which does not store the activation result. 

This ensures that one can run say 10k activations without worrying about the storage cost. 

### Usage

Below steps demonstrate one way of using this store with Standalone OpenWhisk server

#### 1. Prepare configuration

Create a `standalone-perf.conf` with below content

```
include classpath("standalone.conf")

whisk {
  spi {
    LogStoreProvider = "org.apache.openwhisk.core.containerpool.logging.LogDriverLogStoreProvider"
    ActivationStoreProvider = "org.apache.openwhisk.core.database.memory.NoopActivationStoreProvider"
  }
  //TODO Configure concurrecny
}
```

here we configure

1. NoopActivationStoreProvider to swallow all the activation result
2. LogDriverLogStoreProvider - Disable the log collection overhead

#### 2. Run the server

```
java -Dlogback.log.level=warn -jar openwhisk-standalone.jar -c standalone-perf.conf
```

Now attach the [Java Async Profiler](https://github.com/jvm-profiling-tools/async-profiler). If using Intellij you can use its [inbuilt support for async profiler](https://www.jetbrains.com/help/idea/cpu-profiler.html)

#### 3. Run perf test

Create a hello world action and invoke it multiple times

```
ab -p post.json -T application/json -H 'Authorization: Basic MjNiYzQ2YjEtNzFmNi00ZWQ1LThjNTQtODE2YWE0ZjhjNTAyOjEyM3pPM3haQ0xyTU42djJCS0sxZFhZRnBYbFBrY2NPRnFtMTJDZEFzTWdSVTRWck5aOWx5R1ZDR3VNREdJd1A=' -c 2 -n 10000 "http://localhost:3233/api/v1/namespaces/_/actions/hello?blocking=true&result=true"
```

Post run collect the profiler result and analyze the stats

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

