### PR TITLE
Fixes #4711 - add a namespace configuration option to KCF

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -77,7 +77,6 @@ whisk {
       key: "openwhisk-role"
       value: "invoker"
     }
-
     # Enables forwarding to remote port via a local random port. This mode is mostly useful
     # for development via Standalone mode
     port-forwarding-enabled = false
@@ -87,6 +86,10 @@ whisk {
     #  2. OR yaml formatted multi line string. See multi line config support https://github.com/lightbend/config/blob/master/HOCON.md#multi-line-strings
     #
     #pod-template =
+
+    # Set this optiona string to be the namespace that the invoker should target for adding pods. This allows the invoker to run in a namesapce it doesn't have API access to but add pods to another namespace. See also https://github.com/apache/openwhisk/issues/4711
+    # action-namespace = "ns-actions"
+
   }
 
   # Timeouts for runc commands. Set to "Inf" to disable timeout.

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -87,7 +87,9 @@ whisk {
     #
     #pod-template =
 
-    # Set this optiona string to be the namespace that the invoker should target for adding pods. This allows the invoker to run in a namesapce it doesn't have API access to but add pods to another namespace. See also https://github.com/apache/openwhisk/issues/4711
+    # Set this optional string to be the namespace that the invoker should target for adding pods. This allows the invoker to run in a namesapce it doesn't have API access to but add pods to another namespace. See also https://github.com/apache/openwhisk/issues/4711
+    # When not set the underlying client may pickup the namesapce from the kubeconfig or via system property setting.
+    # See https://github.com/fabric8io/kubernetes-client#configuring-the-client for more information.
     # action-namespace = "ns-actions"
 
   }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -47,7 +47,7 @@ import spray.json._
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -99,7 +99,7 @@ class KubernetesClient(
     .withRequestTimeout(config.timeouts.logs.toMillis.toInt)
   config.actionNamespace match {
     case Some(s) => configBuilder.withNamespace(s)
-    case _ =>
+    case _       =>
   }
   implicit protected val kubeRestClient = new DefaultKubernetesClient(
     configBuilder
@@ -447,7 +447,7 @@ protected[core] final case class TypedLogLine(time: Instant, stream: String, log
 
 protected[core] object TypedLogLine {
 
-  import KubernetesClient.{K8STimestampFormat, parseK8STimestamp}
+  import KubernetesClient.{parseK8STimestamp, K8STimestampFormat}
 
   def readInstant(json: JsValue): Instant = json match {
     case JsString(str) =>

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -94,16 +94,13 @@ class KubernetesClient(
     with ProcessRunner {
   implicit protected val ec = executionContext
   implicit protected val am = ActorMaterializer()
-  protected val configBuilder = new ConfigBuilder()
-    .withConnectionTimeout(config.timeouts.logs.toMillis.toInt)
-    .withRequestTimeout(config.timeouts.logs.toMillis.toInt)
-  config.actionNamespace match {
-    case Some(s) => configBuilder.withNamespace(s)
-    case _       =>
+  implicit protected val kubeRestClient = {
+    val configBuilder = new ConfigBuilder()
+      .withConnectionTimeout(config.timeouts.logs.toMillis.toInt)
+      .withRequestTimeout(config.timeouts.logs.toMillis.toInt)
+    config.actionNamespace.foreach(configBuilder.withNamespace)
+    new DefaultKubernetesClient(configBuilder.build())
   }
-  implicit protected val kubeRestClient = new DefaultKubernetesClient(
-    configBuilder
-      .build())
 
   private val podBuilder = new WhiskPodBuilder(kubeRestClient, config.userPodNodeAffinity, config.podTemplate)
 


### PR DESCRIPTION
A fix for #4711 

<!--- Provide a concise summary of your changes in the Title -->

## Description
This change forces the k8s client to use a particular namespace when communicating with the API server. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [X] I opened an issue to propose and discuss this change (#4711)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

