### PR TITLE
change tests to use nodejs:10 instead of nodejs:6

### DIFF
--- a/tests/dat/actions/echo.json
+++ b/tests/dat/actions/echo.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "publish": false,
     "exec": {
-        "kind": "nodejs:6",
+        "kind": "nodejs:10",
         "code": "/**\n * Returns params, or an empty string if no parameter values are provided\n */\nfunction main(params) {\n    return params || {};\n}\n\n"
     },
     "annotations": [],

--- a/tests/dat/actions/word_count.json
+++ b/tests/dat/actions/word_count.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "publish": false,
     "exec": {
-        "kind": "nodejs:6",
+        "kind": "nodejs:10",
         "code": "/**\n *  word count utility\n */\nfunction main(params) {\n    var str = params.payload.toString();\n    var words = str.split(\" \");\n    var count = words.length;\n    console.log(\"The message '\"+str+\"' has\", count, 'words');\n    return { count: count };\n}\n"
     },
     "annotations": [],

--- a/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
@@ -248,11 +248,11 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
     val subject = Subject().asString
     try {
       // set some limits
-      wskadmin.cli(Seq("limits", "set", subject, "--allowedKinds", "nodejs:6", "blackbox"))
+      wskadmin.cli(Seq("limits", "set", subject, "--allowedKinds", "nodejs:10", "blackbox"))
       // check correctly set
       val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
       lines should have size 1
-      lines(0) shouldBe "allowedKinds = [u'nodejs:6', u'blackbox']"
+      lines(0) shouldBe "allowedKinds = [u'nodejs:10', u'blackbox']"
     } finally {
       wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/EntitlementProviderTests.scala
@@ -53,7 +53,7 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
   val adminUser = WhiskAuthHelpers.newIdentity(Subject("admin"))
   val guestUser = WhiskAuthHelpers.newIdentity(Subject("anonym"))
 
-  val allowedKinds = Set("nodejs:6", "python")
+  val allowedKinds = Set("nodejs:10", "python")
   val disallowedKinds = Set("golang", "blackbox")
 
   def getExec(kind: String): Exec = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
@@ -39,7 +39,7 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
 
   behavior of "Kind Restrictor"
 
-  val allowedKinds = Set("nodejs:6", "python")
+  val allowedKinds = Set("nodejs:10", "python")
   val disallowedKinds = Set("golang", "blackbox")
   val allKinds = allowedKinds ++ disallowedKinds
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -154,7 +154,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             response = response,
             logs = logs,
             duration = Some(101L),
-            annotations = Parameters("kind", "nodejs:6") ++ Parameters(
+            annotations = Parameters("kind", "nodejs:10") ++ Parameters(
               "limits",
               ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
@@ -205,7 +205,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             response = response,
             logs = logs,
             duration = Some(101L),
-            annotations = Parameters("kind", "nodejs:6") ++ Parameters(
+            annotations = Parameters("kind", "nodejs:10") ++ Parameters(
               "limits",
               ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
@@ -317,7 +317,7 @@ class ArtifactWithFileStorageActivationStoreTests()
               response = response,
               logs = logs,
               duration = Some(101L),
-              annotations = Parameters("kind", "nodejs:6") ++ Parameters(
+              annotations = Parameters("kind", "nodejs:10") ++ Parameters(
                 "limits",
                 ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
                 Parameters("waitTime", 16.toJson) ++

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/LimitsCommandTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/LimitsCommandTests.scala
@@ -50,7 +50,7 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       "--concurrentInvocations",
       "11",
       "--allowedKinds",
-      "nodejs:6",
+      "nodejs:10",
       "blackbox",
       "--storeActivations",
       "false",
@@ -61,7 +61,7 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       invocationsPerMinute = Some(3),
       firesPerMinute = Some(7),
       concurrentInvocations = Some(11),
-      allowedKinds = Some(Set("nodejs:6", "blackbox")),
+      allowedKinds = Some(Set("nodejs:10", "blackbox")),
       storeActivations = Some(false))
 
     resultOk("limits", "set", "--invocationsPerMinute", "13", ns) shouldBe CommandMessages.limitsSuccessfullyUpdated(ns)
@@ -97,10 +97,10 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
 
   it should "update existing allowedKind limit" in {
     val ns = newNamespace()
-    resultOk("limits", "set", "--allowedKinds", "nodejs:6", ns)
-    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:6"
-    resultOk("limits", "set", "--allowedKinds", "nodejs:6", "blackbox", "python", ns)
-    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:6, blackbox, python"
+    resultOk("limits", "set", "--allowedKinds", "nodejs:10", ns)
+    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:10"
+    resultOk("limits", "set", "--allowedKinds", "nodejs:10", "blackbox", "python", ns)
+    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:10, blackbox, python"
 
     //Delete
     resultOk("limits", "delete", ns) shouldBe CommandMessages.limitsDeleted

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -116,7 +116,7 @@ class AttachmentCompatibilityTests
   it should "read existing base64 encoded code string" in {
     implicit val tid: TransactionId = transid()
     val exec = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "code": "SGVsbG8gT3BlbldoaXNr"
                |}""".stripMargin.parseJson.asJsObject
     val (id, action) = makeActionJson(namespace, aname(), exec)
@@ -129,7 +129,7 @@ class AttachmentCompatibilityTests
   it should "read existing simple code string" in {
     implicit val tid: TransactionId = transid()
     val exec = """{
-                 |  "kind": "nodejs:6",
+                 |  "kind": "nodejs:10",
                  |  "code": "while (true)"
                  |}""".stripMargin.parseJson.asJsObject
     val (id, action) = makeActionJson(namespace, aname(), exec)

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecManifestTests.scala
@@ -267,7 +267,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |{ "runtimes": {
                  |    "nodef": [
                  |      {
-                 |        "kind": "nodejs:6",
+                 |        "kind": "nodejs:10",
                  |        "deprecated": true,
                  |        "image": {
                  |          "name": "nodejsaction"
@@ -319,7 +319,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |""".stripMargin.parseJson.asJsObject
 
     val js6 = RuntimeManifest(
-      "nodejs:6",
+      "nodejs:10",
       ImageName("nodejsaction"),
       deprecated = Some(true),
       stemCells = Some(List(StemCell(1, 128.MB))))

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecTests.scala
@@ -59,7 +59,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
                  |  "updated": 1533623651650,
                  |  "entityType": "action",
                  |  "exec": {
-                 |    "kind": "nodejs:6",
+                 |    "kind": "nodejs:10",
                  |    "code": "foo",
                  |    "binary": false
                  |  },
@@ -82,7 +82,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
   it should "properly determine binary property" in {
     val j1 = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "code": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -91,7 +91,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
     }
 
     val j2 = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "code": "while (true)",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -101,7 +101,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
     //Defaults to binary
     val j3 = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "code": "while (true)"
                |}""".stripMargin.parseJson.asJsObject
     Exec.serdes.read(j3) should matchPattern {
@@ -128,7 +128,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
   it should "read code stored as jar property" in {
     val j1 = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "jar": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -143,7 +143,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
         |  "runtimes": {
         |    "nodejs": [
         |      {
-        |        "kind": "nodejs:6",
+        |        "kind": "nodejs:10",
         |        "default": true,
         |        "image": {
         |          "prefix": "openwhisk",
@@ -164,7 +164,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
       new TestConfig(Map(WhiskConfig.runtimesManifest -> oldManifestJson), ExecManifest.requiredProperties)
     ExecManifest.initialize(oldConfig)
     val j1 = """{
-               |  "kind": "nodejs:6",
+               |  "kind": "nodejs:10",
                |  "code": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
              |}""".stripMargin.parseJson.asJsObject

--- a/tests/src/test/scala/system/rest/JsonSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/JsonSchemaTests.scala
@@ -51,7 +51,7 @@ class JsonSchemaTests extends FlatSpec with Matchers with JsonSchema with RestUt
                        | "name":"foo",
                        | "version":"1.1.1",
                        | "publish":false,
-                       | "exec":{ "code": "foo", "kind": "nodejs:6" },
+                       | "exec":{ "code": "foo", "kind": "nodejs:10" },
                        | "parameters":["key1","value1"],
                        | "limits":{ "timeout":1000, "memory":200 } }""".stripMargin
     assert(check(ACTION, schema))


### PR DESCRIPTION
NodeJS 6 is long past EOL.  Need to remove uses of nodejs:6 kind from master branch...