### PR TITLE
Pod template support with KubernetesContainerFactory

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile ('com.fasterxml.uuid:java-uuid-generator:3.1.3')
     compile 'com.github.ben-manes.caffeine:caffeine:2.6.2'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'io.fabric8:kubernetes-client:4.4.2'
+    compile "io.fabric8:kubernetes-client:${gradle.kube_client.version}"
     compile ('io.kamon:kamon-core_2.12:1.1.3') {
         exclude group: 'com.lihaoyi'
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMapValue.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/ConfigMapValue.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import java.io.File
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.apache.commons.io.FileUtils
+import pureconfig.ConfigReader
+import pureconfig.ConvertHelpers.catchReadError
+
+class ConfigMapValue private (val value: String)
+
+object ConfigMapValue {
+
+  /**
+   * Checks if the value is a file url like `file:/etc/config/foo.yaml` then treat it as a file reference
+   * and read its content otherwise consider it as a literal value
+   */
+  def apply(config: String): ConfigMapValue = {
+    val value = if (config.startsWith("file:")) {
+      val uri = new URI(config)
+      val file = new File(uri)
+      FileUtils.readFileToString(file, UTF_8)
+    } else config
+    new ConfigMapValue(value)
+  }
+
+  implicit val reader: ConfigReader[ConfigMapValue] = ConfigReader.fromString[ConfigMapValue](catchReadError(apply))
+}

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -81,6 +81,11 @@ whisk {
     # Enables forwarding to remote port via a local random port. This mode is mostly useful
     # for development via Standalone mode
     port-forwarding-enabled = false
+
+    # Pod template as yaml formatted multi line string. If specified then Action Pod would be based
+    # on this template
+    # See multi line config support https://github.com/lightbend/config/blob/master/HOCON.md#multi-line-strings
+    #pod-template =
   }
 
   # Timeouts for runc commands. Set to "Inf" to disable timeout.

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -82,9 +82,10 @@ whisk {
     # for development via Standalone mode
     port-forwarding-enabled = false
 
-    # Pod template as yaml formatted multi line string. If specified then Action Pod would be based
-    # on this template
-    # See multi line config support https://github.com/lightbend/config/blob/master/HOCON.md#multi-line-strings
+    # Pod template used as base for Action Pods created. It can be either
+    #  1. Reference to file `file:/path/to/template.yml`
+    #  2. OR yaml formatted multi line string. See multi line config support https://github.com/lightbend/config/blob/master/HOCON.md#multi-line-strings
+    #
     #pod-template =
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -34,7 +34,7 @@ import io.fabric8.kubernetes.client.utils.Serialization
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 import okhttp3.{Call, Callback, Request, Response}
 import okio.BufferedSource
-import org.apache.openwhisk.common.{Logging, TransactionId}
+import org.apache.openwhisk.common.{ConfigMapValue, Logging, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.containerpool.docker.ProcessRunner
 import org.apache.openwhisk.core.containerpool.{ContainerAddress, ContainerId}
@@ -76,7 +76,7 @@ case class KubernetesClientConfig(timeouts: KubernetesClientTimeoutConfig,
                                   invokerAgent: KubernetesInvokerAgentConfig,
                                   userPodNodeAffinity: KubernetesInvokerNodeAffinity,
                                   portForwardingEnabled: Boolean,
-                                  podTemplate: Option[String] = None)
+                                  podTemplate: Option[ConfigMapValue] = None)
 
 /**
  * Serves as an interface to the Kubernetes API by proxying its REST API and/or invoking the kubectl CLI.

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -30,6 +30,7 @@ import akka.stream.stage._
 import akka.stream.{ActorMaterializer, Attributes, Outlet, SourceShape}
 import akka.util.ByteString
 import io.fabric8.kubernetes.api.model._
+import io.fabric8.kubernetes.client.utils.Serialization
 import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
 import okhttp3.{Call, Callback, Request, Response}
 import okio.BufferedSource
@@ -107,7 +108,9 @@ class KubernetesClient(
           labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
 
     val pod = podBuilder.buildPodSpec(name, image, memory, environment, labels)
-    //TODO Log pod spec if debug enabled
+    if (transid.meta.extraLogging) {
+      log.info(this, s"Pod spec being created\n${Serialization.asYaml(pod)}")
+    }
     val namespace = kubeRestClient.getNamespace
     kubeRestClient.pods.inNamespace(namespace).create(pod)
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -44,7 +44,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
@@ -108,7 +107,7 @@ class KubernetesClient(
           labels: Map[String, String] = Map.empty)(implicit transid: TransactionId): Future[KubernetesContainer] = {
 
     val pod = podBuilder.buildPodSpec(name, image, memory, environment, labels)
-
+    //TODO Log pod spec if debug enabled
     val namespace = kubeRestClient.getNamespace
     kubeRestClient.pods.inNamespace(namespace).create(pod)
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool.kubernetes
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import io.fabric8.kubernetes.api.model.{
+  AffinityBuilder,
+  EnvVarBuilder,
+  Pod,
+  PodBuilder,
+  Quantity,
+  SecurityContextBuilder
+}
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.entity.ByteSize
+
+import scala.collection.JavaConverters._
+
+class WhiskPodBuilder(client: NamespacedKubernetesClient,
+                      userPodNodeAffinity: KubernetesInvokerNodeAffinity,
+                      podTemplate: Option[String] = None) {
+
+  def buildPodSpec(name: String,
+                   image: String,
+                   memory: ByteSize,
+                   environment: Map[String, String],
+                   labels: Map[String, String])(implicit transid: TransactionId): Pod = {
+    val envVars = environment.map {
+      case (key, value) => new EnvVarBuilder().withName(key).withValue(value).build()
+    }.toSeq
+
+    val baseBuilder = podTemplate match {
+      case Some(template) =>
+        new PodBuilder(loadPodSpec(template))
+      case None => new PodBuilder()
+    }
+
+    val podBuilder = baseBuilder
+      .withNewMetadata()
+      .withName(name)
+      .addToLabels("name", name)
+      .addToLabels(labels.asJava)
+      .endMetadata()
+      .withNewSpec()
+      .withRestartPolicy("Always")
+    if (userPodNodeAffinity.enabled) {
+      val invokerNodeAffinity = new AffinityBuilder()
+        .withNewNodeAffinity()
+        .withNewRequiredDuringSchedulingIgnoredDuringExecution()
+        .addNewNodeSelectorTerm()
+        .addNewMatchExpression()
+        .withKey(userPodNodeAffinity.key)
+        .withOperator("In")
+        .withValues(userPodNodeAffinity.value)
+        .endMatchExpression()
+        .endNodeSelectorTerm()
+        .endRequiredDuringSchedulingIgnoredDuringExecution()
+        .endNodeAffinity()
+        .build()
+      podBuilder.withAffinity(invokerNodeAffinity)
+    }
+    val secContext = new SecurityContextBuilder()
+      .withNewCapabilities()
+      .addToDrop("NET_RAW", "NET_ADMIN")
+      .endCapabilities()
+      .build()
+    val pod = podBuilder
+      .addNewContainer()
+      .withNewResources()
+      .withLimits(Map("memory" -> new Quantity(memory.toMB + "Mi")).asJava)
+      .endResources()
+      .withSecurityContext(secContext)
+      .withName("user-action")
+      .withImage(image)
+      .withEnv(envVars.asJava)
+      .addNewPort()
+      .withContainerPort(8080)
+      .withName("action")
+      .endPort()
+      .endContainer()
+      .endSpec()
+      .build()
+    pod
+  }
+
+  private def loadPodSpec(spec: String): Pod = {
+    val resources = client.load(new ByteArrayInputStream(spec.getBytes(StandardCharsets.UTF_8)))
+    resources.get().get(0).asInstanceOf[Pod]
+  }
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
@@ -23,15 +23,15 @@ import java.nio.charset.StandardCharsets.UTF_8
 import io.fabric8.kubernetes.api.builder.Predicate
 import io.fabric8.kubernetes.api.model.{ContainerBuilder, EnvVarBuilder, Pod, PodBuilder, Quantity}
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{ConfigMapValue, TransactionId}
 import org.apache.openwhisk.core.entity.ByteSize
 
 import scala.collection.JavaConverters._
 
 class WhiskPodBuilder(client: NamespacedKubernetesClient,
                       userPodNodeAffinity: KubernetesInvokerNodeAffinity,
-                      podTemplate: Option[String] = None) {
-  private val template = podTemplate.map(_.getBytes(UTF_8))
+                      podTemplate: Option[ConfigMapValue] = None) {
+  private val template = podTemplate.map(_.value.getBytes(UTF_8))
   private val actionContainerName = "user-action"
   private val actionContainerPredicate: Predicate[ContainerBuilder] = (cb) => cb.getName == actionContainerName
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,4 +48,5 @@ gradle.ext.akka = [version : '2.5.22']
 gradle.ext.akka_kafka = [version : '1.0.5']
 gradle.ext.akka_http = [version : '10.1.8']
 
-gradle.ext.curator = [version:'4.0.0']
+gradle.ext.curator = [version : '4.0.0']
+gradle.ext.kube_client = [version: '4.4.2']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -201,6 +201,8 @@ dependencies {
     compile 'com.atlassian.oai:swagger-request-validator-core:1.4.5'
     compile "com.typesafe.akka:akka-stream-kafka-testkit_2.12:${gradle.akka_kafka.version}"
     compile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
+    compile "com.typesafe.akka:akka-stream-testkit_2.12:${gradle.akka.version}"
+    compile "io.fabric8:kubernetes-server-mock:${gradle.kube_client.version}"
 
     compile "com.amazonaws:aws-java-sdk-s3:1.11.295"
 

--- a/tests/src/test/scala/org/apache/openwhisk/common/ConfigMapValueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/ConfigMapValueTests.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Files
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.io.FileUtils
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+import pureconfig.loadConfigOrThrow
+
+@RunWith(classOf[JUnitRunner])
+class ConfigMapValueTests extends FlatSpec with Matchers {
+  behavior of "ConfigMapValue"
+
+  case class ValueTest(template: ConfigMapValue, count: Int)
+
+  it should "read from string" in {
+    val config = ConfigFactory.parseString("""
+       |whisk {
+       |  value-test {
+       |    template = "test string"
+       |    count = 42
+       |  }
+       |}""".stripMargin)
+
+    val valueTest = readValueTest(config)
+    valueTest.template.value shouldBe "test string"
+  }
+
+  it should "read from file reference" in {
+    val file = Files.createTempFile("whisk", null).toFile
+    FileUtils.write(file, "test string", UTF_8)
+
+    val config = ConfigFactory.parseString(s"""
+       |whisk {
+       |  value-test {
+       |    template = "${file.toURI}"
+       |    count = 42
+       |  }
+       |}""".stripMargin)
+
+    val valueTest = readValueTest(config)
+    valueTest.template.value shouldBe "test string"
+
+    file.delete()
+  }
+
+  private def readValueTest(config: com.typesafe.config.Config) = {
+    loadConfigOrThrow[ValueTest](config.getConfig("whisk.value-test"))
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubeClientSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubeClientSupport.scala
@@ -48,6 +48,7 @@ trait KubeClientSupport extends TestSuite with BeforeAndAfterAll with StreamLogg
     if (!useMockServer) {
       val kubeconfig = sys.env.get("KUBECONFIG")
       assume(kubeconfig.isDefined, "KUBECONFIG env must be defined")
+      println(s"Using kubeconfig from ${kubeconfig.get}")
     }
     super.beforeAll()
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubeClientSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubeClientSupport.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool.kubernetes.test
+
+import common.StreamLogging
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
+import org.scalatest.{BeforeAndAfterAll, Suite, TestSuite}
+
+import scala.concurrent.duration._
+
+trait KubeClientSupport extends TestSuite with BeforeAndAfterAll with StreamLogging {
+  self: Suite =>
+
+  protected def useMockServer = true
+
+  protected lazy val (kubeClient, closeable) = {
+    if (useMockServer) {
+      val server = new KubernetesMockServer(false)
+      server.init()
+      (server.createClient(), () => server.destroy())
+    } else {
+      val client = new DefaultKubernetesClient(
+        new ConfigBuilder()
+          .withConnectionTimeout(1.minute.toMillis.toInt)
+          .withRequestTimeout(1.minute.toMillis.toInt)
+          .build())
+      (client, () => client.close())
+    }
+  }
+
+  override def beforeAll(): Unit = {
+    if (!useMockServer) {
+      val kubeconfig = sys.env.get("KUBECONFIG")
+      assume(kubeconfig.isDefined, "KUBECONFIG env must be defined")
+    }
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    closeable.apply()
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
@@ -19,7 +19,7 @@ package org.apache.openwhisk.core.containerpool.kubernetes.test
 
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.utils.Serialization
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{ConfigMapValue, TransactionId}
 import org.apache.openwhisk.core.containerpool.kubernetes.{KubernetesInvokerNodeAffinity, WhiskPodBuilder}
 import org.apache.openwhisk.core.entity.size._
 import org.junit.runner.RunWith
@@ -66,7 +66,7 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
        |      image : "busybox"
        |""".stripMargin
 
-    val builder = new WhiskPodBuilder(kubeClient, affinity.copy(enabled = false), Some(template))
+    val builder = new WhiskPodBuilder(kubeClient, affinity.copy(enabled = false), Some(ConfigMapValue(template)))
     val pod = assertPodSettings(builder)
 
     val ac = getActionContainer(pod)
@@ -95,7 +95,7 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
        |            values:
        |            - "test"""".stripMargin
 
-    val builder = new WhiskPodBuilder(kubeClient, affinity.copy(enabled = true), Some(template))
+    val builder = new WhiskPodBuilder(kubeClient, affinity.copy(enabled = true), Some(ConfigMapValue(template)))
     val pod = assertPodSettings(builder)
 
     val terms =

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool.kubernetes.test
+
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.client.utils.Serialization
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.containerpool.kubernetes.{KubernetesInvokerNodeAffinity, WhiskPodBuilder}
+import org.apache.openwhisk.core.entity.size._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport {
+  implicit val tid: TransactionId = TransactionId.testing
+  private val testImage = "busybox"
+  private val memLimit = 10.MB
+  private val name = "whisk"
+
+  behavior of "WhiskPodBuilder"
+
+  it should "build a pod spec" in {
+    val affinity = KubernetesInvokerNodeAffinity(enabled = true, "openwhisk-role", "invoker")
+    val builder = new WhiskPodBuilder(kubeClient, affinity)
+
+    val pod = builder.buildPodSpec(name, testImage, memLimit, Map("foo" -> "bar"), Map("fooL" -> "barV"))
+    assertPodSettings(pod)
+  }
+
+  private def assertPodSettings(pod: Pod): Unit = {
+    withClue(Serialization.asYaml(pod)) {
+      val c = pod.getSpec.getContainers.asScala.find(_.getName == "user-action").get
+      c.getEnv.asScala.exists(_.getName == "foo") shouldBe true
+
+      c.getResources.getLimits.asScala.get("memory").map(_.getAmount) shouldBe Some("10Mi")
+      c.getSecurityContext.getCapabilities.getDrop.asScala should contain allOf ("NET_RAW", "NET_ADMIN")
+      c.getPorts.asScala.find(_.getName == "action").map(_.getContainerPort) shouldBe Some(8080)
+      c.getImage shouldBe testImage
+
+      pod.getMetadata.getLabels.asScala.get("name") shouldBe Some(name)
+      pod.getMetadata.getLabels.asScala.get("fooL") shouldBe Some("barV")
+      pod.getMetadata.getName shouldBe name
+    }
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
@@ -68,16 +68,6 @@ class StandaloneKCFTests
          |}""".stripMargin)
   }
 
-  override def beforeAll(): Unit = {
-    val kubeconfig = sys.env.get("KUBECONFIG")
-    require(kubeconfig.isDefined, "KUBECONFIG env must be defined")
-    println(s"Using kubeconfig from ${kubeconfig.get}")
-
-    //Note the context need to specify default namespace
-    //kubectl config set-context --current --namespace=default
-    super.beforeAll()
-  }
-
   override def afterAll(): Unit = {
     checkPodState()
     super.afterAll()

--- a/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/standalone/StandaloneKCFTests.scala
@@ -35,7 +35,6 @@ class StandaloneKCFTests
     with KubeClientSupport {
   override implicit val wskprops = WskProps().copy(apihost = serverUrl)
 
-  val qt = "\"\"\""
   //Turn on to debug locally easily
   override protected val dumpLogsAlways = false
 


### PR DESCRIPTION
This PR adds support for providing a base Pod template to customize the action Pod created by KubernetesContainerFactory (KCF)

## Description

Sometime back we [discussed a usecase on DL][1] to configure a private registry for action containers. This PR now enables that usecase via an optional `pod-template` config

### Usage

Provide the base pod template via config like below

Pod template yaml stored at "/pod-template.yaml` 

```yaml
---
apiVersion: "v1"
kind: "Pod"
metadata:
  annotations:
    allow-outbound : "true"
```

```
whisk {
  spi {
    ContainerFactoryProvider = "org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"
  }
  kubernetes {
    pod-template = "file:/pod-template.yaml"
  }
}
```

When KCF would create an action container POD it would use the above template as base and add the changes required by OpenWhisk on top of that. 

There are 3 ways to pass this yaml config

#### 1. Inline

```
whisk {
  kubernetes {
    pod-template = """---
apiVersion: "v1"
kind: "Pod"
metadata:
  annotations:
    allow-outbound : "true"
    """
  }
}
```

#### 2. Via File reference

```
whisk {
  kubernetes {
    pod-template = "file:/pod-template.yaml"
  }
}
```
Here the file can be mounted from a config map

#### 3. Via ENV

```
whisk {
  kubernetes {
    pod-template = ${WHISK_POD_TEMPLATE}
  }
}
```

Here the env `WHISK_POD_TEMPLATE` is configured via a ConfigMap value

To see the final POD spec this PR also enables support for logging the pod spec in yaml via `X-OW-EXTRA-LOGGING` header (#3174). 

For example assume that setup has a `hello` action configured (say using #4671). 

```
$ curl -k --dump-header -  -X POST \
      --user "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP" \
      -H "X-OW-EXTRA-LOGGING: on" \
      "http://localhost:3233/api/v1/namespaces/_/actions/hello?blocking=true&result=true"
```

Then above command would log the pod spec

```yaml
[2019-10-15T16:23:12.659Z] [INFO] [#tid_B7WSlmTXLKHTDCH0TYb6mcf6ttpyKNrZ] [KubernetesClient] Pod spec being created
---
apiVersion: "v1"
kind: "Pod"
metadata:
  annotations:
    allow-outbound: "true"
  labels:
    name: "wsk0-1-guest-hello3"
    invoker: "invoker0"
  name: "wsk0-1-guest-hello3"
  namespace: "default"
spec:
  containers:
  - env:
    - name: "__OW_API_HOST"
      value: "http://host.docker.internal:3233"
    image: "openwhisk/action-nodejs-v10:1.14.0-incubating"
    name: "user-action"
    ports:
    - containerPort: 8080
      name: "action"
    resources:
      limits:
        memory: "256Mi"
      requests: {}
    securityContext:
      capabilities:
        drop:
        - "NET_RAW"
        - "NET_ADMIN"
  nodeSelector: {}
  restartPolicy: "Always"
```

This spec includes the custom annotation configured in base template `allow-outbound`

### Implementation Details

With `pod-template` one can configure any k8s supported config for the `Pod`. Each such pod would always have  a  `container` named `user-action`. Following aspects though would be controlled by KCF 

1. Container memory limit
2. Container port
3. Container env
4. Container securityContext would always have `NET_RAW` and `NET_ADMIN` dropped. One can "add" more capabilities
5. Pod name

[1]: https://lists.apache.org/thread.html/ac5954d64078744fd5b234f973cd29556b77a846116f5793f1ed9b16@%3Cdev.openwhisk.apache.org%3E

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

