### PR TITLE
mark nodejs:6 as deprecated

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -22,7 +22,7 @@
                     "name": "nodejs6action",
                     "tag": "nightly"
                 },
-                "deprecated": false,
+                "deprecated": true,
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"


### PR DESCRIPTION
EOL of NodeJS 6 was April 2019.  We should move forward on removing support for nodejs:6 kind from Apache OpenWhisk