### PR TITLE
Standalone based sanity test for KubernetesContainerFactory

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
@@ -23,11 +23,25 @@ import org.scalatest.junit.JUnitRunner
 import system.basic.WskRestBasicTests
 
 @RunWith(classOf[JUnitRunner])
-class StandaloneKafkaTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
+class StandaloneKCFTests extends WskRestBasicTests with StandaloneServerFixture with StandaloneSanityTestSupport {
   override implicit val wskprops = WskProps().copy(apihost = serverUrl)
 
-  override protected def supportedTests: Set[String] =
-    Set("Wsk Action REST should invoke a blocking action and get only the result")
+  //Turn on to debug locally easily
+  override protected val dumpLogsAlways = false
 
-  override protected def extraArgs: Seq[String] = Seq("--dev-mode", "--kafka")
+  override protected val dumpStartupLogs = false
+
+  override protected def supportedTests = Set("Wsk Action REST should invoke a blocking action and get only the result")
+
+  override protected def extraArgs: Seq[String] = Seq("--dev-mode", "--dev-kcf")
+
+  override def beforeAll(): Unit = {
+    val kubeconfig = sys.env.get("KUBECONFIG")
+    require(kubeconfig.isDefined, "KUBECONFIG env must be defined")
+    println(s"Using kubeconfig from ${kubeconfig.get}")
+
+    //Note the context need to specify default namespace
+    //kubectl config set-context --current --namespace=default
+    super.beforeAll()
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneServerFixture.scala
@@ -54,6 +54,10 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   protected def waitForOtherThings(): Unit = {}
 
+  protected def dumpLogsAlways: Boolean = false
+
+  protected def dumpStartupLogs: Boolean = false
+
   protected val dataDirPath: String = FilenameUtils.concat(FileUtils.getTempDirectoryPath, "standalone")
 
   override def beforeAll(): Unit = {
@@ -85,6 +89,9 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
         serverStartedForTest = true
         println(s"Started test server at $serverUrl in [$w]")
         waitForOtherThings()
+        if (dumpStartupLogs) {
+          println(logLines.mkString("\n"))
+        }
     }
   }
 
@@ -102,7 +109,7 @@ trait StandaloneServerFixture extends TestSuite with BeforeAndAfterAll with Stre
 
   override def withFixture(test: NoArgTest) = {
     val outcome = super.withFixture(test)
-    if (outcome.isFailed) {
+    if (outcome.isFailed || (outcome.isSucceeded && dumpLogsAlways)) {
       println(logLines.mkString("\n"))
     }
     stream.reset()

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -30,6 +30,21 @@ $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD properties.yml -e manifest_file="/ansible/files/runtimes-nodeonly.json"
 $ANSIBLE_CMD downloadcli-github.yml
 
+# Install kubectl
+curl -Lo ./kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.1/bin/linux/amd64/kubectl
+chmod +x kubectl
+sudo cp kubectl /usr/local/bin/kubectl
+
+# Install kind
+curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64
+chmod +x kind
+sudo cp kind /usr/local/bin/kind
+
+kind create cluster --wait 5m
+export KUBECONFIG="$(kind get kubeconfig-path)"
+kubectl config set-context --current --namespace=default
+
+
 cd $ROOTDIR
 TERM=dumb ./gradlew :core:standalone:build \
   :core:monitoring:user-events:distDocker


### PR DESCRIPTION
Adds a basic sanity test based for KubernetesContainerFactory using Standalone mode

## Description

This PR creates a small k8s setup based on [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) using approach taken in apache/openwhisk-deploy-kube#535. Here we just create base kind cluster with no OpenWhisk related components installed.

Later the Standalone server is used and configured to connect to this kind cluster (#4671) to run a basic invocation test

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

