### PR TITLE
Force filterKeys and mapValues to return a Map.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentHandler.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/DocumentHandler.scala
@@ -156,7 +156,7 @@ object ActivationHandler extends SimpleHandler {
   }
 
   private def computeActivationView(js: JsObject): JsObject = {
-    val common = js.fields.filterKeys(commonFields)
+    val common = js.fields.filterKeys(commonFields).toMap
 
     val (endTime, duration) = js.getFields("end", "start") match {
       case Seq(JsNumber(end), JsNumber(start)) if end != 0 => (JsNumber(end), JsNumber(end - start))
@@ -263,19 +263,19 @@ object WhisksHandler extends SimpleHandler {
   }
 
   private def computeTriggersView(js: JsObject): JsObject = {
-    JsObject(js.fields.filterKeys(commonFields))
+    JsObject(js.fields.filterKeys(commonFields).toMap)
   }
 
   private def computePublicPackageView(js: JsObject): JsObject = {
-    JsObject(js.fields.filterKeys(commonFields) + ("binding" -> JsFalse))
+    JsObject(js.fields.filterKeys(commonFields).toMap + ("binding" -> JsFalse))
   }
 
   private def computeRulesView(js: JsObject) = {
-    JsObject(js.fields.filterKeys(ruleFields))
+    JsObject(js.fields.filterKeys(ruleFields).toMap)
   }
 
   private def computePackageView(js: JsObject): JsObject = {
-    val common = js.fields.filterKeys(commonFields)
+    val common = js.fields.filterKeys(commonFields).toMap
     val binding = js.fields.get("binding") match {
       case Some(x: JsObject) if x.fields.nonEmpty => x
       case _                                      => JsFalse
@@ -284,7 +284,7 @@ object WhisksHandler extends SimpleHandler {
   }
 
   private def computeActionView(js: JsObject): JsObject = {
-    val base = js.fields.filterKeys(commonFields ++ Set("limits"))
+    val base = js.fields.filterKeys(commonFields ++ Set("limits")).toMap
     val exec_binary = JsHelpers.getFieldPath(js, "exec", "binary")
     JsObject(base + ("exec" -> JsObject("binary" -> exec_binary.getOrElse(JsFalse))))
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/WhiskPackage.scala
@@ -122,14 +122,8 @@ case class WhiskPackage(namespace: EntityPath,
    * for this check.
    */
   def withPackageActions(actions: List[WhiskPackageAction] = List.empty): WhiskPackageWithActions = {
-    val actionGroups = actions map { a =>
-      //  group into "actions" and "feeds"
-      val feed = a.annotations.get(Parameters.Feed) map { _ =>
-        true
-      } getOrElse false
-      (feed, a)
-    } groupBy { _._1 } mapValues { _.map(_._2) }
-    WhiskPackageWithActions(this, actionGroups.getOrElse(false, List.empty), actionGroups.getOrElse(true, List.empty))
+    val (feedActions, nonFeedActions) = actions.partition(_.annotations.get(Parameters.Feed).isDefined)
+    WhiskPackageWithActions(this, nonFeedActions, feedActions)
   }
 
   def toJson = WhiskPackage.serdes.write(this).asJsObject

--- a/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
+++ b/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
@@ -101,11 +101,11 @@ class ShootInvokerTests extends TestHelpers with WskTestHelpers with JsHelpers w
       action.create(
         name,
         Some(TestUtils.getTestActionFilename("printParams.js")),
-        parameters = params.mapValues(_.toJson))
+        parameters = params.mapValues(_.toJson).toMap)
     }
 
     val invokeParams = Map("payload" -> testString)
-    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
+    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson).toMap)
     withActivation(wsk.activation, run) { activation =>
       val logs = activation.logs.get.mkString(" ")
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1714,7 +1714,7 @@ class ContainerProxyTests
       initializeEnv.fields("__OW_TRANSACTION_ID") shouldBe transid.id.toJson
 
       val convertedAuthKey = message.user.authkey.toEnvironment.fields.map(f => ("__OW_" + f._1.toUpperCase(), f._2))
-      val authEnvironment = initializeEnv.fields.filterKeys(convertedAuthKey.contains)
+      val authEnvironment = initializeEnv.fields.filterKeys(convertedAuthKey.contains).toMap
       if (apiKeyMustBePresent) {
         convertedAuthKey shouldBe authEnvironment
       } else {
@@ -1746,7 +1746,7 @@ class ContainerProxyTests
       environment.fields("action_version") shouldBe message.action.version.toJson
       environment.fields("activation_id") shouldBe message.activationId.toJson
       environment.fields("transaction_id") shouldBe transid.id.toJson
-      val authEnvironment = environment.fields.filterKeys(message.user.authkey.toEnvironment.fields.contains)
+      val authEnvironment = environment.fields.filterKeys(message.user.authkey.toEnvironment.fields.contains).toMap
       if (apiKeyMustBePresent) {
         message.user.authkey.toEnvironment shouldBe authEnvironment.toJson.asJsObject
       } else {

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -102,11 +102,11 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
       action.create(
         name,
         Some(TestUtils.getTestActionFilename("printParams.js")),
-        parameters = params.mapValues(_.toJson))
+        parameters = params.mapValues(_.toJson).toMap)
     }
 
     val invokeParams = Map("payload" -> testString)
-    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson))
+    val run = wsk.action.invoke(name, invokeParams.mapValues(_.toJson).toMap)
     withActivation(wsk.activation, run) { activation =>
       val logs = activation.logs.get.mkString(" ")
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Scala 2.13 makes both of these return views rather than strict maps. We don't need view semantics in any of these places, so we're safe to use the proposed alternative code as seen in https://docs.scala-lang.org/overviews/core/collections-migration-213.html#what-are-the-breaking-changes.

## Related issue and scope
- [X] I opened an issue to propose and discuss this change (#4741)

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

