### PR TITLE
Update embedded-kafka to 2.4.0.

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -151,9 +151,7 @@ dependencies {
     compile project(':tools:admin')
     compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
 
-    //Tried with 0.16.0 has support for Kafka 0.11.0 https://github.com/embeddedkafka/embedded-kafka/tree/v0.16.0
-    //But that causes class compatability issue die to use of newer client version
-    compile "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.1.1"
+    compile "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
     compile "org.scala-lang:scala-reflect:${gradle.scala.version}"
 
     testCompile "junit:junit:4.11"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
embedded-kafka isn't available for Scala 2.13 prior to 2.4.0. See https://mvnrepository.com/artifact/io.github.embeddedkafka/embedded-kafka

This also externalizes the version number to be uniformly bumpable.

## Related issue and scope
Ref #4741.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

This should probably be tested by IBM (Kubernetes) and Adobe (Mesos) to make sure we don't break here.

