### PR TITLE
Upgrade scalatest to 3.0.8.

### DIFF
--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile "io.prometheus:simpleclient_common:0.6.0"
 
     testCompile "junit:junit:4.11"
-    testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.1"
+    testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
     testCompile "com.typesafe.akka:akka-stream-kafka-testkit_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
     testCompile "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"

--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     compile "org.scala-lang:scala-reflect:${gradle.scala.version}"
 
     testCompile "junit:junit:4.11"
-    testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.5"
+    testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
 }
 
 tasks.withType(ScalaCompile) {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     compile "org.apache.httpcomponents:httpmime:4.3.6"
     compile "junit:junit:4.11"
     compile "io.rest-assured:rest-assured:4.0.0"
-    compile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.5"
+    compile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
     compile "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     compile "com.google.code.gson:gson:2.3.1"
     compile "org.scalamock:scalamock-scalatest-support_${gradle.scala.depVersion}:3.6.0"

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/DatastoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/DatastoreTests.scala
@@ -26,7 +26,6 @@ import org.scalatest.junit.JUnitRunner
 import akka.stream.ActorMaterializer
 import common.{StreamLogging, WskActorSystem}
 import org.apache.openwhisk.common.WhiskInstants
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.apache.openwhisk.core.database.DocumentConflictException
 import org.apache.openwhisk.core.database.CacheChangeNotification
@@ -42,7 +41,6 @@ class DatastoreTests
     with WskActorSystem
     with DbUtils
     with ExecHelpers
-    with MockitoSugar
     with StreamLogging
     with WhiskInstants {
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
scalatest isn't available for Scala 2.13 prior to 3.0.8. See https://mvnrepository.com/artifact/org.scalatest/scalatest

This also externalizes the version number to be uniformly bumpable.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

This should probably be tested by IBM (Kubernetes) and Adobe (Mesos) to make sure we don't break here.

