### PR TITLE
Add '_deleted' to includePaths for CosmosDB IndexingPolicy validation

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBViewMapper.scala
@@ -213,7 +213,8 @@ private[cosmosdb] object ActivationViewMapper extends SimpleMapper with WhiskIns
       includedPaths = Set(
         IncludedPath(s"/$NS/?", Index(Range, String, -1)),
         IncludedPath(s"/$computed/$NS_PATH/?", Index(Range, String, -1)),
-        IncludedPath(s"/$START/?", Index(Range, Number, -1))))
+        IncludedPath(s"/$START/?", Index(Range, Number, -1)),
+        IncludedPath(s"/$deleted/?", Index(Range, Number, -1))))
 
   override protected def where(ddoc: String,
                                view: String,


### PR DESCRIPTION
## Description
A performance improvement was made to the `activations` collection in CosmosDB to index on the soft delete path `_deleted`. This change improved performance on queries and reduces the RU usage in CosmosDB.

To align with this change, the `ActivationViewMapper`'s `IndexingPolicy` was updated to add the new path to `includePaths`. This is used to verify that the acitvations collection's policy in CosmosDB is as expected in openwhisk upon connecting.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [X] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

