### PR TITLE
Remove usages of rxscala and replace with Java based code.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -81,9 +81,9 @@ dependencies {
     compile "io.zipkin.reporter2:zipkin-sender-okhttp3:2.6.1"
     compile "io.zipkin.reporter2:zipkin-reporter:2.6.1"
 
-    compile "io.reactivex:rxscala_${gradle.scala.depVersion}:0.26.5"
-    compile "io.reactivex:rxjava-reactive-streams:1.2.1"
-    compile "com.microsoft.azure:azure-cosmosdb:2.6.2"
+    compile "io.reactivex:rxjava:1.3.8"
+    compile 'io.reactivex:rxjava-reactive-streams:1.2.1'
+    compile ('com.microsoft.azure:azure-cosmosdb:2.6.2')
 
     compile ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.0.1") {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -82,8 +82,8 @@ dependencies {
     compile "io.zipkin.reporter2:zipkin-reporter:2.6.1"
 
     compile "io.reactivex:rxjava:1.3.8"
-    compile 'io.reactivex:rxjava-reactive-streams:1.2.1'
-    compile ('com.microsoft.azure:azure-cosmosdb:2.6.2')
+    compile "io.reactivex:rxjava-reactive-streams:1.2.1"
+    compile "com.microsoft.azure:azure-cosmosdb:2.6.2"
 
     compile ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.0.1") {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RxObservableImplicits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RxObservableImplicits.scala
@@ -34,9 +34,7 @@ private[cosmosdb] trait RxObservableImplicits {
      * @return the head result of the [[Observable]].
      */
     def head(): Future[T] = {
-      def toHandler[T](f: (T) => Unit): Action1[T] = new Action1[T] {
-        def call(t: T) = f(t)
-      }
+      def toHandler[P](f: (P) => Unit): Action1[P] = (t: P) => f(t)
 
       val promise = Promise[T]()
       observable.single.subscribe(toHandler(promise.success), toHandler(promise.failure))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RxObservableImplicits.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RxObservableImplicits.scala
@@ -18,8 +18,8 @@
 package org.apache.openwhisk.core.database.cosmosdb
 
 import com.microsoft.azure.cosmosdb.{FeedResponse, Resource, ResourceResponse}
-import rx.lang.scala.JavaConverters._
 import rx.Observable
+import rx.functions.Action1
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
@@ -34,8 +34,12 @@ private[cosmosdb] trait RxObservableImplicits {
      * @return the head result of the [[Observable]].
      */
     def head(): Future[T] = {
+      def toHandler[T](f: (T) => Unit): Action1[T] = new Action1[T] {
+        def call(t: T) = f(t)
+      }
+
       val promise = Promise[T]()
-      observable.asScala.single.subscribe(x => promise.success(x), e => promise.failure(e))
+      observable.single.subscribe(toHandler(promise.success), toHandler(promise.failure))
       promise.future
     }
   }
@@ -46,8 +50,8 @@ private[cosmosdb] trait RxObservableImplicits {
 
   implicit class RxScalaFeedObservable[T <: Resource](observable: Observable[FeedResponse[T]]) {
     def blockingOnlyResult(): Option[T] = {
-      val value = observable.asScala.toList.toBlocking.single
-      val results = value.head.getResults.asScala
+      val value = observable.toBlocking.single
+      val results = value.getResults.asScala
       require(results.isEmpty || results.size == 1, s"More than one result found $results")
       results.headOption
     }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
RxScala has been abandoned: https://github.com/ReactiveX/RxScala/issues/244. To unblock the move to Scala 2.13, this removes all usages of it and replaces it with Java interoperable code.

## Related issue and scope
Ref #4741

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

