### PR TITLE
deprecate nodejs:8 kind

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -36,7 +36,7 @@
                     "name": "action-nodejs-v8",
                     "tag": "nightly"
                 },
-                "deprecated": false,
+                "deprecated": true,
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"


### PR DESCRIPTION
EOL of NodeJS v8 was Dec 31, 2019.
