### PR TITLE
Fix invalid module name in intellijRunConfig script

### DIFF
--- a/tools/dev/src/main/groovy/intellijRunConfig.groovy
+++ b/tools/dev/src/main/groovy/intellijRunConfig.groovy
@@ -34,7 +34,7 @@ def configTemplate = '''<component name="ProjectRunConfigurationManager">
     <option name="ENABLE_SWING_INSPECTOR" value="false" />
     <option name="ENV_VARIABLES" />
     <option name="PASS_PARENT_ENVS" value="true" />
-    <module name="${type}_main" />
+    <module name="openwhisk.core.${type}.main" />
     <envs>
       <% env.each { k,v -> %><env name="$k" value="$v" />
       <% } %>


### PR DESCRIPTION

## Description
Because the module name is incorrect, the IntelliJ utility script doesn't make valid run configurations. 
So it fixes the invalid module name.

<img src="https://user-images.githubusercontent.com/5635513/70017308-1a77fb00-15c6-11ea-84df-c995fbb65462.png" width="400">


## My changes affect the following components
- [x] General tooling

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

