### PR TITLE
AttachmentStore implementation based on Azure Blob

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -95,7 +95,9 @@ dependencies {
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
 
-    compile "com.azure:azure-storage-blob:12.0.0"
+    compile ("com.azure:azure-storage-blob:12.0.0") {
+        exclude group: "com.azure", module: "azure-core-test"
+    }
 }
 
 configurations {

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -94,8 +94,8 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
-
-    compile ("com.azure:azure-storage-blob:12.0.0") {
+    
+    compile ("com.azure:azure-storage-blob:12.0.1") {
         exclude group: "com.azure", module: "azure-core-test"
     }
 }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -94,8 +94,8 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
-    
-    compile ("com.azure:azure-storage-blob:12.0.1") {
+
+    compile ("com.azure:azure-storage-blob:12.4.0") {
         exclude group: "com.azure", module: "azure-core-test"
     }
 }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -94,6 +94,8 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.dataformat'
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
+
+    compile "com.azure:azure-storage-blob:12.0.0"
 }
 
 configurations {

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
 
-    compile ("com.azure:azure-storage-blob:12.4.0") {
+    compile ("com.azure:azure-storage-blob:12.6.0") {
         exclude group: "com.azure", module: "azure-core-test"
     }
 }

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -334,6 +334,32 @@ whisk {
     #      password         =       # password of the provide ES
     #   }
     # }
+    
+    azure-blob {
+        # Config property when using AzureBlobAttachmentStore
+        # whisk {
+        #  spi {
+        #    AttachmentStoreProvider = org.apache.openwhisk.core.database.azblob.AzureBlobAttachmentStoreProvider
+        #  }
+        #}
+
+        # Blob container endpoint like https://foostore.blob.core.windows.net/test-ow-travis
+        # It is of format https://<account-name>.blob.core.windows.net/<container-name>
+        # endpoint =
+
+        # Storage account name
+        # account-name =
+
+        # Container name within storage account used to store the blobs
+        # container-name =
+
+        # Shared key credentials
+        # https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/storage/azure-storage-blob#shared-key-credential
+        # account-key
+
+        # Folder path within the container (optional)
+        # prefix
+    }
 
     # transaction ID related configuration
     transactions {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -359,6 +359,12 @@ whisk {
 
         # Folder path within the container (optional)
         # prefix
+
+        retry-config {
+            max-tries = 3
+            try-timeout = 5 seconds
+            retry-delay = 10 milliseconds
+        }
     }
 
     # transaction ID related configuration

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -334,7 +334,7 @@ whisk {
     #      password         =       # password of the provide ES
     #   }
     # }
-    
+
     azure-blob {
         # Config property when using AzureBlobAttachmentStore
         # whisk {

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -361,9 +361,11 @@ whisk {
         # prefix
 
         retry-config {
+            retry-policy-type = FIXED
             max-tries = 3
             try-timeout = 5 seconds
             retry-delay = 10 milliseconds
+            #secondary-host = ""
         }
     }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -577,6 +577,4 @@ object LoggingMarkers {
   val DATABASE_ATTS_DELETE =
     LogMarkerToken(database, "deleteDocumentAttachments", start)(MeasurementUnit.time.milliseconds)
   val DATABASE_BATCH_SIZE = LogMarkerToken(database, "batchSize", counter)(MeasurementUnit.none)
-  val DATABASE_ATTS_LIST =
-    LogMarkerToken(database, "listDocumentAttachments", start)(MeasurementUnit.time.milliseconds)
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -577,4 +577,6 @@ object LoggingMarkers {
   val DATABASE_ATTS_DELETE =
     LogMarkerToken(database, "deleteDocumentAttachments", start)(MeasurementUnit.time.milliseconds)
   val DATABASE_BATCH_SIZE = LogMarkerToken(database, "batchSize", counter)(MeasurementUnit.none)
+  val DATABASE_ATTS_LIST =
+    LogMarkerToken(database, "listDocumentAttachments", start)(MeasurementUnit.time.milliseconds)
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -272,6 +272,6 @@ object ConfigKeys {
   val apacheClientConfig = "whisk.apache-client"
 
   val parameterStorage = "whisk.parameter-storage"
-  
+
   val azBlob = "whisk.azure-blob"
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -272,4 +272,6 @@ object ConfigKeys {
   val apacheClientConfig = "whisk.apache-client"
 
   val parameterStorage = "whisk.parameter-storage"
+  
+  val azBlob = "whisk.azure-blob"
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.azblob
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.model.ContentType
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.{ByteString, ByteStringBuilder}
+import com.azure.storage.blob.{BlobContainerAsyncClient, BlobContainerClientBuilder}
+import com.azure.storage.common.StorageSharedKeyCredential
+import com.typesafe.config.Config
+import org.apache.openwhisk.common.LoggingMarkers.{
+  DATABASE_ATTS_DELETE,
+  DATABASE_ATT_DELETE,
+  DATABASE_ATT_GET,
+  DATABASE_ATT_SAVE
+}
+import org.apache.openwhisk.common.{Logging, TransactionId}
+import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.database.StoreUtils.{combinedSink, reportFailure}
+import org.apache.openwhisk.core.database.{
+  AttachResult,
+  AttachmentStore,
+  AttachmentStoreProvider,
+  DocumentSerializer,
+  NoDocumentException
+}
+import org.apache.openwhisk.core.entity.DocId
+import pureconfig.loadConfigOrThrow
+import reactor.core.publisher.Flux
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+import scala.util.Success
+
+case class AzBlobConfig(endpoint: String,
+                        accountKey: String,
+                        containerName: String,
+                        accountName: String,
+                        prefix: Option[String]) {
+  def prefixFor[D](implicit tag: ClassTag[D]): String = {
+    val className = tag.runtimeClass.getSimpleName.toLowerCase
+    prefix.map(p => s"$p/$className").getOrElse(className)
+  }
+}
+
+object AzureBlobAttachmentStoreProvider extends AttachmentStoreProvider {
+  override def makeStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
+                                                              logging: Logging,
+                                                              materializer: ActorMaterializer): AttachmentStore = {
+    makeStore[D](actorSystem.settings.config)
+  }
+
+  def makeStore[D <: DocumentSerializer: ClassTag](config: Config)(implicit actorSystem: ActorSystem,
+                                                                   logging: Logging,
+                                                                   materializer: ActorMaterializer): AttachmentStore = {
+    val azConfig = loadConfigOrThrow[AzBlobConfig](config, ConfigKeys.azBlob)
+    new AzureBlobAttachmentStore(createClient(azConfig), azConfig.prefixFor[D])
+  }
+
+  def createClient(config: AzBlobConfig): BlobContainerAsyncClient = {
+    new BlobContainerClientBuilder()
+      .endpoint(config.endpoint)
+      .credential(new StorageSharedKeyCredential(config.accountName, config.accountKey))
+      .containerName(config.containerName)
+      .buildAsyncClient()
+  }
+}
+
+class AzureBlobAttachmentStore(client: BlobContainerAsyncClient, prefix: String)(implicit system: ActorSystem,
+                                                                                 logging: Logging,
+                                                                                 materializer: ActorMaterializer)
+    extends AttachmentStore {
+  override protected[core] def scheme: String = "az"
+
+  override protected[core] implicit val executionContext: ExecutionContext = system.dispatcher
+
+  override protected[core] def attach(
+    docId: DocId,
+    name: String,
+    contentType: ContentType,
+    docStream: Source[ByteString, _])(implicit transid: TransactionId): Future[AttachResult] = {
+    require(name != null, "name undefined")
+    val start =
+      transid.started(this, DATABASE_ATT_SAVE, s"[ATT_PUT] uploading attachment '$name' of document 'id: $docId'")
+    val blobClient = getBlobClient(docId, name)
+
+    //TODO Use BlobAsyncClient#upload(Flux<ByteBuffer>, com.azure.storage.blob.models.ParallelTransferOptions, boolean)
+    val uploadSink = Sink.fold[ByteStringBuilder, ByteString](new ByteStringBuilder)((builder, b) => builder ++= b)
+
+    val f = docStream.runWith(combinedSink(uploadSink))
+    val g = f.flatMap { r =>
+      val buff = r.uploadResult.result().compact
+      val uf = blobClient.upload(Flux.fromArray(Array(buff.asByteBuffer)), buff.size).toFuture.toScala
+      uf.map(_ => AttachResult(r.digest, r.length))
+    }
+
+    g.foreach(_ =>
+      transid
+        .finished(this, start, s"[ATT_PUT] '$prefix' completed uploading attachment '$name' of document 'id: $docId'"))
+
+    reportFailure(
+      g,
+      start,
+      failure => s"[ATT_PUT] '$prefix' internal error, name: '$name', doc: '$docId', failure: '${failure.getMessage}'")
+  }
+
+  override protected[core] def readAttachment[T](docId: DocId, name: String, sink: Sink[ByteString, Future[T]])(
+    implicit transid: TransactionId): Future[T] = {
+    require(name != null, "name undefined")
+    val start =
+      transid.started(
+        this,
+        DATABASE_ATT_GET,
+        s"[ATT_GET] '$prefix' finding attachment '$name' of document 'id: $docId'")
+    val blobClient = getBlobClient(docId, name)
+    val f = blobClient.exists().toFuture.toScala.flatMap { exists =>
+      if (exists) {
+        val bbFlux = blobClient.download()
+        val rf = Source.fromPublisher(bbFlux).map(ByteString(_)).runWith(sink)
+        rf.andThen {
+          case Success(_) =>
+            transid
+              .finished(
+                this,
+                start,
+                s"[ATT_GET] '$prefix' completed: found attachment '$name' of document 'id: $docId'")
+        }
+      } else {
+        transid
+          .finished(
+            this,
+            start,
+            s"[ATT_GET] '$prefix', retrieving attachment '$name' of document 'id: $docId'; not found.",
+            logLevel = Logging.ErrorLevel)
+        Future.failed(NoDocumentException("Not found on 'readAttachment'."))
+      }
+    }
+
+    reportFailure(
+      f,
+      start,
+      failure =>
+        s"[ATT_GET] '$prefix' internal error, name: '$name', doc: 'id: $docId', failure: '${failure.getMessage}'")
+  }
+
+  override protected[core] def deleteAttachments(docId: DocId)(implicit transid: TransactionId): Future[Boolean] = {
+    val start =
+      transid.started(
+        this,
+        DATABASE_ATTS_DELETE,
+        s"[ATT_DELETE] deleting attachments of document 'id: $docId' with prefix ${objectKeyPrefix(docId)}")
+
+    val f = Source
+      .fromPublisher(client.listBlobsByHierarchy(objectKeyPrefix(docId)))
+      .mapAsync(1)(b => client.getBlobAsyncClient(b.getName).delete().toFuture.toScala)
+      .runWith(Sink.seq)
+      .map(_ => true)
+
+    f.foreach(_ =>
+      transid.finished(this, start, s"[ATTS_DELETE] completed: deleting attachments of document 'id: $docId'"))
+
+    reportFailure(
+      f,
+      start,
+      failure => s"[ATTS_DELETE] '$prefix' internal error, doc: '$docId', failure: '${failure.getMessage}'")
+  }
+
+  override protected[core] def deleteAttachment(docId: DocId, name: String)(
+    implicit transid: TransactionId): Future[Boolean] = {
+    val start =
+      transid.started(this, DATABASE_ATT_DELETE, s"[ATT_DELETE] deleting attachment '$name' of document 'id: $docId'")
+
+    val f = getBlobClient(docId, name).delete().toFuture.toScala.map(_ => true)
+
+    f.foreach(_ =>
+      transid.finished(this, start, s"[ATT_DELETE] completed: deleting attachment '$name' of document 'id: $docId'"))
+
+    reportFailure(
+      f,
+      start,
+      failure => s"[ATT_DELETE] '$prefix' internal error, doc: '$docId', failure: '${failure.getMessage}'")
+  }
+
+  override def shutdown(): Unit = {}
+
+  private def objectKey(id: DocId, name: String): String = s"$prefix/${id.id}/$name"
+
+  private def objectKeyPrefix(id: DocId): String =
+    s"$prefix/${id.id}/" //must end with a slash so that ".../<package>/<action>other" does not match for "<package>/<action>"
+
+  private def getBlobClient(docId: DocId, name: String) =
+    client.getBlobAsyncClient(objectKey(docId, name)).getBlockBlobAsyncClient
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
@@ -43,7 +43,8 @@ import org.apache.openwhisk.core.database.{
   NoDocumentException
 }
 import org.apache.openwhisk.core.entity.DocId
-import pureconfig.loadConfigOrThrow
+import pureconfig._
+import pureconfig.generic.auto._
 import reactor.core.publisher.Flux
 
 import scala.compat.java8.FutureConverters._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
@@ -67,7 +67,11 @@ case class AzBlobConfig(endpoint: String,
     prefix.map(p => s"$p/$className").getOrElse(className)
   }
 }
-case class AzBlobRetryConfig(maxTries: Int, tryTimeout: FiniteDuration, retryDelay: FiniteDuration)
+case class AzBlobRetryConfig(retryPolicyType: RetryPolicyType,
+                             maxTries: Int,
+                             tryTimeout: FiniteDuration,
+                             retryDelay: FiniteDuration,
+                             secondaryHost: Option[String])
 object AzureBlobAttachmentStoreProvider extends AttachmentStoreProvider {
   override def makeStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
                                                               logging: Logging,
@@ -98,12 +102,12 @@ object AzureBlobAttachmentStoreProvider extends AttachmentStoreProvider {
     builder
       .containerName(config.containerName)
       .retryOptions(new RequestRetryOptions(
-        RetryPolicyType.FIXED,
+        config.retryConfig.retryPolicyType,
         config.retryConfig.maxTries,
         config.retryConfig.tryTimeout.toSeconds.toInt,
         config.retryConfig.retryDelay.toMillis,
         config.retryConfig.retryDelay.toMillis,
-        null))
+        config.retryConfig.secondaryHost.orNull))
       .buildAsyncClient()
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
@@ -51,10 +51,10 @@ trait AzureBlob extends FlatSpec {
     super.withFixture(test)
   }
 
-  val endpoint = sys.env("AZ_ENDPOINT")
-  val accountName = sys.env("AZ_ACCOUNT_NAME")
+  val endpoint = System.getenv("AZ_ENDPOINT")
+  val accountName = System.getenv("AZ_ACCOUNT_NAME")
   val containerName = sys.env.getOrElse("AZ_CONTAINER_NAME", "test-ow-travis")
-  val accountKey = sys.env("AZ_ACCOUNT_KEY")
+  val accountKey = System.getenv("AZ_ACCOUNT_KEY")
 
   def prefix: String
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.azblob
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.database.{AttachmentStore, DocumentSerializer}
+import org.scalatest.FlatSpec
+
+import scala.reflect.ClassTag
+
+trait AzureBlob extends FlatSpec {
+  def makeAzureStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
+                                                          logging: Logging,
+                                                          materializer: ActorMaterializer): AttachmentStore = {
+    val config = ConfigFactory.parseString(s"""
+        |whisk {
+        |  azure-blob {
+        |    endpoint = "$endpoint"
+        |    account-name = "$accountName"
+        |    container-name = "$containerName"
+        |    account-key = "$accountKey"
+        |    prefix = $prefix
+        |  }
+        |}""".stripMargin).withFallback(ConfigFactory.load()).resolve()
+    AzureBlobAttachmentStoreProvider.makeStore[D](config)
+  }
+
+  override protected def withFixture(test: NoArgTest) = {
+    assume(
+      accountKey != null,
+      "'AZ_ACCOUNT_KEY' env not configured. Configure following " +
+        "env variables for test to run. 'AZ_ENDPOINT', 'AZ_ACCOUNT_NAME', 'AZ_CONTAINER_NAME'")
+    super.withFixture(test)
+  }
+
+  val endpoint = System.getenv("AZ_ENDPOINT")
+  val accountName = System.getenv("AZ_ACCOUNT_NAME")
+  val containerName = System.getenv("AZ_CONTAINER_NAME")
+  val accountKey = System.getenv("AZ_ACCOUNT_KEY")
+
+  def prefix: String
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlob.scala
@@ -51,10 +51,10 @@ trait AzureBlob extends FlatSpec {
     super.withFixture(test)
   }
 
-  val endpoint = System.getenv("AZ_ENDPOINT")
-  val accountName = System.getenv("AZ_ACCOUNT_NAME")
-  val containerName = System.getenv("AZ_CONTAINER_NAME")
-  val accountKey = System.getenv("AZ_ACCOUNT_KEY")
+  val endpoint = sys.env("AZ_ENDPOINT")
+  val accountName = sys.env("AZ_ACCOUNT_NAME")
+  val containerName = sys.env.getOrElse("AZ_CONTAINER_NAME", "test-ow-travis")
+  val accountKey = sys.env("AZ_ACCOUNT_KEY")
 
   def prefix: String
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStoreBehaviorBase.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStoreBehaviorBase.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.azblob
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.database.{AttachmentStore, DocumentSerializer}
+import org.apache.openwhisk.core.database.memory.{MemoryArtifactStoreBehaviorBase, MemoryArtifactStoreProvider}
+import org.apache.openwhisk.core.database.test.AttachmentStoreBehaviors
+import org.apache.openwhisk.core.database.test.behavior.ArtifactStoreAttachmentBehaviors
+import org.apache.openwhisk.core.entity.WhiskEntity
+import org.scalatest.FlatSpec
+
+import scala.reflect.ClassTag
+import scala.util.Random
+
+trait AzureBlobAttachmentStoreBehaviorBase
+    extends FlatSpec
+    with MemoryArtifactStoreBehaviorBase
+    with ArtifactStoreAttachmentBehaviors
+    with AttachmentStoreBehaviors {
+  override lazy val store = makeAzureStore[WhiskEntity]
+
+  override implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  override val prefix = s"attachmentTCK_${Random.alphanumeric.take(4).mkString}"
+
+  override protected def beforeAll(): Unit = {
+    MemoryArtifactStoreProvider.purgeAll()
+    super.beforeAll()
+  }
+
+  override def getAttachmentStore[D <: DocumentSerializer: ClassTag](): AttachmentStore =
+    makeAzureStore[D]()
+
+  def makeAzureStore[D <: DocumentSerializer: ClassTag]()(implicit actorSystem: ActorSystem,
+                                                          logging: Logging,
+                                                          materializer: ActorMaterializer): AttachmentStore
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStoreITTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStoreITTests.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database.azblob
+
+import org.apache.openwhisk.core.entity.WhiskEntity
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class AzureBlobAttachmentStoreITTests extends AzureBlobAttachmentStoreBehaviorBase with AzureBlob {
+  override lazy val store = makeAzureStore[WhiskEntity]
+
+  override def storeType: String = "Azure"
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobConfigTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobConfigTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.openwhisk.core.database.azblob
 
 import com.azure.storage.common.policy.RetryPolicyType

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobConfigTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/azblob/AzureBlobConfigTest.scala
@@ -1,0 +1,23 @@
+package org.apache.openwhisk.core.database.azblob
+
+import com.azure.storage.common.policy.RetryPolicyType
+import org.apache.openwhisk.core.ConfigKeys
+import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+import pureconfig._
+import pureconfig.generic.auto._
+
+@RunWith(classOf[JUnitRunner])
+class AzureBlobConfigTest extends FlatSpec with Matchers {
+
+  behavior of "AzureBlobConfig"
+  it should "use valid defaults for retry option" in {
+    val config: AzBlobRetryConfig = loadConfigOrThrow[AzBlobRetryConfig](ConfigKeys.azBlob + ".retry-config")
+    //make sure retry type is set to FIXED
+    config.retryPolicyType shouldBe RetryPolicyType.FIXED
+    //make sure optional secondaryHost is not set
+    config.secondaryHost shouldBe None
+
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentStoreBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentStoreBehaviors.scala
@@ -127,6 +127,8 @@ trait AttachmentStoreBehaviors
     //Make sure doc2 attachments are left untouched
     if (!lazyDeletes) attachmentBytes(docId2, "c21").futureValue.result() shouldBe ByteString(b1)
     if (!lazyDeletes) attachmentBytes(docId2, "c22").futureValue.result() shouldBe ByteString(b2)
+
+    attachmentsToDelete += docId2.asString
   }
 
   it should "throw NoDocumentException on reading non existing attachment" in {


### PR DESCRIPTION
Adds `AzureBlobAttachmentStore` as an `AttachmentStore` implementation backed by [Azure Blob](https://azure.microsoft.com/en-in/services/storage/blobs/)

Fixes #4666

## Description

`azure-storage-blob:12.0.0` is now based on [Project Reactor][1]. `AzureBlobAttachmentStore` uses the library via the Reaxtive Stream support (Publisher/Subscriber) from Akka and Project Reactor and thus enables non blocking reads and writes

This library adds following dependencies

<img width="585" alt="image" src="https://user-images.githubusercontent.com/664531/68470672-8aeb6080-0242-11ea-98ce-6217cb1c420b.png">

### Usage

To enable this one needs to configure

```
whisk {
    azure-blob {
        # Config property when using AzureBlobAttachmentStore
        # whisk {
        #  spi {
        #    AttachmentStoreProvider = org.apache.openwhisk.core.database.azblob.AzureBlobAttachmentStoreProvider
        #  }
        #}

        # Blob container endpoint like https://foostore.blob.core.windows.net/test-ow-travis
        # It is of format https://<account-name>.blob.core.windows.net/<container-name>
        # endpoint =

        # Storage account name
        # account-name =

        # Container name within storage account used to store the blobs
        # container-name =

        # Shared key credentials
        # https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/storage/azure-storage-blob#shared-key-credential
        # account-key

        # Folder path within the container (optional)
        # prefix
    }
}
```


### Testing

`AzureBlobAttachmentStoreITTests` enables integration test which run against the Azure Blob service. It needs following env settings

* `AZ_ENDPOINT` - Endpoint url
* `AZ_ACCOUNT_NAME` - Name of storage account
* `AZ_ACCOUNT_KEY` - Account key
* `AZ_CONTAINER_NAME` - Optional. Defaults to `test-ow-travis`

Another test is being implemented based on [Azurite Simulator][2]. However currently due to Azure/azure-sdk-for-java#6140 (fixed in master but not released) the tests cannot be run against that

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4666)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

[1]: https://projectreactor.io/
[2]: https://github.com/Azure/Azurite
