### PR TITLE
Extend error handing in entitlement interface

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -81,6 +81,8 @@ object Messages {
   val notAuthorizedtoOperateOnResource = "The supplied authentication is not authorized to access this resource."
   def notAuthorizedtoAccessResource(value: String) =
     s"The supplied authentication is not authorized to access '$value'."
+  def failedToCheckAccessResourceAuthorization(value: String) =
+    s"The supplied authentication could not be checked for access authorization on '$value'."
   def notAuthorizedtoActionKind(value: String) =
     s"The supplied authentication is not authorized to access actions of kind '$value'."
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/LocalEntitlement.scala
@@ -62,11 +62,11 @@ protected[core] class LocalEntitlementProvider(
 
   /** Checks if subject has explicit grant for a resource. */
   protected override def entitled(user: Identity, right: Privilege, resource: Resource)(
-    implicit transid: TransactionId): Future[Option[Boolean]] = Future.successful {
+    implicit transid: TransactionId) = Future.successful {
     val subject = user.subject
     lazy val one = matrix.get((subject, resource.id)) map { _ contains right } getOrElse false
     lazy val any = matrix.get((subject, resource.parent)) map { _ contains right } getOrElse false
-    Some(one || any)
+    one || any
   }
 }
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/LocalEntitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/LocalEntitlement.scala
@@ -62,11 +62,11 @@ protected[core] class LocalEntitlementProvider(
 
   /** Checks if subject has explicit grant for a resource. */
   protected override def entitled(user: Identity, right: Privilege, resource: Resource)(
-    implicit transid: TransactionId) = Future.successful {
+    implicit transid: TransactionId): Future[Option[Boolean]] = Future.successful {
     val subject = user.subject
     lazy val one = matrix.get((subject, resource.id)) map { _ contains right } getOrElse false
     lazy val any = matrix.get((subject, resource.parent)) map { _ contains right } getOrElse false
-    one || any
+    Some(one || any)
   }
 }
 


### PR DESCRIPTION
For reasons explained in detail in this _dev.openwhisk.apache.org_ discussion thread ([Extend the SPI entitlement interface](https://lists.apache.org/thread.html/8b5ddfe5e302098370b8b4bc265e5aed5f57ba7c2c73860363a9da6a@%3Cdev.openwhisk.apache.org%3E)) we would like to change the SPI entitlement interface from Future[Boolean] to Future[Option[Boolean]]. Motivation is to signal that the entitlement request couldn't be performed at all if calling an external entitlement service failed because of a network error or unavailability of the service itself so that the caller can act more appropriate.

## Description
This code change changes the SPI entitlement interface from Future[Boolean] to Future[Option[Boolean]] and adapts the SPI entitlement implementation in _LocalEntitlementProvider_ accordingly. It also introduces a _failedToCheckAccessResourceAuthorization_ as new error response and adapts the _check_ method accordingly.<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

