### PR TITLE
Update akka libraries to version 2.5.26.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,7 @@ gradle.ext.scalafmt = [
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
 
-gradle.ext.akka = [version : '2.5.22']
+gradle.ext.akka = [version : '2.5.26']
 gradle.ext.akka_kafka = [version : '1.1.0']
 gradle.ext.akka_http = [version : '10.1.8']
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Akka isn't available for Scala 2.13 prior to 2.5.24. See https://mvnrepository.com/artifact/com.typesafe.akka/akka-actor. We might as well bump through all the minor versions though.

## Related issue and scope
Ref #4741

See dev-list discussion on Scala 2.13 here: https://lists.apache.org/thread.html/c8e2fa40b646dccc6e3a6cbca2370904477f5dd8dbb315173f055a2c@%3Cdev.openwhisk.apache.org%3E

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).