### PR TITLE
Add healthcheck for Invoker -> Action Container 

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -484,9 +484,17 @@ object LoggingMarkers {
     LogMarkerToken(invoker, "mesos", start, Some(cmd), Map("cmd" -> cmd))(MeasurementUnit.time.milliseconds)
   def INVOKER_MESOS_CMD_TIMEOUT(cmd: String) =
     LogMarkerToken(invoker, "mesos", timeout, Some(cmd), Map("cmd" -> cmd))(MeasurementUnit.none)
-  def INVOKER_CONTAINER_START(containerState: String) =
-    LogMarkerToken(invoker, "containerStart", counter, Some(containerState), Map("containerState" -> containerState))(
-      MeasurementUnit.none)
+  def INVOKER_CONTAINER_START(containerState: String, userNamespace: String, actionNamespace: String, action: String) =
+    LogMarkerToken(
+      invoker,
+      "containerStart",
+      counter,
+      Some(containerState),
+      Map(
+        "containerState" -> containerState,
+        "userNamespace" -> userNamespace,
+        "actionNamespace" -> actionNamespace,
+        "action" -> action))(MeasurementUnit.none)
   val INVOKER_CONTAINER_HEALTH = LogMarkerToken(invoker, "containerHealth", start)(MeasurementUnit.time.milliseconds)
   val INVOKER_CONTAINER_HEALTH_FAILED_WARM =
     LogMarkerToken(invoker, "containerHealthFailed", counter, Some("warm"), Map("containerState" -> "warm"))(

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -519,6 +519,10 @@ object LoggingMarkers {
     LogMarkerToken(containerPool, "prewarmCount", counter)(MeasurementUnit.none)
   val CONTAINER_POOL_PREWARM_SIZE =
     LogMarkerToken(containerPool, "prewarmSize", counter)(MeasurementUnit.information.megabytes)
+  val CONTAINER_POOL_IDLES_COUNT =
+    LogMarkerToken(containerPool, "idlesCount", counter)(MeasurementUnit.none)
+  val CONTAINER_POOL_IDLES_SIZE =
+    LogMarkerToken(containerPool, "idlesSize", counter)(MeasurementUnit.information.megabytes)
 
   val INVOKER_TOTALMEM_BLACKBOX = LogMarkerToken(loadbalancer, "totalCapacityBlackBox", counter)(MeasurementUnit.none)
   val INVOKER_TOTALMEM_MANAGED = LogMarkerToken(loadbalancer, "totalCapacityManaged", counter)(MeasurementUnit.none)

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -487,6 +487,7 @@ object LoggingMarkers {
   def INVOKER_CONTAINER_START(containerState: String) =
     LogMarkerToken(invoker, "containerStart", counter, Some(containerState), Map("containerState" -> containerState))(
       MeasurementUnit.none)
+  val INVOKER_CONTAINER_HEALTH = LogMarkerToken(invoker, "containerHealth", start)(MeasurementUnit.time.milliseconds)
   val CONTAINER_CLIENT_RETRIES =
     LogMarkerToken(containerClient, "retries", counter)(MeasurementUnit.none)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -488,6 +488,12 @@ object LoggingMarkers {
     LogMarkerToken(invoker, "containerStart", counter, Some(containerState), Map("containerState" -> containerState))(
       MeasurementUnit.none)
   val INVOKER_CONTAINER_HEALTH = LogMarkerToken(invoker, "containerHealth", start)(MeasurementUnit.time.milliseconds)
+  val INVOKER_CONTAINER_HEALTH_FAILED_WARM =
+    LogMarkerToken(invoker, "containerHealthFailed", counter, Some("warm"), Map("containerState" -> "warm"))(
+      MeasurementUnit.none)
+  val INVOKER_CONTAINER_HEALTH_FAILED_PREWARM =
+    LogMarkerToken(invoker, "containerHealthFailed", counter, Some("prewarm"), Map("containerState" -> "prewarm"))(
+      MeasurementUnit.none)
   val CONTAINER_CLIENT_RETRIES =
     LogMarkerToken(containerClient, "retries", counter)(MeasurementUnit.none)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -484,7 +484,7 @@ object LoggingMarkers {
     LogMarkerToken(invoker, "mesos", start, Some(cmd), Map("cmd" -> cmd))(MeasurementUnit.time.milliseconds)
   def INVOKER_MESOS_CMD_TIMEOUT(cmd: String) =
     LogMarkerToken(invoker, "mesos", timeout, Some(cmd), Map("cmd" -> cmd))(MeasurementUnit.none)
-  def INVOKER_CONTAINER_START(containerState: String, userNamespace: String, actionNamespace: String, action: String) =
+  def INVOKER_CONTAINER_START(containerState: String, invocationNamespace: String, namespace: String, action: String) =
     LogMarkerToken(
       invoker,
       "containerStart",
@@ -492,8 +492,8 @@ object LoggingMarkers {
       Some(containerState),
       Map(
         "containerState" -> containerState,
-        "userNamespace" -> userNamespace,
-        "actionNamespace" -> actionNamespace,
+        "initiator" -> invocationNamespace,
+        "namespace" -> namespace,
         "action" -> action))(MeasurementUnit.none)
   val INVOKER_CONTAINER_HEALTH = LogMarkerToken(invoker, "containerHealth", start)(MeasurementUnit.time.milliseconds)
   val INVOKER_CONTAINER_HEALTH_FAILED_WARM =

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
@@ -225,6 +225,7 @@ object TransactionId {
   val invokerHealth = TransactionId(systemPrefix + "invokerHealth") // Invoker supervision
   val controller = TransactionId(systemPrefix + "controller") // Controller startup
   val dbBatcher = TransactionId(systemPrefix + "dbBatcher") // Database batcher
+  val actionHealthPing = TransactionId(systemPrefix + "actionHealth")
 
   def apply(tid: String, extraLogging: Boolean = false): TransactionId = {
     val now = Instant.now(Clock.systemUTC()).inMills

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -247,6 +247,7 @@ object ConfigKeys {
 
   val containerProxy = "whisk.container-proxy"
   val containerProxyTimeouts = s"$containerProxy.timeouts"
+  val containerProxyHealth = s"$containerProxy.action-health-check"
 
   val s3 = "whisk.s3"
   val query = "whisk.query-limit"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/AkkaContainerClient.scala
@@ -143,14 +143,14 @@ protected class AkkaContainerClient(
                               retry: Boolean,
                               reschedule: Boolean,
                               endpoint: String,
-                              retryCount: Int = 0): Future[(HttpResponse, Int)] = {
+                              retryCount: Int = 0)(implicit tid: TransactionId): Future[(HttpResponse, Int)] = {
     val start = Instant.now
 
     request(req)
       .map((_, retryCount))
       .recoverWith {
         case _: StreamTcpException if reschedule =>
-          Future.failed(ContainerHealthError(endpoint))
+          Future.failed(ContainerHealthError(tid, endpoint))
         case t: StreamTcpException if retry =>
           if (timeout > Duration.Zero) {
             akka.pattern.after(retryInterval, as.scheduler)({

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
@@ -90,7 +90,7 @@ protected class ApacheBlockingContainerClient(hostname: String,
    * @param retry whether or not to retry on connection failure
    * @return Left(Error Message) or Right(Status Code, Response as UTF-8 String)
    */
-  def post(endpoint: String, body: JsValue, retry: Boolean)(
+  def post(endpoint: String, body: JsValue, retry: Boolean, reschedule: Boolean = false)(
     implicit tid: TransactionId): Future[Either[ContainerHttpError, ContainerResponse]] = {
     val entity = new StringEntity(body.compactPrint, StandardCharsets.UTF_8)
     entity.setContentType("application/json")
@@ -101,14 +101,18 @@ protected class ApacheBlockingContainerClient(hostname: String,
 
     Future {
       blocking {
-        execute(request, timeout, maxConcurrent, retry)
+        execute(request, timeout, maxConcurrent, retry, reschedule)
       }
     }
   }
 
   // Annotation will make the compiler complain if no tail recursion is possible
-  @tailrec private def execute(request: HttpRequestBase, timeout: FiniteDuration, maxConcurrent: Int, retry: Boolean)(
-    implicit tid: TransactionId): Either[ContainerHttpError, ContainerResponse] = {
+  @tailrec private def execute(
+    request: HttpRequestBase,
+    timeout: FiniteDuration,
+    maxConcurrent: Int,
+    retry: Boolean,
+    reschedule: Boolean = false)(implicit tid: TransactionId): Either[ContainerHttpError, ContainerResponse] = {
     val start = Instant.now
 
     Try(connection.execute(request)).map { response =>
@@ -159,6 +163,8 @@ protected class ApacheBlockingContainerClient(hostname: String,
         Failure(RetryableConnectionError(t))
     } match {
       case Success(response) => response
+      case Failure(_: RetryableConnectionError) if reschedule =>
+        throw ContainerHealthError(request.getURI.toString)
       case Failure(t: RetryableConnectionError) if retry =>
         if (timeout > Duration.Zero) {
           Thread.sleep(50) // Sleep for 50 milliseconds

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
@@ -162,8 +162,9 @@ protected class ApacheBlockingContainerClient(hostname: String,
       case t: NoHttpResponseException if ApacheBlockingContainerClient.clientConfig.retryNoHttpResponseException =>
         Failure(RetryableConnectionError(t))
     } match {
-      case Success(response) => response
+      case Success(response)                                  => response
       case Failure(_: RetryableConnectionError) if reschedule =>
+        //propagate as a failed future; clients can retry at a different container
         throw ContainerHealthError(request.getURI.toString)
       case Failure(t: RetryableConnectionError) if retry =>
         if (timeout > Duration.Zero) {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
@@ -165,7 +165,7 @@ protected class ApacheBlockingContainerClient(hostname: String,
       case Success(response)                                  => response
       case Failure(_: RetryableConnectionError) if reschedule =>
         //propagate as a failed future; clients can retry at a different container
-        throw ContainerHealthError(request.getURI.toString)
+        throw ContainerHealthError(tid, request.getURI.toString)
       case Failure(t: RetryableConnectionError) if retry =>
         if (timeout > Duration.Zero) {
           Thread.sleep(50) // Sleep for 50 milliseconds

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -48,6 +48,7 @@ case class ContainerId(asString: String) {
 }
 case class ContainerAddress(host: String, port: Int = 8080) {
   require(host.nonEmpty, "ContainerIp must not be empty")
+  def asString() = s"${host}:${port}"
 }
 
 object Container {
@@ -72,7 +73,7 @@ trait Container {
 
   implicit protected val as: ActorSystem
   protected val id: ContainerId
-  protected val addr: ContainerAddress
+  protected[core] val addr: ContainerAddress
   protected implicit val logging: Logging
   protected implicit val ec: ExecutionContext
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -254,7 +254,7 @@ case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
 case class InitializationError(interval: Interval, response: ActivationResponse) extends Exception(response.toString)
 
 /** Indicates a connection error after resuming a container */
-case class ContainerHealthError(msg: String) extends Exception(msg)
+case class ContainerHealthError(tid: TransactionId, msg: String) extends Exception(msg)
 
 case class Interval(start: Instant, end: Instant) {
   def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -150,8 +150,11 @@ trait Container {
   }
 
   /** Runs code in the container. Thread-safe - caller may invoke concurrently for concurrent activation processing. */
-  def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, maxConcurrent: Int)(
-    implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+  def run(parameters: JsObject,
+          environment: JsObject,
+          timeout: FiniteDuration,
+          maxConcurrent: Int,
+          reschedule: Boolean = false)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
     val actionName = environment.fields.get("action_name").map(_.convertTo[String]).getOrElse("")
     val start =
       transid.started(
@@ -162,7 +165,7 @@ trait Container {
 
     val parameterWrapper = JsObject("value" -> parameters)
     val body = JsObject(parameterWrapper.fields ++ environment.fields)
-    callContainer("/run", body, timeout, maxConcurrent, retry = false)
+    callContainer("/run", body, timeout, maxConcurrent, retry = false, reschedule)
       .andThen { // never fails
         case Success(r: RunResult) =>
           transid.finished(
@@ -194,12 +197,14 @@ trait Container {
    * @param body body to send
    * @param timeout timeout of the request
    * @param retry whether or not to retry the request
+   * @param reschedule throw a reschedule error in case of connection failure
    */
   protected def callContainer(path: String,
                               body: JsObject,
                               timeout: FiniteDuration,
                               maxConcurrent: Int,
-                              retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
+                              retry: Boolean = false,
+                              reschedule: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
     val started = Instant.now()
     val http = httpConnection.getOrElse {
       val conn = openConnections(timeout, maxConcurrent)
@@ -207,7 +212,7 @@ trait Container {
       conn
     }
     http
-      .post(path, body, retry)
+      .post(path, body, retry, reschedule)
       .map { response =>
         val finished = Instant.now()
         RunResult(Interval(started, finished), response)
@@ -247,6 +252,9 @@ case class BlackboxStartupError(msg: String) extends ContainerStartupError(msg)
 
 /** Indicates an error while initializing a container */
 case class InitializationError(interval: Interval, response: ActivationResponse) extends Exception(response.toString)
+
+/** Indicates a connection error after resuming a container */
+case class ContainerHealthError(msg: String) extends Exception(msg)
 
 case class Interval(start: Instant, end: Instant) {
   def duration = Duration.create(end.toEpochMilli() - start.toEpochMilli(), MILLISECONDS)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerClient.scala
@@ -24,7 +24,7 @@ import org.apache.openwhisk.core.entity.ActivationResponse.ContainerHttpError
 import org.apache.openwhisk.core.entity.ActivationResponse._
 
 trait ContainerClient {
-  def post(endpoint: String, body: JsValue, retry: Boolean)(
+  def post(endpoint: String, body: JsValue, retry: Boolean, reschedule: Boolean)(
     implicit tid: TransactionId): Future[Either[ContainerHttpError, ContainerResponse]]
   def close(): Future[Unit]
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosTask.scala
@@ -188,7 +188,7 @@ object JsonFormatters extends DefaultJsonProtocol {
 }
 
 class MesosTask(override protected val id: ContainerId,
-                override protected val addr: ContainerAddress,
+                override protected[core] val addr: ContainerAddress,
                 override protected implicit val ec: ExecutionContext,
                 override protected implicit val logging: Logging,
                 override protected val as: ActorSystem,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
@@ -43,7 +43,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * (external log collection and retrieval must be enabled via LogStore SPI to expose logs to wsk cli)
  */
 class YARNTask(override protected val id: ContainerId,
-               override protected val addr: ContainerAddress,
+               override protected[core] val addr: ContainerAddress,
                override protected val ec: ExecutionContext,
                override protected val logging: Logging,
                override protected val as: ActorSystem,

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -126,6 +126,11 @@ whisk {
       idle-container = 10 minutes
       pause-grace = 50 milliseconds
     }
+    action-health-check {
+      enabled = false # if true, prewarm containers will be pinged periodically and warm containers will be pinged once after resumed
+      check-period = 3 seconds # how often should prewarm containers be pinged (tcp connection attempt)
+      max-fails = 3 # prewarm containers that fail this number of times will be destroyed and replaced
+    }
   }
 
   # tracing configuration

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -257,7 +257,9 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
         prewarmedPool = prewarmedPool - sender()
       }
 
+      //backfill prewarms on every ContainerRemoved, just in case
       backfillPrewarms(false) //in case a prewarm is removed due to health failure or crash
+
     // This message is received for one of these reasons:
     // 1. Container errored while resuming a warm container, could not process the job, and sent the job back
     // 2. The container aged, is destroying itself, and was assigned a job which it had to send back

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -90,7 +90,11 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
 
     r.msg.transid.mark(
       this,
-      LoggingMarkers.INVOKER_CONTAINER_START(containerState),
+      LoggingMarkers.INVOKER_CONTAINER_START(
+        containerState,
+        r.msg.user.namespace.toString,
+        r.msg.action.namespace.toString,
+        r.msg.action.name.toString),
       s"containerStart containerState: $containerState container: $container activations: $activeActivations of max $maxConcurrent action: $actionName namespace: $namespaceName activationId: $activationId",
       akka.event.Logging.InfoLevel)
   }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -442,8 +442,8 @@ object ContainerPool {
                                            idles: Map[A, ContainerData]): Option[(A, ContainerData)] = {
     idles
       .find {
-        case (_, c @ WarmedData(_, `invocationNamespace`, `action`, _, _)) if c.hasCapacity() => true
-        case _                                                                                => false
+        case (_, c @ WarmedData(_, `invocationNamespace`, `action`, _, _, _)) if c.hasCapacity() => true
+        case _                                                                                   => false
       }
       .orElse {
         idles.find {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -403,6 +403,10 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
     MetricEmitter.emitGaugeMetric(
       LoggingMarkers.CONTAINER_POOL_PREWARM_SIZE,
       prewarmedPool.map(_._2.memoryLimit.toMB).sum)
+    val unused = freePool.filter(_._2.activeActivationCount == 0)
+    val unusedMB = unused.map(_._2.memoryLimit.toMB).sum
+    MetricEmitter.emitGaugeMetric(LoggingMarkers.CONTAINER_POOL_IDLES_COUNT, unused.size)
+    MetricEmitter.emitGaugeMetric(LoggingMarkers.CONTAINER_POOL_IDLES_SIZE, unusedMB)
   }
 }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -542,16 +542,7 @@ class ContainerProxy(factory: (TransactionId,
         disableHealthPing()
       }
     case _ -> Ready =>
-      if (healtCheckConfig.enabled) {
-        logging.debug(this, "enabling health ping on Ready")
-        enableHealthPing(nextStateData.getContainer)
-      }
       unstashAll()
-    case _ -> Pausing =>
-      if (healtCheckConfig.enabled && healthPingActor.isDefined) {
-        logging.debug(this, "disabling health ping on Pausing")
-        disableHealthPing()
-      }
     case _ -> Paused =>
       unstashAll()
     case _ -> Removing =>

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -40,6 +40,7 @@ import pureconfig.generic.auto._
 import akka.stream.ActorMaterializer
 import java.net.InetSocketAddress
 import java.net.SocketException
+import org.apache.openwhisk.common.MetricEmitter
 import org.apache.openwhisk.common.StartMarker
 import org.apache.openwhisk.common.TransactionId.systemPrefix
 import scala.collection.immutable
@@ -372,6 +373,7 @@ class ContainerProxy(factory: (TransactionId,
 
     // prewarm container failed
     case Event(_: FailureMessage, data: PreWarmedData) =>
+      MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_CONTAINER_HEALTH_FAILED_PREWARM)
       destroyContainer(data.container)
   }
 
@@ -434,6 +436,7 @@ class ContainerProxy(factory: (TransactionId,
 
     //ContainerHealthError should cause rescheduling of the job
     case Event(FailureMessage(c: ContainerHealthError), data: WarmedData) =>
+      MetricEmitter.emitCounterMetric(LoggingMarkers.INVOKER_CONTAINER_HEALTH_FAILED_WARM)
       resumeRun.foreach(context.parent ! _)
       resumeRun = None
       rescheduleJob = true

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -650,9 +650,7 @@ class ContainerProxy(factory: (TransactionId,
     }
   }
   private def disableHealthPing() = {
-    if (healtCheckConfig.enabled) {
-      healthPingActor.foreach(_ ! HealthPingEnabled(false))
-    }
+    healthPingActor.foreach(_ ! HealthPingEnabled(false))
   }
 
   /**
@@ -963,11 +961,17 @@ object ContainerProxy {
 }
 
 object TCPPingClient {
-  def props(containerId:String, config: ContainerProxyHealthCheckConfig, remote: InetSocketAddress, replies: ActorRef) =
+  def props(containerId: String,
+            config: ContainerProxyHealthCheckConfig,
+            remote: InetSocketAddress,
+            replies: ActorRef) =
     Props(new TCPPingClient(containerId, remote, replies, config))
 }
 
-class TCPPingClient(containerId:String, remote: InetSocketAddress, listener: ActorRef, config: ContainerProxyHealthCheckConfig)
+class TCPPingClient(containerId: String,
+                    remote: InetSocketAddress,
+                    listener: ActorRef,
+                    config: ContainerProxyHealthCheckConfig)
     extends Actor {
   implicit val logging = new AkkaLogging(context.system.log)
   import context.system
@@ -1018,7 +1022,9 @@ class TCPPingClient(containerId:String, remote: InetSocketAddress, listener: Act
       sender() ! Close
       if (failedCount > 0) {
         //reset in case of temp failure
-        logging.info(this, s"Succeeded health connection to $containerId ($addressString) after $failedCount previous failures")
+        logging.info(
+          this,
+          s"Succeeded health connection to $containerId ($addressString) after $failedCount previous failures")
         failedCount = 0
       } else {
         logging.debug(this, s"Succeeded health connection to $containerId ($addressString)")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -860,7 +860,8 @@ object ContainerProxy {
             collectLogs: LogsCollector,
             instance: InvokerInstanceId,
             poolConfig: ContainerPoolConfig,
-            healthCheckConfig: ContainerProxyHealthCheckConfig,
+            healthCheckConfig: ContainerProxyHealthCheckConfig =
+              loadConfigOrThrow[ContainerProxyHealthCheckConfig](ConfigKeys.containerProxyHealth),
             unusedTimeout: FiniteDuration = timeouts.idleContainer,
             pauseGrace: FiniteDuration = timeouts.pauseGrace) =
     Props(

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -627,7 +627,6 @@ class ContainerProxy(factory: (TransactionId,
       .map(_ => ContainerRemoved)
       .pipeTo(self)
 
-    println("on to removing")
     goto(Removing)
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -210,11 +210,13 @@ class DockerContainer(protected val id: ContainerId,
     }
   }
 
-  override protected def callContainer(path: String,
-                                       body: JsObject,
-                                       timeout: FiniteDuration,
-                                       maxConcurrent: Int,
-                                       retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
+  override protected def callContainer(
+    path: String,
+    body: JsObject,
+    timeout: FiniteDuration,
+    maxConcurrent: Int,
+    retry: Boolean = false,
+    reschedule: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
     val started = Instant.now()
     val http = httpConnection.getOrElse {
       val conn = if (Container.config.akkaClient) {
@@ -231,7 +233,7 @@ class DockerContainer(protected val id: ContainerId,
     }
 
     http
-      .post(path, body, retry)
+      .post(path, body, retry, reschedule)
       .flatMap { response =>
         val finished = Instant.now()
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -164,7 +164,7 @@ object DockerContainer {
  * @param addr the ip of the container
  */
 class DockerContainer(protected val id: ContainerId,
-                      protected val addr: ContainerAddress,
+                      protected[core] val addr: ContainerAddress,
                       protected val useRunc: Boolean)(implicit docker: DockerApiWithFileAccess,
                                                       runc: RuncApi,
                                                       override protected val as: ActorSystem,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -107,9 +107,9 @@ class InvokerReactive(
   instance: InvokerInstanceId,
   producer: MessageProducer,
   poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool),
-  limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit))(
-  implicit actorSystem: ActorSystem,
-  logging: Logging)
+  limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit),
+  healthchecksConfig: ContainerProxyHealthCheckConfig = loadConfigOrThrow[ContainerProxyHealthCheckConfig](
+    ConfigKeys.containerProxyHealth))(implicit actorSystem: ActorSystem, logging: Logging)
     extends InvokerCore {
 
   implicit val materializer: ActorMaterializer = ActorMaterializer()
@@ -196,7 +196,7 @@ class InvokerReactive(
   private val childFactory = (f: ActorRefFactory) =>
     f.actorOf(
       ContainerProxy
-        .props(containerFactory.createContainer, ack, store, collectLogs, instance, poolConfig))
+        .props(containerFactory.createContainer, ack, store, collectLogs, instance, poolConfig, healthchecksConfig))
 
   val prewarmingConfigs: List[PrewarmingConfig] = {
     ExecManifest.runtimesManifest.stemcells.flatMap {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -107,9 +107,9 @@ class InvokerReactive(
   instance: InvokerInstanceId,
   producer: MessageProducer,
   poolConfig: ContainerPoolConfig = loadConfigOrThrow[ContainerPoolConfig](ConfigKeys.containerPool),
-  limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit),
-  healthchecksConfig: ContainerProxyHealthCheckConfig = loadConfigOrThrow[ContainerProxyHealthCheckConfig](
-    ConfigKeys.containerProxyHealth))(implicit actorSystem: ActorSystem, logging: Logging)
+  limitsConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit))(
+  implicit actorSystem: ActorSystem,
+  logging: Logging)
     extends InvokerCore {
 
   implicit val materializer: ActorMaterializer = ActorMaterializer()
@@ -196,7 +196,7 @@ class InvokerReactive(
   private val childFactory = (f: ActorRefFactory) =>
     f.actorOf(
       ContainerProxy
-        .props(containerFactory.createContainer, ack, store, collectLogs, instance, poolConfig, healthchecksConfig))
+        .props(containerFactory.createContainer, ack, store, collectLogs, instance, poolConfig))
 
   val prewarmingConfigs: List[PrewarmingConfig] = {
     ExecManifest.runtimesManifest.stemcells.flatMap {

--- a/core/monitoring/user-events/compose/grafana/dashboards/global-metrics.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/global-metrics.json
@@ -15,6 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "iteration": 1580164337194,
   "links": [],
   "panels": [
     {
@@ -282,7 +283,9 @@
       "recent": false,
       "search": true,
       "starred": false,
-      "tags": ["openwhisk"],
+      "tags": [
+        "openwhisk"
+      ],
       "title": "Related Dashboards",
       "type": "dashlist"
     },
@@ -551,6 +554,177 @@
           "max": null,
           "min": null,
           "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState!=\"warmed\"}[$interval])) by (containerState)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{containerState}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Non-warm container starts [$interval]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 14,
+      "interval": "",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState=\"warmed\"}[$interval])) by (containerState)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ containerState }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Warm container starts [$interval]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
         }
       ],
       "yaxis": {

--- a/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
@@ -1554,7 +1554,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval])) by (containerState)",
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\",region=~\"$region\",stack=~\"$stack\"}[$interval])) by (containerState)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{containerState}}",

--- a/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
@@ -1470,7 +1470,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState!=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval])) by (containerState)",
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState!=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\",region=~\"$region\",stack=~\"$stack\"}[$interval])) by (containerState)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{containerState}}",

--- a/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
@@ -1,46 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "6.1.6"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -58,8 +16,7 @@
   "editable": true,
   "gnetId": 9564,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1574127067913,
+  "iteration": 1580164808936,
   "links": [],
   "panels": [
     {
@@ -1458,6 +1415,174 @@
           "decimals": 0,
           "format": "ms",
           "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 41,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState!=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval])) by (containerState)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{containerState}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Non-warm container starts [$interval]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 42,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(increase(counter_invoker_containerStart_counter_total{containerState=\"warmed\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval])) by (containerState)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{containerState}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Warm container starts [$interval]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
           "logBase": 1,
           "max": null,
           "min": null,

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/AkkaContainerClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/AkkaContainerClientTests.scala
@@ -39,6 +39,7 @@ import scala.concurrent.duration._
 import spray.json.JsObject
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.containerpool.AkkaContainerClient
+import org.apache.openwhisk.core.containerpool.ContainerHealthError
 import org.apache.openwhisk.core.entity.ActivationResponse._
 import org.apache.openwhisk.core.entity.size._
 
@@ -141,6 +142,14 @@ class AkkaContainerClientTests
     }
     waited should be > timeout.toMillis
     waited should be < (timeout * 2).toMillis
+  }
+
+  it should "throw ContainerHealthError on HttpHostConnectException if reschedule==true" in {
+    val timeout = 5.seconds
+    val connection = new AkkaContainerClient("0.0.0.0", 12345, timeout, 1.B, 100)
+    assertThrows[ContainerHealthError] {
+      Await.result(connection.post("/run", JsObject.empty, retry = false, reschedule = true), 10.seconds)
+    }
   }
 
   it should "retry till success within timeout limit" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -112,7 +112,8 @@ class DockerContainerTests
         body: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
-        retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
+        retry: Boolean = false,
+        reschedule: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
         ccRes
       }
       override protected val logCollectingIdleTimeout = awaitLogs

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
@@ -108,7 +108,8 @@ class KubernetesContainerTests
         body: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
-        retry: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
+        retry: Boolean = false,
+        reschedule: Boolean = false)(implicit transid: TransactionId): Future[RunResult] = {
         ccRes
       }
       override protected val waitForLogs = awaitLogs

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -110,11 +110,11 @@ class ContainerPoolTests
 
   /** Helper to create PreWarmedData */
   def preWarmedData(kind: String, memoryLimit: ByteSize = memoryLimit) =
-    PreWarmedData(stub[Container], kind, memoryLimit)
+    PreWarmedData(stub[MockableContainer], kind, memoryLimit)
 
   /** Helper to create WarmedData */
   def warmedData(run: Run, lastUsed: Instant = Instant.now) = {
-    WarmedData(stub[Container], run.msg.user.namespace.name, run.action, lastUsed)
+    WarmedData(stub[MockableContainer], run.msg.user.namespace.name, run.action, lastUsed)
   }
 
   /** Creates a sequence of containers and a factory returning this sequence. */
@@ -742,6 +742,9 @@ class ContainerPoolTests
     containers(0).expectMsg(runMessageConcurrent)
   }
 }
+abstract class MockableContainer extends Container {
+  protected[core] val addr: ContainerAddress = ContainerAddress("nohost")
+}
 
 /**
  * Unit tests for the ContainerPool object.
@@ -765,14 +768,14 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
                  namespace: String = standardNamespace.asString,
                  lastUsed: Instant = Instant.now,
                  active: Int = 0) =
-    WarmedData(stub[Container], EntityName(namespace), action, lastUsed, active)
+    WarmedData(stub[MockableContainer], EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create WarmingData with sensible defaults */
   def warmingData(action: ExecutableWhiskAction = createAction(),
                   namespace: String = standardNamespace.asString,
                   lastUsed: Instant = Instant.now,
                   active: Int = 0) =
-    WarmingData(stub[Container], EntityName(namespace), action, lastUsed, active)
+    WarmingData(stub[MockableContainer], EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create WarmingData with sensible defaults */
   def warmingColdData(action: ExecutableWhiskAction = createAction(),
@@ -782,7 +785,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     WarmingColdData(EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create PreWarmedData with sensible defaults */
-  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[Container], kind, 256.MB)
+  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[MockableContainer], kind, 256.MB)
 
   /** Helper to create NoData */
   def noData() = NoData()

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -810,8 +810,12 @@ class ContainerProxyTests
   it should "complete the transaction and reuse the container on a failed run IFF failure was applicationError" in within(
     timeout) {
     val container = new TestContainer {
-      override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-        implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+      override def run(
+        parameters: JsObject,
+        environment: JsObject,
+        timeout: FiniteDuration,
+        concurrent: Int,
+        reschedule: Boolean = false)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
         atomicRunCount.incrementAndGet()
         //every other run fails
         if (runCount % 2 == 0) {
@@ -983,8 +987,12 @@ class ContainerProxyTests
   it should "complete the transaction and destroy the container on a failed run IFF failure was containerError" in within(
     timeout) {
     val container = new TestContainer {
-      override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-        implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+      override def run(
+        parameters: JsObject,
+        environment: JsObject,
+        timeout: FiniteDuration,
+        concurrent: Int,
+        reschedule: Boolean = false)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
         atomicRunCount.incrementAndGet()
         Future.successful((initInterval, ActivationResponse.developerError(("boom"))))
       }
@@ -1552,8 +1560,12 @@ class ContainerProxyTests
 
       initPromise.map(_.future).getOrElse(Future.successful(initInterval))
     }
-    override def run(parameters: JsObject, environment: JsObject, timeout: FiniteDuration, concurrent: Int)(
-      implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
+    override def run(
+      parameters: JsObject,
+      environment: JsObject,
+      timeout: FiniteDuration,
+      concurrent: Int,
+      reschedule: Boolean = false)(implicit transid: TransactionId): Future[(Interval, ActivationResponse)] = {
 
       // the "init" arguments are not passed on run
       parameters shouldBe JsObject(activationArguments.fields.filter(k => !filterEnvVar(k._1)))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -162,7 +162,7 @@ class ContainerProxyTests
   def expectWarmed(namespace: String, action: ExecutableWhiskAction) = {
     val test = EntityName(namespace)
     expectMsgPF() {
-      case a @ NeedWork(WarmedData(_, `test`, `action`, _, _)) => //matched, otherwise will fail
+      case a @ NeedWork(WarmedData(_, `test`, `action`, _, _, _)) => //matched, otherwise will fail
     }
   }
 
@@ -1649,7 +1649,7 @@ class ContainerProxyTests
       initialCount)
     val nextWarmedData = warmedData.nextRun(Run(action, message))
     nextWarmedData should matchPattern {
-      case WarmedData(pwData.container, message.user.namespace.name, action, _, newCount) =>
+      case WarmedData(pwData.container, message.user.namespace.name, action, _, newCount, _) =>
     }
     warmedData.lastUsed.until(nextWarmedData.lastUsed, ChronoUnit.SECONDS) should be >= timeDiffSeconds.toLong
   }


### PR DESCRIPTION
To validate state of containers before use.


<!--- Provide a concise summary of your changes in the Title -->

## Description
In our deployment case (mesos/kubernetes) there are occasional cases where prewarm/warm containers fail outside of the usage of ContainerProxy, but ContainerProxy/ContainerPool are not aware of these failures. When this happens, when eventually the containers are used, there is a guarantee of failing the activation, since ContainerProxy assumes the prewarm/warm container is running fine, and it just sees a failure for /init or /run. 

This may be more pertinent to ContainerFactory impls that launch containers on hosts other than the invoker (mesos, k8s, yarn), but since it is also possible for docker containers local to invoker to be interrupted by some other system, it may be useful in all cases as a preventative measure. 

This PR introduces a tcp connection health check from invoker to each action container where:
- prewarm containers will be connected periodically
- failure to connect to prewarm will eventually (after configurable number of failures) cause the container to be destroyed and deplaced with a new prewarm container
- warm containers (paused) will be connected immediately after resume, and immediately before usage for /run
- failure to connect to warm will cause the job to be rescheduled and the warm container to be destroyed

<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

