### PR TITLE
Update Scallop to 3.3.2.

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -149,7 +149,7 @@ install.dependsOn(bootJar)
 dependencies {
     compile project(':core:controller')
     compile project(':tools:admin')
-    compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.1"
+    compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
 
     //Tried with 0.16.0 has support for Kafka 0.11.0 https://github.com/embeddedkafka/embedded-kafka/tree/v0.16.0
     //But that causes class compatability issue die to use of newer client version

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -43,7 +43,7 @@ bootJar {
 
 dependencies {
     compile project(':common:scala')
-    compile "org.rogach:scallop_${gradle.scala.depVersion}:3.1.2"
+    compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
 }
 
 tasks.withType(ScalaCompile) {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
scallop isn't available for Scala 2.13 prior to 3.3.0. See https://mvnrepository.com/artifact/org.rogach/scallop.

This also externalizes the version number to be uniformly bumpable.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

This should probably be tested by IBM (Kubernetes) and Adobe (Mesos) to make sure we don't break here.

