### PR TITLE
Keep container running for truncated responses

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -49,7 +49,6 @@ protected[core] case class ActivationResponse private (statusCode: Int,
   def isContainerError = statusCode == ActivationResponse.DeveloperError
   def isWhiskError = statusCode == ActivationResponse.WhiskError
   def withoutResult = ActivationResponse(statusCode, None)
-  def isTruncated = statusCode == ActivationResponse.Truncated
 
   override def toString = toJsonObject.compactPrint
 }
@@ -63,46 +62,39 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
   val ApplicationError = 1 // action ran but there was an error and it was handled
   val DeveloperError = 2 // action ran but failed to handle an error, or action did not run and failed to initialize
   val WhiskError = 3 // internal system error
-  val Truncated = 4 // action ran correctly, but returned a response that was too large
 
   val statusSuccess = "success"
   val statusApplicationError = "application_error"
   val statusDeveloperError = "action_developer_error"
   val statusWhiskError = "whisk_internal_error"
-  val truncatedError = "success_but_truncated"
 
   protected[core] def statusForCode(code: Int) = {
-    require(code >= 0 && code <= 4)
+    require(code >= 0 && code <= 3)
     code match {
       case Success          => statusSuccess
       case ApplicationError => statusApplicationError
       case DeveloperError   => statusDeveloperError
-      case Truncated        => truncatedError
       case WhiskError       => statusWhiskError
     }
   }
 
   protected[core] def messageForCode(code: Int) = {
-    require(code >= 0 && code <= 4)
+    require(code >= 0 && code <= 3)
     code match {
       case Success          => "success"
       case ApplicationError => "application error"
       case DeveloperError   => "action developer error"
-      case Truncated        => "success but response was truncated"
       case WhiskError       => "whisk internal error"
     }
   }
 
   private def error(code: Int, errorValue: JsValue, size: Option[Int]) = {
-    require(code == ApplicationError || code == DeveloperError || code == WhiskError || code == Truncated)
+    require(code == ApplicationError || code == DeveloperError || code == WhiskError)
     ActivationResponse(code, Some(JsObject(ERROR_FIELD -> errorValue)), size)
   }
 
   protected[core] def success(result: Option[JsValue] = None, size: Option[Int] = None) =
     ActivationResponse(Success, result, size)
-
-  protected[core] def truncatedError(body: String, size: Option[Int] = None) =
-    error(Truncated, JsString(body), size)
 
   protected[core] def applicationError(errorValue: JsValue, size: Option[Int] = None) =
     error(ApplicationError, errorValue, size)
@@ -242,7 +234,7 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
             }
 
           case Some((length, maxlength)) =>
-            truncatedError(truncatedResponse(str, length, maxlength), Some(length.toBytes.toInt))
+            applicationError(JsString(truncatedResponse(str, length, maxlength)), Some(length.toBytes.toInt))
         }
 
       case Left(_: MemoryExhausted) =>

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -296,7 +296,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
             // and instead clients must check if 'error' is in the JSON
             // PRESERVING OLD BEHAVIOR and will address defect in separate change
             complete(BadGateway, response)
-          } else if (activation.response.isContainerError || activation.response.isTruncated) {
+          } else if (activation.response.isContainerError) {
             complete(BadGateway, response)
           } else {
             complete(InternalServerError, response)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -296,7 +296,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
             // and instead clients must check if 'error' is in the JSON
             // PRESERVING OLD BEHAVIOR and will address defect in separate change
             complete(BadGateway, response)
-          } else if (activation.response.isContainerError) {
+          } else if (activation.response.isContainerError || activation.response.isTruncated) {
             complete(BadGateway, response)
           } else {
             complete(InternalServerError, response)

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
@@ -51,7 +51,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
       {
         val response = ContainerResponse(okStatus = true, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
         val run = processRunResponseContent(Right(response), logger)
-        run.statusCode shouldBe Truncated
+        run.statusCode shouldBe ApplicationError
         run.result.get.asJsObject
           .fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationResponseTests.scala
@@ -51,7 +51,7 @@ class ActivationResponseTests extends FlatSpec with Matchers {
       {
         val response = ContainerResponse(okStatus = true, m.take(max.toBytes.toInt - 1), Some(m.length.B, max))
         val run = processRunResponseContent(Right(response), logger)
-        run.statusCode shouldBe DeveloperError
+        run.statusCode shouldBe Truncated
         run.result.get.asJsObject
           .fields(ERROR_FIELD) shouldBe truncatedResponse(response.entity, m.length.B, max).toJson
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -313,7 +313,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       def checkResponse(activation: ActivationResult) = {
         val response = activation.response
         response.success shouldBe false
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Truncated)
         val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
         val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
         withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -313,7 +313,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       def checkResponse(activation: ActivationResult) = {
         val response = activation.response
         response.success shouldBe false
-        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.Truncated)
+        response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
         val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
         val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
         withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {


### PR DESCRIPTION
Keep the container running even if the action produced truncated response.

## Description
If a container sometimes produces replies that are greater than the allowed max size, that container cannot be reused. However, treating this in a similar fashion to unhandled exception or other developer error seems too heavy handed. Layer concurrency on this and you get a lot of failed activations and container churn due to a only slightly misbehaving action.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [X] I opened an issue to propose and discuss this change (#4750)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [X] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

