### PR TITLE
Enable Standalone User Event Dev mode

### DIFF
--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -99,7 +99,7 @@ $ java -jar openwhisk-standalone.jar -h
       --dev-user-events-port  <arg>   Specify the port for the user-event
                                       service. This mode can be used for local
                                       development of user-event service by
-                                      configuring the Prometheus to connect to
+                                      configuring Prometheus to connect to
                                       existing running service instance
       --disable-color-logging         Disables colored logging
       --kafka-docker-port  <arg>      Kafka port for use by docker based

--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -93,23 +93,28 @@ $ java -jar openwhisk-standalone.jar -h
   -d, --data-dir  <arg>            Directory used for storage
       --dev-kcf                    Enables KubernetesContainerFactory for local
                                    development
-      --dev-mode                   Developer mode speeds up the startup by
-                                   disabling preflight checks and avoiding
-                                   explicit pulls.
-      --disable-color-logging      Disables colored logging
-      --kafka-docker-port  <arg>   Kafka port for use by docker based services.
-                                   If not specified then 9091 or some random
-                                   free port (if 9091 is busy) would be used
-      --kafka-port  <arg>          Kafka port. If not specified then 9092 or
-                                   some random free port (if 9092 is busy) would
-                                   be used
-  -p, --port  <arg>                Server port
+      --dev-mode                      Developer mode speeds up the startup by
+                                      disabling preflight checks and avoiding
+                                      explicit pulls.
+      --dev-user-events-port  <arg>   Specify the port for the user-event
+                                      service. This mode can be used for local
+                                      development of user-event service by
+                                      configuring the Prometheus to connect to
+                                      existing running service instance
+      --disable-color-logging         Disables colored logging
+      --kafka-docker-port  <arg>      Kafka port for use by docker based
+                                      services. If not specified then 9091 or
+                                      some random free port (if 9091 is busy)
+                                      would be used
+      --kafka-port  <arg>             Kafka port. If not specified then 9092 or
+                                      some random free port (if 9092 is busy)
+                                      would be used
+  -p, --port  <arg>                   Server port
   -v, --verbose
-      --zk-port  <arg>             Zookeeper port. If not specified then 2181 or
-                                   some random free port (if 2181 is busy) would
-                                   be used
-  -h, --help                       Show help message
-      --version                    Show version of this program
+      --zk-port  <arg>                Zookeeper port. If not specified then 2181
+                                      or some random free port (if 2181 is busy)
+                                      would be used
+  -h, --help                          Show help message
 
 OpenWhisk standalone server
 ```

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -103,7 +103,7 @@ class Conf(arguments: Seq[String]) extends ScallopConf(Conf.expandAllMode(argume
 
   val devUserEventsPort = opt[Int](
     descr = "Specify the port for the user-event service. This mode can be used for local " +
-      "development of user-event service by configuring the Prometheus to connect to existing running service instance")
+      "development of user-event service by configuring Prometheus to connect to existing running service instance")
 
   mainOptions = Seq(manifest, configFile, apiGw, couchdb, userEvents, kafka, kafkaUi)
 

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -101,6 +101,10 @@ class Conf(arguments: Seq[String]) extends ScallopConf(Conf.expandAllMode(argume
 
   val devKcf = opt[Boolean](descr = "Enables KubernetesContainerFactory for local development")
 
+  val devUserEventsPort = opt[Int](
+    descr = "Specify the port for the user-event service. This mode can be used for local " +
+      "development of user-event service by configuring the Prometheus to connect to existing running service instance")
+
   mainOptions = Seq(manifest, configFile, apiGw, couchdb, userEvents, kafka, kafkaUi)
 
   verify()
@@ -219,7 +223,8 @@ object StandaloneOpenWhisk extends SLF4JLogging {
 
     val couchSvcs = if (conf.couchdb()) Some(startCouchDb(dataDir, dockerClient)) else None
     val userEventSvcs =
-      if (conf.userEvents()) startUserEvents(conf.port(), kafkaDockerPort, workDir, dataDir, dockerClient)
+      if (conf.userEvents() || conf.devUserEventsPort.isSupplied)
+        startUserEvents(conf.port(), kafkaDockerPort, conf.devUserEventsPort.toOption, workDir, dataDir, dockerClient)
       else Seq.empty
 
     val svcs = Seq(defaultSvcs, apiGwSvcs, couchSvcs.toList, kafkaSvcs, userEventSvcs).flatten
@@ -503,6 +508,7 @@ object StandaloneOpenWhisk extends SLF4JLogging {
 
   private def startUserEvents(owPort: Int,
                               kafkaDockerPort: Int,
+                              existingUserEventSvcPort: Option[Int],
                               workDir: File,
                               dataDir: File,
                               dockerClient: StandaloneDockerClient)(
@@ -511,7 +517,7 @@ object StandaloneOpenWhisk extends SLF4JLogging {
     ec: ExecutionContext,
     materializer: ActorMaterializer): Seq[ServiceContainer] = {
     implicit val tid: TransactionId = TransactionId(systemPrefix + "userevents")
-    val k = new UserEventLauncher(dockerClient, owPort, kafkaDockerPort, workDir, dataDir)
+    val k = new UserEventLauncher(dockerClient, owPort, kafkaDockerPort, existingUserEventSvcPort, workDir, dataDir)
 
     val f = k.run()
     val g = f.andThen {


### PR DESCRIPTION
With #4656 support was added in standalone mode to launch the User Event service along with required Prometheus and Grafana service. This PR adds support for reusing an existing user-event service (say running with IDE) for faster local developement

## Description

To enable fast local development of user-event service the Standalone OpenWhisk now support connecting to an existing running service instead of launching a new one via Docker

First launch the standalone server with Kafka and pass the port where user-event service would be running (9095 by default)

```
java -jar openwhisk-standalone.jar --dev-user-events-port 9095 --kafka --kafka-ui
```

Then launch the `org.apache.openwhisk.core.monitoring.metrics.Main` via IDE with env set to `KAFKA_HOSTS=localhost:9092`

After this one can do normal action invocation and see metrics appear in Grafana


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

