### PR TITLE
Cosmosdb query metrics for activation poll query

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 
     compile 'io.reactivex:rxscala_2.12:0.26.5'
     compile 'io.reactivex:rxjava-reactive-streams:1.2.1'
-    compile ('com.microsoft.azure:azure-cosmosdb:2.6.1')
+    compile ('com.microsoft.azure:azure-cosmosdb:2.6.2')
 
     compile ('com.lightbend.akka:akka-stream-alpakka-s3_2.12:1.0.1') {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http


### PR DESCRIPTION
To move forward with activation poll uqery optimization for CosmosDB (#4684) we need to collect some mertics. This PR collects 2 such metrics

## Description

This PR adds 2 new metrics which are computed for the activation list query used in `wsk activation poll` command

1. `histogram_cosmosdb_query_resultDelta_seconds` - Records the time delta between current time and the `start` time of the last activation entry in returned list of activations. This helps in determining how much recent activation results are being returned to end users for the poll command
2. `histogram_cosmosdb_query_sinceDelta_seconds` - Records the time delta between current time and the `since` time specified in list query used by activation poll

Below are the stats as recorded for Prometheus

```
# TYPE histogram_cosmosdb_query_resultDelta_seconds histogram
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.005"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.01"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.025"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.05"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.075"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.1"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.25"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.5"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="0.75"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="1.0"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="2.5"} 0.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="5.0"} 2.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="7.5"} 3.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="10.0"} 4.0
histogram_cosmosdb_query_resultDelta_seconds_bucket{view="activations",collection="activations",le="+Inf"} 8.0
histogram_cosmosdb_query_resultDelta_seconds_count{view="activations",collection="activations"} 8.0
histogram_cosmosdb_query_resultDelta_seconds_sum{view="activations",collection="activations"} 259.744

# TYPE histogram_cosmosdb_query_sinceDelta_seconds histogram
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.005"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.01"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.025"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.05"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.075"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.1"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.25"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.5"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="0.75"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="1.0"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="2.5"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="5.0"} 0.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="7.5"} 1.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="10.0"} 2.0
histogram_cosmosdb_query_sinceDelta_seconds_bucket{view="activations",collection="activations",le="+Inf"} 8.0
histogram_cosmosdb_query_sinceDelta_seconds_count{view="activations",collection="activations"} 8.0
histogram_cosmosdb_query_sinceDelta_seconds_sum{view="activations",collection="activations"} 3126736462.304
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

