### PR TITLE
Use spray json like approach for config derivation with  Pureconfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,11 +66,13 @@ subprojects {
         if (project.plugins.hasPlugin('scala')) {
             repositories {
                 mavenCentral()
+                mavenLocal()
             }
 
             tasks.withType(ScalaCompile) {
                 scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
                 scalaCompileOptions.forkOptions.jvmArgs = ["-Xss2m"]
+                scalaCompileOptions.forkOptions.memoryMaximumSize = "1g"
             }
 
             if (project.plugins.hasPlugin('application')) {

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -34,6 +34,10 @@ dependencies {
         exclude group: 'org.scala-lang', module: 'scala-compiler'
         exclude group: 'org.scala-lang', module: 'scala-reflect'
     }
+    compile ("com.github.pureconfig:pureconfig-reflect_${gradle.scala.depVersion}:0.12.3-SNAPSHOT") {
+        exclude group: 'com.github.pureconfig', module: "pureconfig-core_${gradle.scala.depVersion}"
+    }
+
     compile "io.spray:spray-json_${gradle.scala.depVersion}:1.3.5"
     compile "com.lihaoyi:fastparse_${gradle.scala.depVersion}:2.1.3"
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/TransactionId.scala
@@ -24,7 +24,6 @@ import akka.http.scaladsl.model.headers.RawHeader
 import spray.json._
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.tracing.WhiskTracerProvider
 import org.apache.openwhisk.common.WhiskInstants._
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/UserEvents.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/UserEvents.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.common
 
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.connector.{EventMessage, MessageProducer}
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk
+
+import org.apache.openwhisk.common.Https.HttpsConfig
+import org.apache.openwhisk.common.UserEvents.UserEventsConfig
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object common extends ReflectConfigReaders {
+  implicit val httpsConfigReader: ConfigReader[HttpsConfig] = configReader4(HttpsConfig)
+  implicit val txnGenConfigReader: ConfigReader[TransactionGeneratorConfig] = configReader1(TransactionGeneratorConfig)
+  implicit val metricConfigReader: ConfigReader[MetricConfig] = configReader4(MetricConfig)
+  implicit val userEventConfigReader: ConfigReader[UserEventsConfig] = configReader1(UserEventsConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/OpenTracingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/OpenTracingProvider.scala
@@ -27,7 +27,6 @@ import io.opentracing.propagation.{Format, TextMapExtractAdapter, TextMapInjectA
 import io.opentracing.util.GlobalTracer
 import io.opentracing.{Span, SpanContext, Tracer}
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{LogMarkerToken, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import zipkin2.reporter.okhttp3.OkHttpSender

--- a/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/tracing/package.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object tracing extends ReflectConfigReaders {
+  implicit val zipkinConfigReader: ConfigReader[ZipkinConfig] = configReader2(ZipkinConfig)
+  implicit val tracingConfigReader: ConfigReader[TracingConfig] = configReader3(TracingConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaConsumerConnector.scala
@@ -23,7 +23,6 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{RetriableException, WakeupException}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, MetricEmitter, Scheduler}
 import org.apache.openwhisk.connector.kafka.KafkaConfiguration._
 import org.apache.openwhisk.core.ConfigKeys

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -23,7 +23,6 @@ import akka.actor.ActorSystem
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.common.errors.{RetriableException, TopicExistsException}
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{CausedBy, Logging}
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.core.connector.{MessageConsumer, MessageProducer, MessagingProvider}

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.serialization.StringSerializer
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Counter, Logging, TransactionId}
 import org.apache.openwhisk.connector.kafka.KafkaConfiguration._
 import org.apache.openwhisk.core.ConfigKeys

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KamonMetricsReporter.scala
@@ -27,7 +27,6 @@ import org.apache.kafka.common.metrics.stats.Total
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricsReporter}
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.FiniteDuration

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.connector
+
+import org.apache.openwhisk.connector.kafka.KamonMetricsReporter.KafkaMetricConfig
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object kafka extends ReflectConfigReaders {
+  implicit val kafkaConsumerConfigReader: ConfigReader[KafkaConsumerConfig] = configReader1(KafkaConsumerConfig)
+  implicit val kafkaConfigReader: ConfigReader[KafkaConfig] = configReader2(KafkaConfig)
+  implicit val kafkaMetricConfigReader: ConfigReader[KafkaMetricConfig] = configReader2(KafkaMetricConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/FeatureFlags.scala
@@ -17,10 +17,11 @@
 
 package org.apache.openwhisk.core
 import pureconfig._
-import pureconfig.generic.auto._
+import pureconfig.module.reflect.ReflectConfigReaders.configReader1
 
 object FeatureFlags {
   private case class FeatureFlagConfig(requireApiKeyAnnotation: Boolean)
+  private implicit val featureFlagConfigReader: ConfigReader[FeatureFlagConfig] = configReader1(FeatureFlagConfig)
   private val config = loadConfigOrThrow[FeatureFlagConfig](ConfigKeys.featureFlags)
 
   val requireApiKeyAnnotation: Boolean = config.requireApiKeyAnnotation

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ApacheBlockingContainerClient.scala
@@ -39,7 +39,6 @@ import org.apache.openwhisk.core.entity.ActivationResponse._
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.size.SizeLong
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.annotation.tailrec
 import scala.concurrent._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -24,14 +24,12 @@ import akka.event.Logging.InfoLevel
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json.JsObject
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.ActivationResponse.{ContainerConnectionError, ContainerResponse}
 import org.apache.openwhisk.core.entity.{ActivationEntityLimit, ActivationResponse, ByteSize}
-import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/ElasticSearchLogStore.scala
@@ -34,7 +34,6 @@ import scala.util.Try
 import spray.json._
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 case class ElasticSearchLogFieldConfig(userLogs: String,
                                        message: String,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/SplunkLogStore.scala
@@ -40,7 +40,6 @@ import akka.stream.scaladsl.Source
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.Future
 import scala.concurrent.Promise

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object logging extends ReflectConfigReaders {
+  implicit val splunkConfigReader: ConfigReader[SplunkLogStoreConfig] = configReader12(SplunkLogStoreConfig)
+
+  implicit val esFieldConfigReader: ConfigReader[ElasticSearchLogFieldConfig] = configReader5(
+    ElasticSearchLogFieldConfig)
+  implicit val esConfigReader: ConfigReader[ElasticSearchLogStoreConfig] = configReader6(ElasticSearchLogStoreConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/package.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders._
+import org.apache.openwhisk.core.entity.size._
+
+package object containerpool {
+  implicit val poolConfigReader: ConfigReader[ContainerPoolConfig] = configReader3(ContainerPoolConfig)
+  implicit val containerArgsReader: ConfigReader[ContainerArgsConfig] = configReader6(ContainerArgsConfig)
+
+  implicit val registryCredentialsReader: ConfigReader[RuntimesRegistryCredentials] = configReader2(
+    RuntimesRegistryCredentials)
+
+  implicit val registryReader: ConfigReader[RuntimesRegistryConfig] = configReader2(RuntimesRegistryConfig)
+
+  implicit val apacheConfigReader: ConfigReader[ApacheClientConfig] = configReader1(ApacheClientConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStore.scala
@@ -25,7 +25,6 @@ import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.{DocInfo, _}
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 
 import scala.concurrent.Future

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbStoreProvider.scala
@@ -23,9 +23,7 @@ import spray.json.RootJsonFormat
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.DocumentReader
-import org.apache.openwhisk.core.entity.size._
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.reflect.ClassTag
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStoreProvider.scala
@@ -26,10 +26,8 @@ import com.typesafe.config.ConfigFactory
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.database._
-import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.entity.{DocumentReader, WhiskActivation, WhiskAuth, WhiskEntity}
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.RootJsonFormat
 
 import scala.reflect.ClassTag

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBConfig.scala
@@ -27,7 +27,6 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigUtil.joinPath
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/RetryMetricsCollector.scala
@@ -28,7 +28,6 @@ import org.apache.openwhisk.common.{LogMarkerToken, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.slf4j.LoggerFactory
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.util.Try
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+import org.apache.openwhisk.core.entity.size._
+
+package object cosmosdb extends ReflectConfigReaders {
+  implicit val retryOptionConfigReader: ConfigReader[RetryOptions] = configReader2(RetryOptions)
+  implicit val connPolicyConfigReader: ConfigReader[ConnectionPolicy] = configReader5(ConnectionPolicy)
+  implicit val cosmosConfigReader: ConfigReader[CosmosDBConfig] = configReader10(CosmosDBConfig.apply)
+
+  implicit val inlineConfigReader: ConfigReader[InliningConfig] = configReader1(InliningConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/MemoryArtifactStore.scala
@@ -30,10 +30,8 @@ import org.apache.openwhisk.core.database.StoreUtils._
 import org.apache.openwhisk.core.database._
 import org.apache.openwhisk.core.entity.Attachments.Attached
 import org.apache.openwhisk.core.entity._
-import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, RootJsonFormat}
 
 import scala.collection.concurrent.TrieMap

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/memory/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database
+
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object memory extends ReflectConfigReaders {}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import org.apache.openwhisk.core.entity.size._
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object database extends ReflectConfigReaders {
+  implicit val activationStoreConfig: ConfigReader[ArtifactWithFileStorageActivationStoreConfig] = configReader4(
+    ArtifactWithFileStorageActivationStoreConfig)
+  implicit val couchdbConfigReader: ConfigReader[CouchDbConfig] = configReader7(CouchDbConfig)
+  implicit val inlineConfigReader: ConfigReader[InliningConfig] = configReader1(InliningConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/S3AttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/S3AttachmentStore.scala
@@ -43,7 +43,6 @@ import org.apache.openwhisk.core.database.StoreUtils._
 import org.apache.openwhisk.core.database._
 import org.apache.openwhisk.core.entity.DocId
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/s3/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.database
+
+import org.apache.openwhisk.core.database.s3.S3AttachmentStoreProvider.S3Config
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object s3 extends ReflectConfigReaders {
+  implicit val cfConfigReader: ConfigReader[CloudFrontConfig] = configReader4(CloudFrontConfig)
+  implicit val s3ConfigReader: ConfigReader[S3Config] = configReader3(S3Config)
+
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.size.SizeLong
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ConcurrencyLimit.scala
@@ -20,7 +20,6 @@ package org.apache.openwhisk.core.entity
 import com.typesafe.config.ConfigFactory
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.util.{Failure, Success, Try}
 import spray.json._

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/LogLimit.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.language.postfixOps
 import scala.util.Failure

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/MemoryLimit.scala
@@ -26,7 +26,6 @@ import spray.json._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 
 case class MemoryLimitConfig(min: ByteSize, max: ByteSize, std: ByteSize)
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Size.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Size.scala
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets
 
 import com.typesafe.config.ConfigValue
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 import ByteSize.formatError
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/TimeLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/TimeLimit.scala
@@ -18,7 +18,6 @@
 package org.apache.openwhisk.core.entity
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.util.Failure

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskStore.scala
@@ -38,7 +38,6 @@ import org.apache.openwhisk.core.database.DocumentSerializer
 import org.apache.openwhisk.core.database.StaleParameter
 import org.apache.openwhisk.spi.SpiLoader
 import pureconfig._
-import pureconfig.generic.auto._
 import scala.reflect.classTag
 
 object types {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/package.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import org.apache.openwhisk.core.entity.ExecManifest.RuntimeManifestConfig
+import org.apache.openwhisk.core.entity.size._
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object entity extends ReflectConfigReaders {
+  implicit val manifestConfigReader: ConfigReader[RuntimeManifestConfig] = configReader2(RuntimeManifestConfig)
+  implicit val concurrencyConfigReader: ConfigReader[ConcurrencyLimitConfig] = configReader3(ConcurrencyLimitConfig)
+  implicit val memoryConfigReader: ConfigReader[MemoryLimitConfig] = configReader3(MemoryLimitConfig)
+  implicit val logLimitConfigReader: ConfigReader[LogLimitConfig] = configReader3(LogLimitConfig)
+  implicit val timeLimitConfigReader: ConfigReader[TimeLimitConfig] = configReader3(TimeLimitConfig)
+  implicit val dbConfigReader: ConfigReader[DBConfig] = configReader4(DBConfig)
+  implicit val actPayloadConfigReader: ConfigReader[ActivationEntityPayload] = configReader1(ActivationEntityPayload)
+  implicit val actLimitConfigReader: ConfigReader[ActivationEntityLimitConf] = configReader2(ActivationEntityLimitConf)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
@@ -31,7 +31,6 @@ import com.adobe.api.platform.runtime.mesos.UNLIKE
 import java.time.Instant
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object mesos extends ReflectConfigReaders {
+  implicit val timeoutConfigReader: ConfigReader[MesosTimeoutConfig] = configReader5(MesosTimeoutConfig)
+  implicit val mesosHealthConfigReader: ConfigReader[MesosContainerHealthCheckConfig] = configReader6(
+    MesosContainerHealthCheckConfig)
+  implicit val mesosConfigReader: ConfigReader[MesosConfig] = configReader12(MesosConfig)
+}

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNContainerFactory.scala
@@ -28,7 +28,6 @@ import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstance
 import org.apache.openwhisk.core.yarn.YARNComponentActor.CreateContainerAsync
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 
 import scala.collection.immutable.HashMap

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/package.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object yarn extends ReflectConfigReaders {
+  implicit val mesosConfigReader: ConfigReader[YARNConfig] = configReader9(YARNConfig)
+}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -26,7 +26,6 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import kamon.Kamon
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.Https.HttpsConfig

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.server.directives.AuthenticationDirective
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.stream.ActorMaterializer
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.common.{Logging, TransactionId}
@@ -50,6 +49,7 @@ import scala.util.{Failure, Success, Try}
 protected[controller] class SwaggerDocs(apipath: Uri.Path, doc: String)(implicit actorSystem: ActorSystem)
     extends Directives {
   case class SwaggerConfig(fileSystem: Boolean, dirPath: String)
+  implicit val swaggerConfigReader: ConfigReader[SwaggerConfig] = configReader2(SwaggerConfig)
 
   /** Swagger end points. */
   protected val swaggeruipath = "docs"

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Triggers.scala
@@ -36,7 +36,6 @@ import akka.stream.ActorMaterializer
 import spray.json.DefaultJsonProtocol._
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 import org.apache.openwhisk.common.Https.HttpsConfig
 import org.apache.openwhisk.common.{Https, TransactionId}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -45,7 +45,6 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 import pureconfig._
-import pureconfig.generic.auto._
 
 protected[actions] trait PrimitiveActions {
   /** The core collections require backend services to be injected in this trait. */

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/package.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import org.apache.openwhisk.core.controller.actions.ControllerActivationConfig
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object controller extends ReflectConfigReaders {
+  implicit val infoConfigReader: ConfigReader[WhiskInformation] = configReader2(WhiskInformation)
+  implicit val controllerConfigReader: ConfigReader[ControllerActivationConfig] = configReader2(
+    ControllerActivationConfig)
+}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
@@ -29,6 +29,7 @@ import akka.http.scaladsl.model.HttpMethods.PUT
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.controller.configReader2
 import org.apache.openwhisk.core.entity.Identity
 import org.apache.openwhisk.core.entity.WhiskAction
 import org.apache.openwhisk.core.entity.WhiskActivation
@@ -37,7 +38,6 @@ import org.apache.openwhisk.core.entity.WhiskRule
 import org.apache.openwhisk.core.entity.WhiskTrigger
 import org.apache.openwhisk.core.entity.types.EntityStore
 import pureconfig._
-import pureconfig.generic.auto._
 
 /**
  * A collection encapsulates the name of a collection and implicit rights when subject
@@ -110,6 +110,7 @@ protected[core] case class Collection protected (val path: String,
 protected[core] object Collection {
 
   private case class QueryLimit(maxListLimit: Int, defaultListLimit: Int)
+  private implicit val controllerConfigReader: ConfigReader[QueryLimit] = configReader2(QueryLimit)
   private val queryLimit = loadConfigOrThrow[QueryLimit](ConfigKeys.query)
 
   /** Number of records allowed per query. */

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
@@ -30,7 +30,7 @@ import org.apache.openwhisk.core.entitlement.Privilege.REJECT
 import org.apache.openwhisk.common.{Logging, TransactionId, UserEvents}
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.connector.{EventMessage, Metric}
-import org.apache.openwhisk.core.controller.RejectRequest
+import org.apache.openwhisk.core.controller.{configReader1, RejectRequest}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.loadBalancer.{LoadBalancer, ShardingContainerPoolBalancer}
 import org.apache.openwhisk.http.ErrorResponse
@@ -203,9 +203,9 @@ protected[core] abstract class EntitlementProvider(
 
   private val kindRestrictor = {
     import pureconfig._
-    import pureconfig.generic.auto._
     import org.apache.openwhisk.core.ConfigKeys
     case class AllowedKinds(whitelist: Option[Set[String]] = None)
+    implicit val httpsConfigReader: ConfigReader[AllowedKinds] = configReader1(AllowedKinds)
     val allowedKinds = loadConfigOrThrow[AllowedKinds](ConfigKeys.runtimes)
     KindRestrictor(allowedKinds.whitelist)
   }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -26,7 +26,6 @@ import akka.event.Logging.InfoLevel
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.LoggingMarkers._
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector._

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/LeanBalancer.scala
@@ -30,8 +30,6 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.spi.SpiLoader
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig._
-import pureconfig.generic.auto._
-import org.apache.openwhisk.core.entity.size._
 
 import scala.concurrent.Future
 

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -29,7 +29,6 @@ import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import org.apache.kafka.clients.producer.RecordMetadata
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.WhiskConfig._
 import org.apache.openwhisk.core.connector._

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/package.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object loadBalancer extends ReflectConfigReaders {
+  implicit val httpsConfigReader: ConfigReader[ShardingContainerPoolBalancerConfig] = configReader4(
+    ShardingContainerPoolBalancerConfig)
+  implicit val clusterConfigReader: ConfigReader[ClusterConfig] = configReader1(ClusterConfig)
+
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -24,7 +24,6 @@ import akka.actor.{FSM, Props, Stash}
 import akka.event.Logging.InfoLevel
 import akka.pattern.pipe
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.collection.immutable
 import spray.json.DefaultJsonProtocol._
@@ -716,6 +715,11 @@ class ContainerProxy(factory: (TransactionId,
 }
 
 final case class ContainerProxyTimeoutConfig(idleContainer: FiniteDuration, pauseGrace: FiniteDuration)
+
+object ContainerProxyTimeoutConfig {
+  implicit val configReader: ConfigReader[ContainerProxyTimeoutConfig] = configReader2(
+    ContainerProxyTimeoutConfig.apply)
+}
 
 object ContainerProxy {
   def props(factory: (TransactionId,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerClient.scala
@@ -33,7 +33,6 @@ import scala.util.Success
 import scala.util.Try
 import akka.event.Logging.{ErrorLevel, InfoLevel}
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, MetricEmitter, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.containerpool.ContainerId

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainerFactory.scala
@@ -25,7 +25,6 @@ import scala.concurrent.Future
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.WhiskConfig
-import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.ExecManifest
 import org.apache.openwhisk.core.entity.InvokerInstanceId
@@ -34,8 +33,14 @@ import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
 
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.containerpool.{
+  Container,
+  ContainerArgsConfig,
+  ContainerFactory,
+  ContainerFactoryProvider,
+  RuntimesRegistryConfig
+}
 
 case class DockerContainerFactoryConfig(useRunc: Boolean)
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/RuncClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/RuncClient.scala
@@ -29,7 +29,6 @@ import org.apache.openwhisk.common.LoggingMarkers
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.core.ConfigKeys
 import pureconfig._
-import pureconfig.generic.auto._
 import akka.event.Logging.{ErrorLevel, InfoLevel}
 import org.apache.openwhisk.core.containerpool.ContainerId
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/StandaloneDockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/StandaloneDockerContainerFactory.scala
@@ -24,7 +24,6 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.core.containerpool.{Container, ContainerFactory, ContainerFactoryProvider}
 import org.apache.openwhisk.core.entity.{ByteSize, ExecManifest, InvokerInstanceId}
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/package.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders
+
+package object docker extends ReflectConfigReaders {
+  implicit val runcTimeoutConfigReader: ConfigReader[RuncClientTimeouts] = configReader2(RuncClientTimeouts)
+  implicit val dockerClientTimoutConfigReader: ConfigReader[DockerClientTimeoutConfig] = configReader8(
+    DockerClientTimeoutConfig)
+  implicit val dockerClientConfigReader: ConfigReader[DockerClientConfig] = configReader2(DockerClientConfig)
+  implicit val standaloneConfigReader: ConfigReader[StandaloneDockerConfig] = configReader1(StandaloneDockerConfig)
+  implicit val dockerContConfigReader: ConfigReader[DockerContainerFactoryConfig] = configReader1(
+    DockerContainerFactoryConfig)
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -41,7 +41,6 @@ import org.apache.openwhisk.core.containerpool.{ContainerAddress, ContainerId}
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.size._
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClientWithInvokerAgent.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, MessageEntity, Uri}
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.apache.openwhisk.core.ConfigKeys

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -19,7 +19,6 @@ package org.apache.openwhisk.core.containerpool.kubernetes
 
 import akka.actor.ActorSystem
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/package.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders._
+package object kubernetes {
+  implicit val agentConfigReader: ConfigReader[KubernetesInvokerAgentConfig] = configReader2(
+    KubernetesInvokerAgentConfig)
+  implicit val timoutConfigReader: ConfigReader[KubernetesClientTimeoutConfig] = configReader2(
+    KubernetesClientTimeoutConfig)
+  implicit val affinityConfigReader: ConfigReader[KubernetesInvokerNodeAffinity] = configReader3(
+    KubernetesInvokerNodeAffinity)
+  implicit val clientConfigReader: ConfigReader[KubernetesClientConfig] = configReader6(KubernetesClientConfig)
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -28,13 +28,11 @@ import org.apache.openwhisk.core.WhiskConfig._
 import org.apache.openwhisk.core.connector.{MessageProducer, MessagingProvider}
 import org.apache.openwhisk.core.containerpool.ContainerPoolConfig
 import org.apache.openwhisk.core.entity.{ActivationEntityLimit, ConcurrencyLimitConfig, ExecManifest, InvokerInstanceId}
-import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.http.{BasicHttpService, BasicRasService}
 import org.apache.openwhisk.spi.{Spi, SpiLoader}
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -36,7 +36,6 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json._
 
 import scala.concurrent.duration._

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/package.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/package.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders._
+
+package object invoker {
+  implicit val nsConfigReader: ConfigReader[NamespaceBlacklistConfig] = configReader1(NamespaceBlacklistConfig)
+}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/ApiGwLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/ApiGwLauncher.scala
@@ -23,10 +23,12 @@ import akka.pattern.RetrySupport
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.{containerName, createRunCmd}
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+
+case class RedisConfig(image: String)
+case class ApiGwConfig(image: String)
 
 class ApiGwLauncher(docker: StandaloneDockerClient, apiGwApiPort: Int, apiGwMgmtPort: Int, serverPort: Int)(
   implicit logging: Logging,
@@ -35,8 +37,6 @@ class ApiGwLauncher(docker: StandaloneDockerClient, apiGwApiPort: Int, apiGwMgmt
   tid: TransactionId)
     extends RetrySupport {
   private implicit val scd: Scheduler = actorSystem.scheduler
-  case class RedisConfig(image: String)
-  case class ApiGwConfig(image: String)
   private val redisConfig = loadConfigOrThrow[RedisConfig](StandaloneConfigKeys.redisConfigKey)
   private val apiGwConfig = loadConfigOrThrow[ApiGwConfig](StandaloneConfigKeys.apiGwConfigKey)
 

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/CouchDBLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/CouchDBLauncher.scala
@@ -35,25 +35,25 @@ import org.apache.openwhisk.http.PoolingRestClient
 import org.apache.openwhisk.http.PoolingRestClient._
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.{containerName, createRunCmd}
 import pureconfig._
-import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
+
+case class CouchDBConfig(image: String,
+                         user: String,
+                         password: String,
+                         prefix: String,
+                         volumesEnabled: Boolean,
+                         subjectViews: List[String],
+                         whiskViews: List[String],
+                         activationViews: List[String])
 
 class CouchDBLauncher(docker: StandaloneDockerClient, port: Int, dataDir: File)(implicit logging: Logging,
                                                                                 ec: ExecutionContext,
                                                                                 actorSystem: ActorSystem,
                                                                                 materializer: ActorMaterializer,
                                                                                 tid: TransactionId) {
-  case class CouchDBConfig(image: String,
-                           user: String,
-                           password: String,
-                           prefix: String,
-                           volumesEnabled: Boolean,
-                           subjectViews: List[String],
-                           whiskViews: List[String],
-                           activationViews: List[String])
   private val dbConfig = loadConfigOrThrow[CouchDBConfig](StandaloneConfigKeys.couchDBConfigKey)
   private val couchClient = new PoolingRestClient("http", StandaloneDockerSupport.getLocalHostName(), port, 100)
   private val baseHeaders: List[HttpHeader] =

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/PreFlightChecks.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/PreFlightChecks.scala
@@ -21,7 +21,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.lang3.StringUtils
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.isPortFree
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.io.AnsiColor
 import scala.sys.process._

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -34,7 +34,6 @@ import org.apache.openwhisk.core.containerpool.docker.{
 }
 import org.apache.openwhisk.core.containerpool.{ContainerAddress, ContainerId}
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -35,7 +35,6 @@ import org.apache.openwhisk.standalone.ColorOutput.clr
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.checkOrAllocatePort
 import org.rogach.scallop.ScallopConf
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/UserEventLauncher.scala
@@ -26,9 +26,10 @@ import org.apache.commons.io.{FileUtils, IOUtils}
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.standalone.StandaloneDockerSupport.{checkOrAllocatePort, containerName, createRunCmd}
 import pureconfig._
-import pureconfig.generic.auto._
 
 import scala.concurrent.{ExecutionContext, Future}
+
+case class UserEventConfig(image: String, prometheusImage: String, grafanaImage: String)
 
 class UserEventLauncher(docker: StandaloneDockerClient,
                         owPort: Int,
@@ -45,8 +46,6 @@ class UserEventLauncher(docker: StandaloneDockerClient,
   private val userEventPort = existingUserEventSvcPort.getOrElse(checkOrAllocatePort(owPort + 2))
   private val prometheusPort = checkOrAllocatePort(9090)
   private val grafanaPort = checkOrAllocatePort(3000)
-
-  case class UserEventConfig(image: String, prometheusImage: String, grafanaImage: String)
 
   private val userEventConfig = loadConfigOrThrow[UserEventConfig](StandaloneConfigKeys.userEventConfigKey)
 

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/package.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk
+
+import pureconfig.ConfigReader
+import pureconfig.module.reflect.ReflectConfigReaders._
+
+package object standalone {
+  implicit val redisConfigReader: ConfigReader[RedisConfig] = configReader1(RedisConfig)
+  implicit val gwConfigReader: ConfigReader[ApiGwConfig] = configReader1(ApiGwConfig)
+  implicit val couchConfigReader: ConfigReader[CouchDBConfig] = configReader8(CouchDBConfig)
+  implicit val eventConfigReader: ConfigReader[UserEventConfig] = configReader3(UserEventConfig)
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBTestSupport.scala
@@ -20,7 +20,6 @@ package org.apache.openwhisk.core.database.cosmosdb
 import com.microsoft.azure.cosmosdb.{Database, SqlParameter, SqlParameterCollection, SqlQuerySpec}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import pureconfig._
-import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.database.test.behavior.ArtifactStoreTestUtil.storeAvailable
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/s3/CloudFrontSignerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/s3/CloudFrontSignerTests.scala
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 import pureconfig._
-import pureconfig.generic.auto._
 
 @RunWith(classOf[JUnitRunner])
 class CloudFrontSignerTests extends FlatSpec with Matchers with OptionValues {

--- a/tests/src/test/scala/services/HeadersTests.scala
+++ b/tests/src/test/scala/services/HeadersTests.scala
@@ -51,7 +51,6 @@ import akka.http.scaladsl.model.HttpHeader
 import akka.stream.ActorMaterializer
 import common.WskActorSystem
 import pureconfig._
-import pureconfig.generic.auto._
 
 @RunWith(classOf[JUnitRunner])
 class HeadersTests extends FlatSpec with Matchers with ScalaFutures with WskActorSystem with WskTestHelpers {


### PR DESCRIPTION
This PR is based on work done as part of #4509 to figure out approaches to reduce compilation times. It uses a [new proposed approach](pureconfig/pureconfig#673) to switch to [non Shapeless](https://github.com/milessabin/shapeless) based config derivation similar to what we do with spary-json

## Description

This PR is a work in progress till the new support in Pureconfig is completed. With new approach the compilation time for `common/scala` module reduced from ~ 60 sec to ~40 sec on my laptop

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#4509)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

