### PR TITLE
Simplify Cosmos query string generation.

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtilTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBUtilTest.scala
@@ -55,7 +55,7 @@ class CosmosDBUtilTest extends FlatSpec with Matchers with OptionValues {
     JsHelpers.getFieldPath(result, "b", "c").value shouldBe JsString("r['b']['c']")
   }
 
-  private def fieldsAsJson(fields: String*) = toJson(CosmosDBUtil.prepareFieldClause(fields.toList))
+  private def fieldsAsJson(fields: String*) = toJson(CosmosDBUtil.prepareFieldClause(fields.toSet))
 
   private def toJson(s: String): JsObject = {
     //Strip of last `As VIEW`


### PR DESCRIPTION
## Description
Scala 2.13 didn't like the type shenanigans going on here and my head hurt trying to understand it too. Reimplemented a hopefully equally correct version with no shenanigans.

## Related issue and scope
Ref #4741

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

