### PR TITLE
Add response size and dev errors to user-events dashboard

### DIFF
--- a/core/monitoring/user-events/compose/grafana/dashboards/global-metrics.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/global-metrics.json
@@ -101,14 +101,15 @@
     },
     {
       "cacheTimeout": null,
-      "colorBackground": false,
+      "colorBackground": true,
       "colorValue": false,
       "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
+        "#3274D9",
+        "#3274D9",
+        "#3274D9"
       ],
       "datasource": "Prometheus",
+      "decimals": 0,
       "description": "Total number of cold starts",
       "format": "none",
       "gauge": {
@@ -153,9 +154,9 @@
         }
       ],
       "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "fillColor": "#1F60C4",
         "full": false,
-        "lineColor": "#9ac48a",
+        "lineColor": "#8AB8FF",
         "show": true
       },
       "tableColumn": "Value",
@@ -169,7 +170,7 @@
         }
       ],
       "thresholds": "1",
-      "title": "Cold Starts",
+      "title": "Cold starts",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -187,11 +188,12 @@
       "colorPrefix": false,
       "colorValue": false,
       "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
+        "#3274D9",
+        "#3274D9",
+        "#3274D9"
       ],
       "datasource": "Prometheus",
+      "decimals": 0,
       "description": "Total number of error due to Runtime implementation",
       "format": "none",
       "gauge": {
@@ -236,9 +238,9 @@
         }
       ],
       "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "fillColor": "#1F60C4",
         "full": false,
-        "lineColor": "#9ac48a",
+        "lineColor": "#8AB8FF",
         "show": true
       },
       "tableColumn": "Value",
@@ -251,8 +253,8 @@
           "refId": "A"
         }
       ],
-      "thresholds": "0,1",
-      "title": "Internal Errors",
+      "thresholds": "1",
+      "title": "System errors",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -268,7 +270,7 @@
       "folderId": null,
       "gridPos": {
         "h": 3,
-        "w": 11,
+        "w": 12,
         "x": 12,
         "y": 0
       },
