### PR TITLE
Kcf - optional cpu resource scaling based on action memory

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -88,6 +88,15 @@ whisk {
     # See https://github.com/fabric8io/kubernetes-client#configuring-the-client for more information.
     # action-namespace = "ns-actions"
 
+    #scale milliCPU config per segment of memory: 100 milliCPU == .1 vcpu per https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/
+    #code will append the "m" after calculating the number of milliCPU
+    #if missing, the pod will be created without cpu request/limit (and use the default for that namespace/cluster)
+    #if specified, the pod will be created with cpu request+limit set as (action memory limit / cpu-scaling.memory) * cpu-scaling.millicpus; with max of cpu-scaling.max-millicpus and min of cpu-scaling.millicpus
+    #cpu-scaling {
+    #  millicpus = 100
+    #  memory = 256 m
+    #  max-millicpus = 4000
+    #}
   }
 
   # Timeouts for runc commands. Set to "Inf" to disable timeout.

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -37,6 +37,7 @@ import org.apache.openwhisk.core.containerpool.{
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.ExecManifest.ImageName
 import org.apache.openwhisk.core.entity.InvokerInstanceId
+import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 
 class KubernetesContainerFactory(

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
@@ -79,6 +79,20 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
       //scaled cpu is: action mem/config.mem x config.maxMillicpus
       c.getResources.getLimits.asScala.get("cpu").map(_.getAmount) shouldBe Some("600m")
     }
+
+    val config2 = KubernetesClientConfig(
+      KubernetesClientTimeoutConfig(1.second, 1.second),
+      KubernetesInvokerNodeAffinity(false, "k", "v"),
+      true,
+      None,
+      None)
+    val pod4 = builder.buildPodSpec(name, testImage, 7.MB, Map("foo" -> "bar"), Map("fooL" -> "barV"), config2)
+    withClue(Serialization.asYaml(pod4)) {
+      val c = getActionContainer(pod4)
+      //if scaling config is not provided, no cpu resources are specified
+      c.getResources.getLimits.asScala.get("cpu").map(_.getAmount) shouldBe None
+    }
+
   }
   it should "extend existing pod template" in {
     val template = """


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
Allow kubernetes operators to specify configuration to cause pods to request cpu (resources in addition to memory resources) based on scaling the configured action memory.

## Description

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

