### PR TITLE
Simplify Option.filter(identity) pattern to something actually readable.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestClient.scala
@@ -117,16 +117,18 @@ class CouchDbRestClient(protocol: String, host: String, port: Int, username: Str
       }
     }
 
+    def bool2OptStr(bool: Boolean): Option[String] = if (bool) Some("true") else None
+
     val args = Seq[(String, Option[String])](
       "startkey" -> list2OptJson(startKey).map(_.toString),
       "endkey" -> list2OptJson(endKey).map(_.toString),
       "skip" -> skip.filter(_ > 0).map(_.toString),
       "limit" -> limit.filter(_ > 0).map(_.toString),
       "stale" -> stale.value,
-      "include_docs" -> Some(includeDocs).filter(identity).map(_.toString),
-      "descending" -> Some(descending).filter(identity).map(_.toString),
-      "reduce" -> Some(reduce).map(_.toString),
-      "group" -> Some(group).filter(identity).map(_.toString))
+      "include_docs" -> bool2OptStr(includeDocs),
+      "descending" -> bool2OptStr(descending),
+      "reduce" -> Some(reduce.toString),
+      "group" -> bool2OptStr(group))
 
     // Throw out all undefined arguments.
     val argMap: Map[String, String] = args

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -91,8 +91,10 @@ protected[core] object ExecManifest {
       })
 
     val bypassPullForLocalImages = runtimeManifestConfig.bypassPullForLocalImages
-      .filter(identity)
-      .flatMap(_ => runtimeManifestConfig.localImagePrefix)
+      .flatMap {
+        case true  => runtimeManifestConfig.localImagePrefix
+        case false => None
+      }
 
     Runtimes(runtimes.getOrElse(Set.empty), blackbox.getOrElse(Set.empty), bypassPullForLocalImages)
   }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
I used to love to write "smart" code like `Some(descending).filter(identity)`. Coming back to it now, I hate it though. It feels unreadable, especially if there are simpler yet similar terse alternatives.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

