### PR TITLE
Add __OW_ACTION_VERSION in action metadata

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -561,6 +561,7 @@ class ContainerProxy(factory: (TransactionId,
     val environment = Map(
       "namespace" -> job.msg.user.namespace.name.toJson,
       "action_name" -> job.msg.action.qualifiedNameWithLeadingSlash.toJson,
+      "action_version" -> job.msg.action.version.toJson,
       "activation_id" -> job.msg.activationId.toString.toJson,
       "transaction_id" -> job.msg.transid.id.toJson)
 

--- a/core/standalone/README.md
+++ b/core/standalone/README.md
@@ -370,6 +370,7 @@ This shows an output like below indicating that KubernetesContainerFactory based
     "PWD": "/nodejsAction",
     "YARN_VERSION": "1.13.0",
     "__OW_ACTION_NAME": "/guest/hello",
+    "__OW_ACTION_VERSION": "0.0.1",
     "__OW_ACTIVATION_ID": "71e48d2d62e142eca48d2d62e192ec2d",
     "__OW_API_HOST": "http://host.docker.internal:3233",
     "__OW_DEADLINE": "1570223213407",

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -160,6 +160,7 @@ The initialization route is `/init`. It must accept a `POST` request with a JSON
   * `__OW_API_KEY` the API key for the subject invoking the action, this key may be a restricted API key. This property is absent unless explicitly [requested](./annotations.md#annotations-for-all-actions).
   * `__OW_NAMESPACE` the namespace for the _activation_ (this may not be the same as the namespace for the action).
   * `__OW_ACTION_NAME` the fully qualified name of the running action.
+  * `__OW_ACTION_VERSION` the internal version number of the running action.
   * `__OW_ACTIVATION_ID` the activation id for this running action instance.
   * `__OW_DEADLINE` the approximate time when this initializer will have consumed its entire duration quota (measured in epoch milliseconds).
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -670,5 +670,6 @@ Node.js, Python, Swift, Java and Docker actions when using the OpenWhisk Docker 
 * `__OW_API_KEY` the API key for the subject invoking the action, this key may be a restricted API key. This property is absent unless explicitly [requested](./annotations.md#annotations-for-all-actions).
 * `__OW_NAMESPACE` the namespace for the _activation_ (this may not be the same as the namespace for the action).
 * `__OW_ACTION_NAME` the fully qualified name of the running action.
+* `__OW_ACTION_VERSION` the internal version number of the running action.
 * `__OW_ACTIVATION_ID` the activation id for this running action instance.
 * `__OW_DEADLINE` the approximate time when this action will have consumed its entire duration quota (measured in epoch milliseconds).

--- a/tests/dat/actions/helloContext.js
+++ b/tests/dat/actions/helloContext.js
@@ -21,6 +21,7 @@ function main(args) {
        "api_key": process.env['__OW_API_KEY'],
        "namespace": process.env['__OW_NAMESPACE'],
        "action_name": process.env['__OW_ACTION_NAME'],
+       "action_version": process.env['__OW_ACTION_VERSION'],
        "activation_id": process.env['__OW_ACTIVATION_ID'],
        "deadline": process.env['__OW_DEADLINE']
     }

--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -102,6 +102,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
    *               "api_key": process.env__OW_API_KEY,
    *               "namespace": process.env.__OW_NAMESPACE,
    *               "action_name": process.env.__OW_ACTION_NAME,
+   *               "action_version": process.env.__OW_ACTION_VERSION,
    *               "activation_id": process.env.__OW_ACTIVATION_ID,
    *               "deadline": process.env.__OW_DEADLINE
    *             }
@@ -309,6 +310,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
       "api_key" -> "abc",
       "namespace" -> "zzz",
       "action_name" -> "xxx",
+      "action_version" -> "0.0.1",
       "activation_id" -> "iii",
       "deadline" -> "123")
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -335,6 +335,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         fields.get("api_key") shouldBe empty
         fields("namespace") shouldBe namespace
         fields("action_name") shouldBe s"/$namespace/$name"
+        fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
         fields("activation_id") shouldBe activation.activationId
         fields("deadline").toLong should be >= start
       }
@@ -360,6 +361,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         fields("api_key") shouldBe wskprops.authKey
         fields("namespace") shouldBe namespace
         fields("action_name") shouldBe s"/$namespace/$name"
+        fields("action_version") should fullyMatch regex ("""\d+.\d+.\d+""")
         fields("activation_id") shouldBe activation.activationId
         fields("deadline").toLong should be >= start
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1428,6 +1428,7 @@ class ContainerProxyTests
 
       initializeEnv.fields("__OW_NAMESPACE") shouldBe invocationNamespace.name.toJson
       initializeEnv.fields("__OW_ACTION_NAME") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
+      initializeEnv.fields("__OW_ACTION_VERSION") shouldBe message.action.version.toJson
       initializeEnv.fields("__OW_ACTIVATION_ID") shouldBe message.activationId.toJson
       initializeEnv.fields("__OW_TRANSACTION_ID") shouldBe transid.id.toJson
 
@@ -1457,6 +1458,7 @@ class ContainerProxyTests
       val runCount = atomicRunCount.incrementAndGet()
       environment.fields("namespace") shouldBe invocationNamespace.name.toJson
       environment.fields("action_name") shouldBe message.action.qualifiedNameWithLeadingSlash.toJson
+      environment.fields("action_version") shouldBe message.action.version.toJson
       environment.fields("activation_id") shouldBe message.activationId.toJson
       environment.fields("transaction_id") shouldBe transid.id.toJson
       val authEnvironment = environment.fields.filterKeys(message.user.authkey.toEnvironment.fields.contains)


### PR DESCRIPTION
## Description

This PR adds the `__OW_ACTION_VERSION` property to the execution environment. This is for example useful when an action caches some data, so it could add the version number to the cache keys so that deploying a new version of the action would automatically "invalidate" the previous cache entries.

## Related issue and scope

See #4758 

## My changes affect the following components

- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes

- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

