### PR TITLE
Update fastparse to version 2.1.3.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -37,7 +37,7 @@ dependencies {
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
     compile 'io.spray:spray-json_2.12:1.3.5'
-    compile 'com.lihaoyi:fastparse_2.12:1.0.0'
+    compile 'com.lihaoyi:fastparse_2.12:2.1.3'
 
     compile "com.typesafe.akka:akka-actor_2.12:${gradle.akka.version}"
     compile "com.typesafe.akka:akka-stream_2.12:${gradle.akka.version}"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
fastparse in version 1.x.x is not available for Scala 2.13, so this updates it to the latest and greatest with rather minor impact.

## Related issue and scope
Ref #4741

See dev-list discussion on Scala 2.13 here: https://lists.apache.org/thread.html/c8e2fa40b646dccc6e3a6cbca2370904477f5dd8dbb315173f055a2c@%3Cdev.openwhisk.apache.org%3E

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

