### PR TITLE
Update akka-management and discovery to 1.0.5.

### DIFF
--- a/core/controller/build.gradle
+++ b/core/controller/build.gradle
@@ -37,9 +37,9 @@ distDockerCoverage.dependsOn ':common:scala:scoverageClasses', 'scoverageClasses
 
 dependencies {
     compile "org.scala-lang:scala-library:${gradle.scala.version}"
-    compile "com.lightbend.akka.management:akka-management-cluster-bootstrap_${gradle.scala.depVersion}:0.11.0"
-    compile "com.lightbend.akka.discovery:akka-discovery-kubernetes-api_${gradle.scala.depVersion}:0.11.0"
-    compile "com.lightbend.akka.discovery:akka-discovery-marathon-api_${gradle.scala.depVersion}:0.11.0"
+    compile "com.lightbend.akka.management:akka-management-cluster-bootstrap_${gradle.scala.depVersion}:${gradle.akka_management.version}"
+    compile "com.lightbend.akka.discovery:akka-discovery-kubernetes-api_${gradle.scala.depVersion}:${gradle.akka_management.version}"
+    compile "com.lightbend.akka.discovery:akka-discovery-marathon-api_${gradle.scala.depVersion}:${gradle.akka_management.version}"
     compile project(':common:scala')
     compile project(':core:invoker')
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.ThreadLocalRandom
 import akka.actor.{Actor, ActorSystem, Cancellable, Props}
 import akka.cluster.ClusterEvent._
 import akka.cluster.{Cluster, Member, MemberStatus}
-import akka.management.AkkaManagement
+import akka.management.scaladsl.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ gradle.ext.scalafmt = [
 gradle.ext.akka = [version : '2.5.26']
 gradle.ext.akka_kafka = [version : '1.1.0']
 gradle.ext.akka_http = [version : '10.1.11']
+gradle.ext.akka_management = [version : '1.0.5']
 
 gradle.ext.curator = [version : '4.0.0']
 gradle.ext.kube_client = [version: '4.4.2']


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
akka-management and discovery isn't available for Scala 2.13 prior to 1.0.0. See https://mvnrepository.com/artifact/com.lightbend.akka.management/akka-management-cluster-bootstrap.

This also externalizes the version number to be uniformly bumpable.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

This should probably be tested by IBM (Kubernetes) and Adobe (Mesos) to make sure we don't break here.

