### PR TITLE
Add volume mapping for Docker credentials

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -199,6 +199,7 @@ invoker:
   docker:
     become: "{{ invoker_docker_become | default(false) }}"
     runcdir: "{{ invoker_runcdir | default('/run/docker/runtime-runc/moby') }}"
+    volumes: "{{ invoker_docker_volumes | default([]) }}"
   loglevel: "{{ invoker_loglevel | default(whisk_loglevel) | default('INFO') }}"
   jmxremote:
     jvmArgs: "{% if inventory_hostname in groups['invokers'] %}

--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -346,6 +346,11 @@
     volumes: "{{ volumes|default('') }},{{ coverage_logs_dir }}/invoker:/coverage"
   when: coverage_enabled
 
+- name: set invoker docker volumes
+  set_fact:
+    volumes: "{{ volumes|default('') }},{{ invoker.docker.volumes | join(',') }}"
+  when: invoker.docker.volumes|length > 0
+
 - name: start invoker
   docker_container:
     userns_mode: "host"


### PR DESCRIPTION
Fix https://github.com/apache/openwhisk/issues/4787


## Additional information you deem important:
An operator can make invokers access to a private registry by adding this:

```
invoker_docker_volumes:
  - ~/.docker:/root/.docker
```