### PR TITLE
restrict Jenkins dockerhub publish job to run on openwhisk VMs

### DIFF
--- a/tools/jenkins/apache/dockerhub.groovy
+++ b/tools/jenkins/apache/dockerhub.groovy
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-node('xenial&&!H21&&!H22&&!H11&&!ubuntu-eu3') {
+node('openwhisk1||openwhisk2||openwhisk3') {
   sh "env"
   sh "docker version"
   sh "docker info"


### PR DESCRIPTION
Attempt to gain better control over Jenkins execution environment
by restricting job to run on one of the openwhisk VMs.

Running on general pool of machines, the build fails (eg https://builds.apache.org/view/O/view/OpenWhisk/job/OpenWhisk-DockerHub/2135/).

Running on one of our machines, the build succeeds (eg https://builds.apache.org/view/O/view/OpenWhisk/job/OpenWhisk-csantanapr/49/console)