### PR TITLE
Make test result directory used by Gradle test tasks configurable

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -143,6 +143,10 @@ def logTestSetInfo(){
 }
 
 test {
+    // Use command line option "-D testResultsDirName=<name>" to change the default test results directory ("test-results").
+    // Specify a path relative to the build directory or an absolute path.
+    testResultsDirName = System.getProperty('testResultsDirName', testResultsDirName)
+
     exclude 'invokerShoot/**'
 }
 


### PR DESCRIPTION
Use command line option "-D testResultsDirName=<name>" to change the default test results directory ("test-results"). Specify a path relative to the build directory or an absolute path.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

