### PR TITLE
Update scalamock to 4.4.0.

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     compile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.5"
     compile "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     compile "com.google.code.gson:gson:2.3.1"
-    compile "org.scalamock:scalamock-scalatest-support_${gradle.scala.depVersion}:3.6.0"
+    compile "org.scalamock:scalamock_${gradle.scala.depVersion}:4.4.0"
     compile "com.typesafe.akka:akka-http-testkit_${gradle.scala.depVersion}:${gradle.akka_http.version}"
     compile "com.github.java-json-tools:json-schema-validator:2.2.8"
     compile "org.mockito:mockito-core:2.27.0"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
scalatest isn't available for Scala 2.13 prior to 4.3.0. See https://mvnrepository.com/artifact/org.scalamock/scalamock

This also externalizes the version number to be uniformly bumpable.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

This should probably be tested by IBM (Kubernetes) and Adobe (Mesos) to make sure we don't break here.

