### PR TITLE
Centralize settings in the build process to avoid duplication.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ subprojects {
 
     afterEvaluate {
         if (project.plugins.hasPlugin('scala')) {
-
             repositories {
                 mavenCentral()
             }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ subprojects {
 
     afterEvaluate {
         if (project.plugins.hasPlugin('scala')) {
+
             repositories {
                 mavenCentral()
             }

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,20 @@ subprojects {
     version '1.0.0-SNAPSHOT'
 
     afterEvaluate {
-        if (project.plugins.hasPlugin('application')
-                && project.plugins.hasPlugin('scala')) {
-            startScripts {
-                doLast {
-                    unixScript.text = configureUnixClasspath(unixScript)
+        if (project.plugins.hasPlugin('scala')) {
+            repositories {
+                mavenCentral()
+            }
+
+            tasks.withType(ScalaCompile) {
+                scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
+            }
+
+            if (project.plugins.hasPlugin('application')) {
+                startScripts {
+                    doLast {
+                        unixScript.text = configureUnixClasspath(unixScript)
+                    }
                 }
             }
         }

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'org.scoverage'
+plugins {
+    id 'eclipse'
+    id 'maven'
+    id 'org.scoverage'
+    id 'scala'
+}
 
 ext.dockerImageName = 'scala'
 apply from: '../../gradle/docker.gradle'

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -25,10 +25,6 @@ apply from: '../../gradle/docker.gradle'
 
 project.archivesBaseName = "openwhisk-common"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
 
@@ -110,8 +106,4 @@ configurations {
         exclude group: 'commons-logging'
         exclude group: 'log4j'
     }
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -33,10 +33,6 @@ ext.coverageDirs = [
 ]
 distDockerCoverage.dependsOn ':common:scala:scoverageClasses', 'scoverageClasses'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile "com.lightbend.akka.management:akka-management-cluster-bootstrap_${gradle.scala.depVersion}:0.11.0"
@@ -44,10 +40,6 @@ dependencies {
     compile "com.lightbend.akka.discovery:akka-discovery-marathon-api_${gradle.scala.depVersion}:0.11.0"
     compile project(':common:scala')
     compile project(':core:invoker')
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 mainClassName = "org.apache.openwhisk.core.controller.Controller"

--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
-apply plugin: 'application'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'org.scoverage'
+plugins {
+    id 'application'
+    id 'eclipse'
+    id 'maven'
+    id 'org.scoverage'
+    id 'scala'
+}
 
 ext.dockerImageName = 'controller'
 apply from: '../../gradle/docker.gradle'

--- a/core/cosmosdb/cache-invalidator/build.gradle
+++ b/core/cosmosdb/cache-invalidator/build.gradle
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
-apply plugin: 'application'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'org.scoverage'
+plugins {
+    id 'application'
+    id 'eclipse'
+    id 'maven'
+    id 'org.scoverage'
+    id 'scala'
+}
 
 ext.dockerImageName = 'cache-invalidator-cosmosdb'
 apply from: "../../../gradle/docker.gradle"

--- a/core/cosmosdb/cache-invalidator/build.gradle
+++ b/core/cosmosdb/cache-invalidator/build.gradle
@@ -27,19 +27,11 @@ distDocker.dependsOn ':common:scala:distDocker', 'distTar'
 
 project.archivesBaseName = "openwhisk-cache-invalidator-cosmosdb"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
     compile "com.microsoft.azure:azure-cosmos:3.3.0"
     compile "com.typesafe.akka:akka-stream-kafka_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 mainClassName = "org.apache.openwhisk.core.database.cosmosdb.cache.Main"

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
-apply plugin: 'application'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'org.scoverage'
+plugins {
+    id 'application'
+    id 'eclipse'
+    id 'maven'
+    id 'org.scoverage'
+    id 'scala'
+}
 
 ext.dockerImageName = 'invoker'
 apply from: '../../gradle/docker.gradle'

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -32,10 +32,6 @@ ext.coverageDirs = [
 ]
 distDockerCoverage.dependsOn ':common:scala:scoverageClasses', 'scoverageClasses'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
@@ -48,10 +44,6 @@ dependencies {
         exclude group: 'log4j'
         exclude group: 'jline'
     }
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 mainClassName = "org.apache.openwhisk.core.invoker.Invoker"

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -15,10 +15,13 @@
  * limitations under the License.
  */
 
-apply plugin: 'scala'
-apply plugin: 'application'
-apply plugin: 'org.scoverage'
-apply plugin: 'maven'
+plugins {
+    id 'application'
+    id 'eclipse'
+    id 'maven'
+    id 'org.scoverage'
+    id 'scala'
+}
 
 ext.dockerImageName = 'user-events'
 apply from: "../../../gradle/docker.gradle"

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -26,10 +26,6 @@ distDocker.dependsOn ':common:scala:distDocker', 'distTar'
 
 project.archivesBaseName = "openwhisk-user-events"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
@@ -45,10 +41,6 @@ dependencies {
     testCompile "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-http-testkit_${gradle.scala.depVersion}:${gradle.akka_http.version}"
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 mainClassName = "org.apache.openwhisk.core.monitoring.metrics.Main"

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -16,13 +16,12 @@
  */
 
 plugins {
+    id 'maven'
+    id 'org.scoverage'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
-    id "com.gorylenko.gradle-git-properties" version "2.0.0"
     id 'scala'
+    id 'com.gorylenko.gradle-git-properties' version '2.0.0'
 }
-
-apply plugin: 'org.scoverage'
-apply plugin: 'maven'
 
 project.archivesBaseName = "openwhisk-standalone"
 

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -26,10 +26,6 @@ apply plugin: 'maven'
 
 project.archivesBaseName = "openwhisk-standalone"
 
-repositories {
-    mavenCentral()
-}
-
 task copySwagger(type: Copy) {
     def version = "3.6.0"
     mkdir("$buildDir/tmp/swagger")

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -19,13 +19,13 @@ import org.scoverage.ScoverageReport
 import static groovy.json.JsonOutput.*
 
 plugins {
+    id 'eclipse'
+    id 'maven'
     id 'org.hidetake.swagger.generator' version '2.18.1'
+    id 'org.scoverage'
+    id 'scala'
 }
 
-apply plugin: 'scala'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'org.scoverage'
 compileTestScala.options.encoding = 'UTF-8'
 
 install.dependsOn ':tools:admin:install'

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -28,10 +28,6 @@ apply plugin: 'maven'
 apply plugin: 'org.scoverage'
 compileTestScala.options.encoding = 'UTF-8'
 
-repositories {
-    mavenCentral()
-}
-
 install.dependsOn ':tools:admin:install'
 
 project.archivesBaseName = "openwhisk-tests"
@@ -218,10 +214,6 @@ dependencies {
     compile project(':tools:admin')
 
     swaggerCodegen 'io.swagger:swagger-codegen-cli:2.4.9'
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 def keystorePath = new File(sourceSets.test.scala.outputDir, 'keystore')

--- a/tests/dat/actions/unicode.tests/src/java/unicode/build.gradle
+++ b/tests/dat/actions/unicode.tests/src/java/unicode/build.gradle
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
+plugins {
+    id 'java'
+}
 
 version = '1.0'
 

--- a/tests/performance/gatling_tests/build.gradle
+++ b/tests/performance/gatling_tests/build.gradle
@@ -16,11 +16,10 @@
  */
 
 plugins {
-    id "com.github.lkishalmi.gatling" version "0.7.2"
+    id 'com.github.lkishalmi.gatling' version '0.7.2'
+    id 'eclipse'
+    id 'scala'
 }
-
-apply plugin: 'eclipse'
-apply plugin: 'scala'
 
 dependencies {
     gatling "io.spray:spray-json_${gradle.scala.depVersion}:1.3.4"

--- a/tests/performance/gatling_tests/build.gradle
+++ b/tests/performance/gatling_tests/build.gradle
@@ -22,15 +22,7 @@ plugins {
 apply plugin: 'eclipse'
 apply plugin: 'scala'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     gatling "io.spray:spray-json_${gradle.scala.depVersion}:1.3.4"
     gatling "commons-io:commons-io:2.6"
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -25,10 +25,6 @@ apply plugin: 'maven'
 
 project.archivesBaseName = "openwhisk-admin-tools"
 
-repositories {
-    mavenCentral()
-}
-
 jar {
     enabled = true
 }

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -18,10 +18,9 @@
 plugins {
     id 'org.springframework.boot' version '2.0.2.RELEASE'
     id 'scala'
+    id 'maven'
+    id 'org.scoverage'
 }
-
-apply plugin: 'org.scoverage'
-apply plugin: 'maven'
 
 project.archivesBaseName = "openwhisk-admin-tools"
 

--- a/tools/dev/build.gradle
+++ b/tools/dev/build.gradle
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-apply plugin: 'groovy'
+plugins {
+    id 'groovy'
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Description
1. Removes redundant compiler option settings and centralizes them.
2. Makes use of the `plugins` mechanism throughout.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

