### PR TITLE
Optimize ack messages for setups not collecting logs 

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/LogDriverLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/LogDriverLogStore.scala
@@ -39,6 +39,8 @@ class LogDriverLogStore(actorSystem: ActorSystem) extends LogStore {
   /** Indicate --log-driver and --log-opt flags via ContainerArgsConfig.extraArgs */
   override def containerParameters = Map.empty
 
+  override val logCollectionOutOfBand: Boolean = true
+
   def collectLogs(transid: TransactionId,
                   user: Identity,
                   activation: WhiskActivation,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/LogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/LogStore.scala
@@ -50,6 +50,12 @@ trait LogStore {
   def containerParameters: Map[String, Set[String]]
 
   /**
+   * Determines if log collection is actually done by the implementation or done out of band by the
+   * underlying container orchestrator
+   */
+  val logCollectionOutOfBand: Boolean = false
+
+  /**
    * Collect logs after the activation has finished.
    *
    * This method is called after an activation has finished. The logs gathered here are stored along the activation

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -31,6 +31,7 @@ import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.containerpool.logging.LogStoreProvider
 import org.apache.openwhisk.core.database.{UserContext, _}
 import org.apache.openwhisk.core.entity._
+import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
@@ -81,6 +82,8 @@ object InvokerReactive extends InvokerProvider {
    * @return logs for the given activation
    */
   trait LogsCollector {
+    def logsToBeCollected(action: ExecutableWhiskAction): Boolean = action.limits.logs.asMegaBytes != 0.MB
+
     def apply(transid: TransactionId,
               user: Identity,
               activation: WhiskActivation,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/LogStoreCollector.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/LogStoreCollector.scala
@@ -26,6 +26,10 @@ import org.apache.openwhisk.core.invoker.InvokerReactive.LogsCollector
 import scala.concurrent.Future
 
 class LogStoreCollector(store: LogStore) extends LogsCollector {
+
+  override def logsToBeCollected(action: ExecutableWhiskAction): Boolean =
+    super.logsToBeCollected(action) && !store.logCollectionOutOfBand
+
   override def apply(transid: TransactionId,
                      user: Identity,
                      activation: WhiskActivation,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/LogStoreCollector.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/LogStoreCollector.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.invoker
+
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.containerpool.Container
+import org.apache.openwhisk.core.containerpool.logging.LogStore
+import org.apache.openwhisk.core.entity.{ActivationLogs, ExecutableWhiskAction, Identity, WhiskActivation}
+import org.apache.openwhisk.core.invoker.InvokerReactive.LogsCollector
+
+import scala.concurrent.Future
+
+class LogStoreCollector(store: LogStore) extends LogsCollector {
+  override def apply(transid: TransactionId,
+                     user: Identity,
+                     activation: WhiskActivation,
+                     container: Container,
+                     action: ExecutableWhiskAction): Future[ActivationLogs] =
+    store.collectLogs(transid, user, activation, container, action)
+}


### PR DESCRIPTION
Optimizes the ack message flow of setups which collect logs out of band i.e. where logs are not collected as part of activation message processing itself.

Fixes #4635

## Description

Changes the `ContainerProxy` active ack flow when

1. `job.action.limits.logs.asMegaBytes == 0.MB`
2. OR `LogDriverLogStore` is being used

Now the behaviour is

1. No log case
    1. Blocking action send `CombinedCompletionAndResultMessage` directly
    2. Non blocking action send `CompletionMessage` directly
2. Logs case
    1. Blocking action
        1. Send `ResultMessage`
        2. Collect logs
        3. Send `CompletionMessage`
    2. Non blocking action
        1. Collect logs
        2. Send `CompletionMessage`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4635)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

