### PR TITLE
Make sure the API host env var is send only via docker run for test.

### DIFF
--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -316,11 +316,13 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
 
     val env = props.map { case (k, v) => s"__OW_${k.toUpperCase()}" -> v }
 
+    // the api host is sent as a docker run environment parameter
     val (out, err) = withActionContainer(env.take(1).toMap) { c =>
       val (initCode, _) = c.init(initPayload(config.code, config.main))
       initCode should be(200)
 
-      val (runCode, out) = c.run(runPayload(JsObject.empty, Some(props.toMap.toJson.asJsObject)))
+      // we omit the api host from the run payload so the docker run env var is used
+      val (runCode, out) = c.run(runPayload(JsObject.empty, Some(props.drop(1).toMap.toJson.asJsObject)))
       runCode should be(200)
       out shouldBe defined
       props.map {

--- a/tools/actionProxy/invoke.py
+++ b/tools/actionProxy/invoke.py
@@ -66,6 +66,10 @@ def dockerHost():
 def containerRoute(args, path):
     return 'http://%s:%s/%s' % (args.host, args.port, path)
 
+class objectify(object):
+    def __init__(self, d):
+        self.__dict__ = d
+
 def parseArgs():
     parser = argparse.ArgumentParser(description='initialize and run an OpenWhisk action container')
     parser.add_argument('-v', '--verbose', help='verbose output', action='store_true')
@@ -76,6 +80,7 @@ def parseArgs():
 
     initmenu = subparsers.add_parser('init', help='initialize container with src or zip/tgz file')
     initmenu.add_argument('-b', '--binary', help='treat artifact as binary', action='store_true')
+    initmenu.add_argument('-r', '--run', nargs='?', default=None, help='run after init')
     initmenu.add_argument('main', nargs='?', default='main', help='name of the "main" entry method for the action')
     initmenu.add_argument('artifact', help='a source file or zip/tgz archive')
     initmenu.add_argument('env', nargs='?', help='the environment variables to export to the action, either a reference to a file or an inline JSON object', default=None)
@@ -114,7 +119,14 @@ def init(args):
                 "env": processPayload(args.env)
             }
         })
+
     print(r.text)
+
+    if r.status_code == 200 and args.run is not None:
+        runArgs = objectify({})
+        runArgs.__dict__ = args.__dict__.copy()
+        runArgs.payload = args.run
+        run(runArgs)
 
 def run(args):
     value = processPayload(args.payload)


### PR DESCRIPTION
I recently observed that some runtimes may not be properly exporting the `__OW_API_HOST` context property. Unlike other environment variables, this one is set by on the container startup (e.g., `docker run -e`). The test is adjusted so that the `api_host` is not passed in the run payload to make sure the container environment is used. 

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4766)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

