### PR TITLE
Update akka-http to 10.1.10.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -47,7 +47,7 @@ gradle.ext.scalafmt = [
 
 gradle.ext.akka = [version : '2.5.26']
 gradle.ext.akka_kafka = [version : '1.1.0']
-gradle.ext.akka_http = [version : '10.1.8']
+gradle.ext.akka_http = [version : '10.1.10']
 
 gradle.ext.curator = [version : '4.0.0']
 gradle.ext.kube_client = [version: '4.4.2']


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
akka-http itself does work with Scala 2.13 in version 10.1.8 but other upgrade don't seem to like the interop with an older version. See #4746 and #4749 for reference.

## Related issue and scope
Ref #4741 

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