@@ -329,7 +331,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(openwhisk_action_activations_total[1m]))",
+          "expr": "sum(increase(openwhisk_action_activations_total[$interval]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -339,7 +341,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Activations",
+      "title": "Activations [$interval]",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -382,6 +384,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "",
       "fill": 1,
       "gridPos": {
         "h": 8,
@@ -415,7 +418,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(openwhisk_action_waitTime_seconds_sum[30s]) * 1000 / rate(openwhisk_action_waitTime_seconds_count[30s]) ",
+          "expr": "rate(openwhisk_action_waitTime_seconds_sum[$interval]) * 1000 / rate(openwhisk_action_waitTime_seconds_count[$interval]) ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -427,7 +430,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "wait time",
+      "title": "Wait time [$interval]",
       "tooltip": {
         "shared": false,
         "sort": 0,
@@ -443,7 +446,8 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "decimals": 0,
+          "format": "ms",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -456,7 +460,97 @@
           "logBase": 1,
           "max": null,
           "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(openwhisk_action_response_size_bytes_sum[$interval]) / rate(openwhisk_action_response_size_bytes_count[$interval]) ",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{namespace}}/{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response size [$interval]",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
           "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ],
       "yaxis": {
@@ -472,7 +566,86 @@
     "openwhisk"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "30s",
+        "current": {
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
   },
   "time": {
     "from": "now-15m",

--- a/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
+++ b/core/monitoring/user-events/compose/grafana/dashboards/openwhisk_events.json
@@ -59,7 +59,7 @@
   "gnetId": 9564,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1570133426517,
+  "iteration": 1574127067913,
   "links": [],
   "panels": [
     {
@@ -84,7 +84,7 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
+        "w": 5,
         "x": 0,
         "y": 0
       },
@@ -166,8 +166,8 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 6,
+        "w": 5,
+        "x": 5,
         "y": 0
       },
       "id": 32,
@@ -234,12 +234,12 @@
       "colorValue": false,
       "colors": [
         "rgba(41, 156, 70, 0)",
-        "#e24d42",
-        "#e24d42"
+        "#FA6400",
+        "#FA6400"
       ],
       "datasource": "Prometheus",
       "decimals": 0,
-      "description": "Total number of error activations in the selected time interval",
+      "description": "Total number of application and developer errors: \n\n[application_error] =  action ran but there was an error and it was handled\n\n[action_developer_error] = action ran but failed to handle an error, or action did not run and failed to initialize",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -250,11 +250,95 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 12,
+        "w": 4,
+        "x": 10,
         "y": 0
       },
       "id": 34,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "#FF780A",
+        "full": false,
+        "lineColor": "#FFB357",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(openwhisk_action_status{region=~\"$region\",stack=~\"$stack\",namespace=~\"$namespace\",action=~\"$action\",status=~\"application_error|action_developer_error\",initiator=~\"$initiator\"}[$__range]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "title": "Development errors",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorPostfix": false,
+      "colorPrefix": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(41, 156, 70, 0)",
+        "#e24d42",
+        "#e24d42"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 0,
+      "description": "Total number of system activation errors: \n\n[whisk_internal_error] = internal system error",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 14,
+        "y": 0
+      },
+      "id": 39,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -291,14 +375,14 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(openwhisk_action_status{region=~\"$region\",stack=~\"$stack\",namespace=~\"$namespace\",action=~\"$action\",status!=\"success\",initiator=~\"$initiator\"}[$__range]))",
+          "expr": "sum(increase(openwhisk_action_status{region=~\"$region\",stack=~\"$stack\",namespace=~\"$namespace\",action=~\"$action\",status=~\"whisk_internal_error\",initiator=~\"$initiator\"}[$__range]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
         }
       ],
       "thresholds": "1",
-      "title": "Error activations",
+      "title": "System errors",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -332,8 +416,8 @@
       },
       "gridPos": {
         "h": 2,
-        "w": 6,
-        "x": 18,
+        "w": 5,
+        "x": 19,
         "y": 0
       },
       "id": 30,
@@ -748,7 +832,7 @@
       "fill": 0,
       "gridPos": {
         "h": 9,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 10
       },
@@ -835,8 +919,8 @@
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 10
       },
       "id": 18,
@@ -923,11 +1007,12 @@
       "dashes": false,
       "datasource": "Prometheus",
       "decimals": 1,
+      "description": "Number of application, developer and internal errors: \n\n[application_error] =  action ran but there was an error and it was handled\n\n[action_developer_error] = action ran but failed to handle an error, or action did not run and failed to initialize\n\n[whisk_internal_error] = internal system error",
       "fill": 1,
       "gridPos": {
         "h": 9,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 10
       },
       "id": 20,
@@ -1005,19 +1090,6 @@
       }
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Duration graph",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1025,10 +1097,10 @@
       "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 20
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 10
       },
       "id": 22,
       "legend": {
@@ -1054,6 +1126,112 @@
       "points": false,
       "renderer": "flot",
       "repeat": null,
+      "repeatDirection": "h",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(openwhisk_action_response_size_bytes_sum{region=~\"$region\",stack=~\"$stack\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval]) / rate(openwhisk_action_response_size_bytes_count{region=~\"$region\",stack=~\"$stack\",namespace=~\"$namespace\",action=~\"$action\",initiator=~\"$initiator\"}[$interval]) ",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response size [$interval]",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "decbytes",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Duration graph",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 38,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 4,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
       "repeatDirection": "h",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -1530,5 +1708,5 @@
   "timezone": "",
   "title": "Openwhisk - Action Performance Metrics",
   "uid": "Oew1lvymk",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
* Add chart to display `request response size`. 
* Split the error dashboard into `System errors` and `Development errors`. This should make more clear for the developer if the errors are actionable or not. In case of the `System errors`, system admins need to notified. 

<img width="1597" alt="Screen Shot 2019-11-18 at 6 42 35 PM" src="https://user-images.githubusercontent.com/736614/69112434-0dd79c80-0a35-11ea-9749-761dedc95877.png">

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4729)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
- [x] Monitoring

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

