### PR TITLE
Enable strict compile options on all scala projects and fix warnings.

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -162,6 +162,10 @@ dependencies {
     testCompile 'org.scalatest:scalatest_2.12:3.0.5'
 }
 
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+}
+
 gradle.projectsEvaluated {
     tasks.withType(Test) {
         testLogging {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/ServerStartupCheck.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/ServerStartupCheck.scala
@@ -17,7 +17,7 @@
 
 package org.apache.openwhisk.standalone
 
-import java.net.{HttpURLConnection, URI, URL}
+import java.net.{HttpURLConnection, URL}
 
 import akka.http.scaladsl.model.Uri
 import com.google.common.base.Stopwatch

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -50,3 +50,7 @@ dependencies {
     compile project(':common:scala')
     compile 'org.rogach:scallop_2.12:3.1.2'
 }
+
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+}

--- a/tools/admin/src/main/scala/org/apache/openwhisk/core/database/LimitsCommand.scala
+++ b/tools/admin/src/main/scala/org/apache/openwhisk/core/database/LimitsCommand.scala
@@ -19,26 +19,18 @@ package org.apache.openwhisk.core.database
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import org.rogach.scallop.{ScallopConfBase, Subcommand}
-import spray.json.{JsObject, JsString, JsValue, RootJsonFormat}
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.cli.{CommandError, CommandMessages, IllegalState, WhiskCommand}
 import org.apache.openwhisk.core.database.LimitsCommand.LimitEntity
 import org.apache.openwhisk.core.entity.types.AuthStore
-import org.apache.openwhisk.core.entity.{
-  DocId,
-  DocInfo,
-  DocRevision,
-  EntityName,
-  Subject,
-  UserLimits,
-  WhiskAuth,
-  WhiskDocumentReader
-}
+import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
+import org.rogach.scallop.{ScallopConfBase, Subcommand}
+import spray.json.{JsObject, JsString, JsValue, RootJsonFormat}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.reflectiveCalls
 import scala.reflect.classTag
 import scala.util.{Properties, Try}
 

--- a/tools/admin/src/main/scala/org/apache/openwhisk/core/database/UserCommand.scala
+++ b/tools/admin/src/main/scala/org/apache/openwhisk/core/database/UserCommand.scala
@@ -22,17 +22,18 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
-import org.rogach.scallop.{ScallopConfBase, Subcommand}
-import spray.json.{JsBoolean, JsObject, JsString, JsValue, RootJsonFormat}
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.cli.{CommandError, CommandMessages, IllegalState, WhiskCommand}
 import org.apache.openwhisk.core.database.UserCommand.ExtendedAuth
-import org.apache.openwhisk.core.entity.types._
 import org.apache.openwhisk.core.entity._
+import org.apache.openwhisk.core.entity.types._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
+import org.rogach.scallop.{ScallopConfBase, Subcommand}
+import spray.json.{JsBoolean, JsObject, JsString, JsValue, RootJsonFormat}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.reflectiveCalls
 import scala.reflect.classTag
 import scala.util.{Properties, Try}
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Not all scala projects had the compiler flags we usually use so some warnings went under the radar. This fixes this.

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

