### PR TITLE
Update alpakka-file to version 1.1.2.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile "com.typesafe.akka:akka-http-core_${gradle.scala.depVersion}:${gradle.akka_http.version}"
     compile "com.typesafe.akka:akka-http-spray-json_${gradle.scala.depVersion}:${gradle.akka_http.version}"
 
-    compile "com.lightbend.akka:akka-stream-alpakka-file_${gradle.scala.depVersion}:0.15"
+    compile "com.lightbend.akka:akka-stream-alpakka-file_${gradle.scala.depVersion}:1.1.2"
 
     compile "ch.qos.logback:logback-classic:1.2.3"
     compile "org.slf4j:jcl-over-slf4j:1.7.25"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
alpakka-file isn't available for Scala 2.13 prior to 1.1.x. See https://mvnrepository.com/artifact/com.lightbend.akka/akka-stream-alpakka-file.

## Related issue and scope
Ref #4741

See dev-list discussion on Scala 2.13 here: https://lists.apache.org/thread.html/c8e2fa40b646dccc6e3a6cbca2370904477f5dd8dbb315173f055a2c@%3Cdev.openwhisk.apache.org%3E

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
