### PR TITLE
Replace to[Type] calls with explicit types.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBArtifactStore.scala
@@ -350,7 +350,7 @@ class CosmosDBArtifactStore[DocumentAbstraction <: DocumentSerializer](protected
     val f = Source
       .fromPublisher(publisher)
       .wireTap(collectQueryMetrics(_))
-      .mapConcat(asSeq)
+      .mapConcat(asVector)
       .drop(skip)
       .map(queryResultToWhiskJsonDoc)
       .map(js =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupport.scala
@@ -22,7 +22,6 @@ import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import org.apache.openwhisk.common.Logging
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable
 
 private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with CosmosDBUtil {
   protected def config: CosmosDBConfig
@@ -93,5 +92,5 @@ private[cosmosdb] trait CosmosDBSupport extends RxObservableImplicits with Cosmo
   protected def querySpec(id: String) =
     new SqlQuerySpec("SELECT * FROM root r WHERE r.id=@id", new SqlParameterCollection(new SqlParameter("@id", id)))
 
-  protected def asSeq[T <: Resource](r: FeedResponse[T]): immutable.Seq[T] = r.getResults.asScala.to[immutable.Seq]
+  protected def asVector[T <: Resource](r: FeedResponse[T]): Vector[T] = r.getResults.asScala.toVector
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -21,6 +21,7 @@ import java.io.IOException
 import java.net.SocketTimeoutException
 import java.time.format.DateTimeFormatterBuilder
 import java.time.{Instant, ZoneId}
+
 import akka.actor.ActorSystem
 import akka.event.Logging.ErrorLevel
 import akka.event.Logging.InfoLevel
@@ -30,6 +31,7 @@ import akka.stream.scaladsl.Source
 import akka.stream.stage._
 import akka.stream.{ActorMaterializer, Attributes, Outlet, SourceShape}
 import akka.util.ByteString
+
 import collection.JavaConverters._
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.utils.Serialization
@@ -47,7 +49,9 @@ import pureconfig._
 import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
+
 import scala.annotation.tailrec
+import scala.collection.immutable.Queue
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
@@ -330,8 +334,7 @@ object KubernetesRestLogSourceStage {
   @tailrec
   def readLines(src: BufferedSource,
                 lastTimestamp: Option[Instant],
-                lines: Seq[TypedLogLine] = Seq.empty[TypedLogLine]): Seq[TypedLogLine] = {
-
+                lines: Queue[TypedLogLine] = Queue.empty[TypedLogLine]): Queue[TypedLogLine] = {
     if (!src.exhausted()) {
       (for {
         line <- Option(src.readUtf8Line()) if !line.isEmpty

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesClientTests.scala
@@ -44,7 +44,7 @@ import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.core.containerpool.Container.ACTIVATION_LOG_SENTINEL
 
 import scala.collection.mutable
-import scala.collection.immutable
+import scala.collection.immutable.Queue
 
 @RunWith(classOf[JUnitRunner])
 class KubernetesClientTests
@@ -102,14 +102,12 @@ class KubernetesClientTests
   def firstSource(lastTimestamp: Option[Instant] = None): Source[TypedLogLine, Any] =
     Source(
       KubernetesRestLogSourceStage
-        .readLines(new Buffer().writeUtf8(firstLog), lastTimestamp, List.empty)
-        .to[immutable.Seq])
+        .readLines(new Buffer().writeUtf8(firstLog), lastTimestamp, Queue.empty))
 
   def secondSource(lastTimestamp: Option[Instant] = None): Source[TypedLogLine, Any] =
     Source(
       KubernetesRestLogSourceStage
-        .readLines(new Buffer().writeUtf8(secondLog), lastTimestamp, List.empty)
-        .to[immutable.Seq])
+        .readLines(new Buffer().writeUtf8(secondLog), lastTimestamp, Queue.empty))
 
   it should "forward suspend commands to the client" in {
     implicit val kubernetes = new TestKubernetesClient

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/KubernetesContainerTests.scala
@@ -51,7 +51,8 @@ import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.core.containerpool.docker.test.DockerContainerTests._
 
-import scala.collection.{immutable, mutable}
+import scala.collection.immutable.Queue
+import scala.collection.mutable
 
 /**
  * Unit tests for ContainerPool schedule
@@ -435,7 +436,7 @@ class KubernetesContainerTests
       override def logs(container: KubernetesContainer, sinceTime: Option[Instant], waitForSentinel: Boolean)(
         implicit transid: TransactionId): Source[TypedLogLine, Any] = {
         logCalls += ((container.id, sinceTime))
-        logSource(Seq(expectedLogEntry, expectedLogEntry), appendSentinel = false)
+        logSource(Queue(expectedLogEntry, expectedLogEntry), appendSentinel = false)
       }
     }
 
@@ -489,15 +490,15 @@ class KubernetesContainerTests
 object KubernetesContainerTests {
 
   def logSource(logLine: TypedLogLine, appendSentinel: Boolean): Source[TypedLogLine, Any] =
-    logSource(Seq(logLine), appendSentinel)
+    logSource(Queue(logLine), appendSentinel)
 
-  def logSource(logs: Seq[TypedLogLine], appendSentinel: Boolean): Source[TypedLogLine, Any] =
-    Source(toLogs(logs, appendSentinel).to[immutable.Seq])
+  def logSource(logs: Queue[TypedLogLine], appendSentinel: Boolean): Source[TypedLogLine, Any] =
+    Source(toLogs(logs, appendSentinel))
 
-  def toLogs(logLine: TypedLogLine, appendSentinel: Boolean): Seq[TypedLogLine] =
-    toLogs(Seq(logLine), appendSentinel)
+  def toLogs(logLine: TypedLogLine, appendSentinel: Boolean): Queue[TypedLogLine] =
+    toLogs(Queue(logLine), appendSentinel)
 
-  def toLogs(log: Seq[TypedLogLine], appendSentinel: Boolean): Seq[TypedLogLine] =
+  def toLogs(log: Queue[TypedLogLine], appendSentinel: Boolean): Queue[TypedLogLine] =
     if (appendSentinel) {
       val lastTime = log.lastOption.map { case TypedLogLine(time, _, _) => time }.getOrElse(Instant.EPOCH)
       log :+


### PR DESCRIPTION
## Description
Scala 2.13 dropped `to[Type]` in favor of `to(Type)` which isn't backwards compatible. To circumvent cross-compilation issues, this just changes the very little occurrences we had of that to actually use explicit typing to not need the casts at all.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
Ref #4741

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

