### PR TITLE
Update alpakka-s3 to 1.1.2.

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     compile "io.reactivex:rxjava-reactive-streams:1.2.1"
     compile "com.microsoft.azure:azure-cosmosdb:2.6.2"
 
-    compile ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.0.1") {
+    compile ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.1.2") {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.dataformat'


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
alpakka-s3 isn't available for Scala 2.13 prior to 1.1.x. See https://mvnrepository.com/artifact/com.lightbend.akka/akka-stream-alpakka-s3.

## Related issue and scope
Ref #4741

See dev-list discussion on Scala 2.13 here: https://lists.apache.org/thread.html/c8e2fa40b646dccc6e3a6cbca2370904477f5dd8dbb315173f055a2c@%3Cdev.openwhisk.apache.org%3E

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
