### PR TITLE
Increase toStrictTimeout value to omit intermittent timeout exceptions

### DIFF
--- a/tests/src/test/scala/common/rest/WskRestOperations.scala
+++ b/tests/src/test/scala/common/rest/WskRestOperations.scala
@@ -1131,7 +1131,7 @@ trait RunRestCmd extends Matchers with ScalaFutures with SwaggerValidator {
 
   val protocol: String = loadConfigOrThrow[String]("whisk.controller.protocol")
   val idleTimeout: FiniteDuration = 90 seconds
-  val toStrictTimeout: FiniteDuration = 5 seconds
+  val toStrictTimeout: FiniteDuration = 30 seconds
   val queueSize = 10
   val maxOpenRequest = 1024
   val basePath = Path("/api/v1")


### PR DESCRIPTION
In our tests we encounter every now and then failing tests that fail because the HttpEntity.toStrict timed out after 5 seconds. In order to avoid these timeouts I propose to increase the defined timeout from 5 to 30 seconds.

## Description
This code change increase the timeout value `toStrictTimeout` from 5 to 30 seconds. Intention is to avoid the following error: `org.scalatest.exceptions.TestFailedException: The future returned an exception of type: java.util.concurrent.TimeoutException, with message: HttpEntity.toStrict timed out after 5 seconds while still waiting for outstanding data.`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

