### PR TITLE
Fix some Scala 2.13 deprecations.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -83,7 +83,7 @@ trait Logging {
    * @param from Reference, where the method was called from.
    * @param message Message to write to the log if not empty
    */
-  protected[common] def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: => String)
+  protected[common] def emit(loglevel: LogLevel, id: TransactionId, from: AnyRef, message: => String): Unit
 }
 
 /**

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -172,7 +172,7 @@ object OwSink {
    * values of either sink. Code basically copied from {@code Sink.combine}
    */
   def combine[T, U, M1, M2](first: Sink[U, M1], second: Sink[U, M2])(
-    strategy: Int ⇒ Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, (M1, M2)] = {
+    strategy: Int => Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, (M1, M2)] = {
     Sink.fromGraph(GraphDSL.create(first, second)((_, _)) { implicit b => (s1, s2) =>
       import GraphDSL.Implicits._
       val d = b.add(strategy(2))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -534,7 +534,7 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
               }
               attachmentHandler(
                 doc,
-                Attached(getAttachmentName(name), contentType, Some(length.longValue()), Some(digest)))
+                Attached(getAttachmentName(name), contentType, Some(length.longValue), Some(digest)))
             case x =>
               throw DeserializationException("Attachment json does not have required fields" + x)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -397,7 +397,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
       .queryDocuments(collection.getSelfLink, querySpec, newFeedOptions())
       .head()
       .map { r =>
-        val count = r.getResults.asScala.head.getLong(aggregate).longValue()
+        val count = r.getResults.asScala.head.getLong(aggregate).longValue
         transid.finished(this, start, s"[COUNT] '$collName' completed: count $count")
         collectMetrics(countToken, r.getRequestCharge)
         if (count > skip) count - skip else 0L

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
@@ -276,8 +276,8 @@ private[cosmosdb] object ActivationViewMapper extends SimpleMapper with WhiskIns
         //Go for case which does not specify upto as that would be the case with poll based query
         case (None, Some(startFromQuery), Some(JsNumber(start))) =>
           val now = nowInMillis().toEpochMilli
-          val resultStartDelta = (now - start.longValue()).max(0)
-          val queryStartDelta = (now - startFromQuery.longValue()).max(0)
+          val resultStartDelta = (now - start.longValue).max(0)
+          val queryStartDelta = (now - startFromQuery.longValue).max(0)
           resultDeltaToken.histogram.record(resultStartDelta)
           sinceDeltaToken.histogram.record(queryStartDelta)
           Some(s"resultDelta=$resultStartDelta, sinceDelta=$queryStartDelta")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
@@ -94,7 +94,7 @@ object RetryMetricsCollector extends AppenderBase[ILoggingEvent] with SLF4JLoggi
     val t = Try {
       if (args != null & args.length > index) {
         args(index) match {
-          case n: Number => n.intValue()
+          case n: Number => n.intValue
           case _         => 0
         }
       } else 0

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryViewMapper.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryViewMapper.scala
@@ -54,13 +54,13 @@ trait MemoryViewMapper {
 
   protected def gte(js: JsObject, name: String, value: Number): Boolean =
     JsHelpers.getFieldPath(js, name) match {
-      case Some(JsNumber(n)) => n.longValue() >= value.longValue()
+      case Some(JsNumber(n)) => n.longValue >= value.longValue
       case _                 => false
     }
 
   protected def lte(js: JsObject, name: String, value: Number): Boolean =
     JsHelpers.getFieldPath(js, name) match {
-      case Some(JsNumber(n)) => n.longValue() <= value.longValue()
+      case Some(JsNumber(n)) => n.longValue <= value.longValue
       case _                 => false
     }
 
@@ -68,7 +68,7 @@ trait MemoryViewMapper {
     val f =
       (js: JsObject) =>
         JsHelpers.getFieldPath(js, name) match {
-          case Some(JsNumber(n)) => n.longValue()
+          case Some(JsNumber(n)) => n.longValue
           case _                 => 0L
       }
     val order = implicitly[Ordering[Long]]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
@@ -47,14 +47,15 @@ object Attachments {
 
   // Attachments are considered free because the name/content type are system determined
   // and a size check for the content is done during create/update
-  implicit class SizeAttachment[T <% SizeConversion](a: Attachment[T]) extends SizeConversion {
+  implicit class SizeAttachment[T](a: Attachment[T])(implicit ev: T => SizeConversion) extends SizeConversion {
     def sizeIn(unit: SizeUnits.Unit): ByteSize = a match {
       case Inline(v) => (v: SizeConversion).sizeIn(unit)
       case _         => 0.bytes
     }
   }
 
-  implicit class OptionSizeAttachment[T <% SizeConversion](a: Option[Attachment[T]]) extends SizeConversion {
+  implicit class OptionSizeAttachment[T](a: Option[Attachment[T]])(implicit ev: T => SizeConversion)
+      extends SizeConversion {
     def sizeIn(unit: SizeUnits.Unit): ByteSize = a match {
       case Some(Inline(v)) => (v: SizeConversion).sizeIn(unit)
       case _               => 0.bytes

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
@@ -78,7 +78,7 @@ protected[core] object ConcurrencyLimit extends ArgNormalizer[ConcurrencyLimit] 
     def read(value: JsValue) = {
       Try {
         val JsNumber(c) = value
-        require(c.isWhole(), "concurrency limit must be whole number")
+        require(c.isWhole, "concurrency limit must be whole number")
 
         ConcurrencyLimit(c.toInt)
       } match {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Exec.scala
@@ -64,7 +64,7 @@ sealed abstract class ExecMetaDataBase extends Exec {
  * A common super class for all action exec types that contain their executable
  * code explicitly (i.e., any action other than a sequence).
  */
-sealed abstract class CodeExec[+T <% SizeConversion] extends Exec {
+sealed abstract class CodeExec[+T](implicit ev: T => SizeConversion) extends Exec {
 
   /** An entrypoint (typically name of 'main' function). 'None' means a default value will be used. */
   val entryPoint: Option[String]

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
@@ -80,7 +80,7 @@ protected[core] object LogLimit extends ArgNormalizer[LogLimit] {
     def read(value: JsValue) =
       Try {
         val JsNumber(mb) = value
-        require(mb.isWhole(), "log limit must be whole number")
+        require(mb.isWhole, "log limit must be whole number")
         LogLimit(mb.intValue MB)
       } match {
         case Success(limit)                       => limit

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
@@ -76,7 +76,7 @@ protected[core] object MemoryLimit extends ArgNormalizer[MemoryLimit] {
     def read(value: JsValue) =
       Try {
         val JsNumber(mb) = value
-        require(mb.isWhole(), "memory limit must be whole number")
+        require(mb.isWhole, "memory limit must be whole number")
         MemoryLimit(mb.intValue MB)
       } match {
         case Success(limit)                       => limit

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNRESTUtil.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNRESTUtil.scala
@@ -195,6 +195,6 @@ object YARNRESTUtil {
 
     case httpresponse(code, content) =>
       logging.error(this, "Unknown response from YARN")
-      throw new Exception(s"Unknown response from YARN. Code: ${code.intValue()}, content: $content")
+      throw new Exception(s"Unknown response from YARN. Code: ${code.intValue}, content: $content")
   }
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/utils/ExecutionContextFactory.scala
@@ -39,13 +39,13 @@ object ExecutionContextFactory {
    * timeout duration
    *
    */
-  def expire[T](duration: FiniteDuration, using: Scheduler)(value: ⇒ Future[T])(
+  def expire[T](duration: FiniteDuration, using: Scheduler)(value: => Future[T])(
     implicit ec: ExecutionContext): CancellableFuture[T] = {
     val p = Promise[T]()
     val cancellable = using.scheduleOnce(duration) {
       p completeWith {
         try value
-        catch { case NonFatal(t) ⇒ Future.failed(t) }
+        catch { case NonFatal(t) => Future.failed(t) }
       }
     }
     (cancellable, p.future)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -242,7 +242,7 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
     logging.info(this, s"received result ack for '$aid'")(tid)
   }
 
-  protected def releaseInvoker(invoker: InvokerInstanceId, entry: ActivationEntry)
+  protected def releaseInvoker(invoker: InvokerInstanceId, entry: ActivationEntry): Unit
 
   // Singletons for counter metrics related to completion acks
   protected val LOADBALANCER_COMPLETION_ACK_REGULAR =

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -81,8 +81,8 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
   actorSystem.scheduler.schedule(10.seconds, 10.seconds)(emitMetrics())
 
   override def activeActivationsFor(namespace: UUID): Future[Int] =
-    Future.successful(activationsPerNamespace.get(namespace).map(_.intValue()).getOrElse(0))
-  override def totalActiveActivations: Future[Int] = Future.successful(totalActivations.intValue())
+    Future.successful(activationsPerNamespace.get(namespace).map(_.intValue).getOrElse(0))
+  override def totalActiveActivations: Future[Int] = Future.successful(totalActivations.intValue)
 
   /**
    * Calculate the duration within which a completion ack must be received for an activation.

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -68,7 +68,7 @@ class LeanBalancer(config: WhiskConfig,
   }
 
   /** Creates an invoker for executing user actions. There is only one invoker in the lean model. */
-  private def makeALocalThreadedInvoker() {
+  private def makeALocalThreadedInvoker(): Unit = {
     implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
     val limitConfig: ConcurrencyLimitConfig = loadConfigOrThrow[ConcurrencyLimitConfig](ConfigKeys.concurrencyLimit)
     SpiLoader.get[InvokerProvider].instance(config, invokerName, messageProducer, poolConfig, limitConfig)

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
@@ -68,7 +68,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
     histogramCount(durationMetric, namespaceDemo, actionWithCustomPackage) shouldBe 1
     histogramSum(durationMetric, namespaceDemo, actionWithCustomPackage) shouldBe (1.254 +- 0.01)
 
-    gauge(memoryMetric, namespaceDemo, actionWithCustomPackage).intValue() shouldBe 256
+    gauge(memoryMetric, namespaceDemo, actionWithCustomPackage).intValue shouldBe 256
 
     // Default package
     counterTotal(activationMetric, namespaceDemo, actionWithDefaultPackage) shouldBe 1

--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -282,7 +282,7 @@ trait WskTestHelpers extends Matchers {
    * In the case that test throws an exception, print stderr and stdout
    * from the provided RunResult.
    */
-  def withPrintOnFailure(runResult: RunResult)(test: () => Unit) {
+  def withPrintOnFailure(runResult: RunResult)(test: () => Unit): Unit = {
     try {
       test()
     } catch {

--- a/tests/src/test/scala/common/rest/SwaggerValidator.scala
+++ b/tests/src/test/scala/common/rest/SwaggerValidator.scala
@@ -88,7 +88,7 @@ trait SwaggerValidator {
 
     val specResponse = {
       val builder = SimpleResponse.Builder
-        .status(response.status.intValue())
+        .status(response.status.intValue)
       val body = strictEntityBodyAsString(response.entity)
       val withBody =
         if (body.isEmpty) builder

--- a/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
+++ b/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
@@ -310,7 +310,7 @@ class ShootInvokerTests extends TestHelpers with WskTestHelpers with JsHelpers w
       result.getFields("stdout", "code") match {
         case Seq(JsString(stdout), JsNumber(code)) =>
           stdout should not include "bytes from"
-          code.intValue() should not be 0
+          code.intValue should not be 0
         case _ => fail(s"fields 'stdout' or 'code' where not of the expected format, was $result")
       }
     }

--- a/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/UserEventTests.scala
@@ -47,7 +47,7 @@ class UserEventTests extends FlatSpec with Matchers with WskTestHelpers with Str
   val testActionsDir = WhiskProperties.getFileRelativeToWhiskHome("tests/dat/actions")
   behavior of "UserEvents"
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     consumer.close()
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/yarn/test/MockYARNRM.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/yarn/test/MockYARNRM.scala
@@ -184,7 +184,7 @@ class MockYARNRM(port: Int, delayMS: Int) {
       })
   this.server.setExecutor(null) // creates a default executor
 
-  def start() {
+  def start(): Unit = {
     this.server.start()
   }
   def stop(): Unit = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentStoreBehaviors.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentStoreBehaviors.scala
@@ -144,7 +144,7 @@ trait AttachmentStoreBehaviors
     val docId = newDocId()
     val error = new Error("boom!")
     val faultySource = Source(1 to 10)
-      .map { n ⇒
+      .map { n =>
         if (n == 7) throw error
         n
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -78,7 +78,7 @@ class InvokerSupervisionTests
 
   ExecManifest.initialize(config)
 
-  override def afterAll {
+  override def afterAll: Unit = {
     TestKit.shutdownActorSystem(system)
   }
 

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -316,7 +316,7 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
       result.getFields("stdout", "code") match {
         case Seq(JsString(stdout), JsNumber(code)) =>
           stdout should not include "bytes from"
-          code.intValue() should not be 0
+          code.intValue should not be 0
         case _ => fail(s"fields 'stdout' or 'code' where not of the expected format, was $result")
       }
     }

--- a/tests/src/test/scala/system/basic/WskPackageTests.scala
+++ b/tests/src/test/scala/system/basic/WskPackageTests.scala
@@ -176,7 +176,7 @@ class WskPackageTests extends TestHelpers with WskTestHelpers with WskActorSyste
    * Check that a description of an item includes the specified parameters.
    * Parameters keys in later parameter maps override earlier ones.
    */
-  def checkForParameters(itemDescription: String, paramSets: Map[String, JsValue]*) {
+  def checkForParameters(itemDescription: String, paramSets: Map[String, JsValue]*): Unit = {
     // Merge and the parameters handling overrides.
     val merged = HashMap.empty[String, JsValue]
     paramSets.foreach { merged ++= _ }

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -558,7 +558,7 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
   }
 
   /** checks that the logs of the idx-th atomic action from a sequence contains logsStr */
-  private def checkLogsAtomicAction(atomicActionIdx: Int, run: RunResult, regex: Regex) {
+  private def checkLogsAtomicAction(atomicActionIdx: Int, run: RunResult, regex: Regex): Unit = {
     withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
       checkSequenceLogsAndAnnotations(activation, 1)
       val componentId = activation.logs.get(atomicActionIdx)

--- a/tools/admin/src/main/scala/org/apache/openwhisk/core/cli/Main.scala
+++ b/tools/admin/src/main/scala/org/apache/openwhisk/core/cli/Main.scala
@@ -73,7 +73,7 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 object Main {
   val printedName = "wskadmin"
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     //Parse conf before instantiating actorSystem to ensure fast pre check of config
     val conf = new Conf(args)
     initLogging(conf)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
This fixes a bunch of things that are deprecated on Scala 2.13:
- Unicode arrows are deprecated.
- View bounds are deprecated.
- Value functions may no longer have an empty argument list.
- Remove usage of the procedure syntax.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

