### PR TITLE
Specify npm command based on os for standalone compilation

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
     id 'org.springframework.boot' version '2.1.6.RELEASE'
     id "com.gorylenko.gradle-git-properties" version "2.0.0"
@@ -57,8 +59,9 @@ task copyGWActions() {
             def zipFileName = actionName + ".zip"
             def actionDir = new File(routeMgmtDir, actionName)
             def zipFile = new File(routeBuildDir, zipFileName)
+            def npmCommand = (Os.isFamily(Os.FAMILY_WINDOWS)) ? "npm.cmd" : "npm"
             if (!zipFile.exists()) {
-                ant.exec(dir:actionDir, executable:"npm", failonerror:true){
+                ant.exec(dir:actionDir, executable:npmCommand, failonerror:true){
                     arg(line:"install")
                 }
                 ant.zip(destfile:zipFile){


### PR DESCRIPTION

## Description
Standalone compilation was failing on windows os with below error. 

```
 Task :core:standalone:copyGWActions FAILED

FAILURE: Build failed with an exception.

* Where:
Build file 'C:\Users\Administrator\openwhisk\core\standalone\build.gradle' line: 59

* What went wrong:
Execution failed for task ':core:standalone:copyGWActions'.
> Execute failed: java.io.IOException: Cannot run program "npm" (in directory "C:\Users\Administrator\openwhisk\core\routemgmt\createApi"): CreateProcess error=2, The system cannot find the file specified

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

```

This is because "npm" is not found on windows as it is placed as "npm.cmd". 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation
- [x] Standalone

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

