### PR TITLE
Check to see if the user can see the topic before creating it,

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -68,19 +68,25 @@ object KafkaMessagingProvider extends MessagingProvider {
         val nt = new NewTopic(topic, partitions, kafkaConfig.replicationFactor).configs(topicConfig.asJava)
 
         def createTopic(retries: Int = 5): Try[Unit] = {
-          Try(client.createTopics(List(nt).asJava).values().get(topic).get())
-            .map(_ => logging.info(this, s"created topic $topic"))
-            .recoverWith {
-              case CausedBy(_: TopicExistsException) =>
-                Success(logging.info(this, s"topic $topic already existed"))
-              case CausedBy(t: RetriableException) if retries > 0 =>
-                logging.warn(this, s"topic $topic could not be created because of $t, retries left: $retries")
-                Thread.sleep(1.second.toMillis)
-                createTopic(retries - 1)
-              case t =>
-                logging.error(this, s"ensureTopic for $topic failed due to $t")
-                Failure(t)
-            }
+          Try(client.listTopics().names().get())
+            .map(topics =>
+              if (topics.contains(topic)) {
+                Success(logging.info(this, s"$topic already exists and the user can see it, skipping creation."))
+              } else {
+                Try(client.createTopics(List(nt).asJava).values().get(topic).get())
+                  .map(_ => logging.info(this, s"created topic $topic"))
+                  .recoverWith {
+                    case CausedBy(_: TopicExistsException) =>
+                      Success(logging.info(this, s"topic $topic already existed"))
+                    case CausedBy(t: RetriableException) if retries > 0 =>
+                      logging.warn(this, s"topic $topic could not be created because of $t, retries left: $retries")
+                      Thread.sleep(1.second.toMillis)
+                      createTopic(retries - 1)
+                    case t =>
+                      logging.error(this, s"ensureTopic for $topic failed due to $t")
+                      Failure(t)
+                  }
+            })
         }
 
         val result = createTopic()


### PR DESCRIPTION
this allows lower privilege users to be set for the controller
and invoker.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Topics in Kafka are not part of the overall functioning of OW. In other words, there is no dynamic topic creation during the normal functioning of any OW component. Therefore there is not reason to have a credential that is powerful enough to make changes to Kafka deployed in the controller or invoker.
This commit allows those pieces to function with "least privilege" under normal operation, meaning you can now set ACLs for their topics in advance and allow them only rights to read / write the topics in question.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [X] Message Bus - only Kafka
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [X] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

