### PR TITLE
Remove usages of Unit as a value.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/RemoteCacheInvalidation.scala
@@ -65,7 +65,7 @@ class RemoteCacheInvalidation(config: WhiskConfig, component: String, instance: 
   private val cacheInvalidationProducer = msgProvider.getProducer(config)
 
   def notifyOtherInstancesAboutInvalidation(key: CacheKey): Future[Unit] = {
-    cacheInvalidationProducer.send(cacheInvalidationTopic, CacheInvalidationMessage(key, instanceId)).map(_ => Unit)
+    cacheInvalidationProducer.send(cacheInvalidationTopic, CacheInvalidationMessage(key, instanceId)).map(_ => ())
   }
 
   private val invalidationFeed = as.actorOf(Props {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/mesos/MesosContainerFactory.scala
@@ -178,7 +178,7 @@ class MesosContainerFactory(config: WhiskConfig,
       }
     })
 
-  override def init(): Unit = Unit
+  override def init(): Unit = ()
 
   /** Cleanups any remaining Containers; should block until complete; should ONLY be run at shutdown. */
   override def cleanup(): Unit = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/yarn/YARNTask.scala
@@ -64,7 +64,7 @@ class YARNTask(override protected val id: ContainerId,
   /** Dual of halt. */
   override def resume()(implicit transid: TransactionId): Future[Unit] = {
     // resume not supported
-    Future.successful(Unit)
+    Future.successful(())
   }
 
   /** Completely destroys this instance of the container. */

--- a/tools/admin/src/main/scala/org/apache/openwhisk/core/database/UserCommand.scala
+++ b/tools/admin/src/main/scala/org/apache/openwhisk/core/database/UserCommand.scala
@@ -59,7 +59,7 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
       if (s.length < 5) {
         Left(CommandMessages.shortName)
       } else {
-        Right(Unit)
+        Right(())
       }
     }
 
@@ -71,7 +71,7 @@ class UserCommand extends Subcommand("user") with WhiskCommand {
           } else if (!isUUID(uuid)) {
             Left(CommandMessages.invalidUUID)
           } else {
-            Right(Unit)
+            Right(())
           }
         case _ => Left(s"failed to determine authorization id and key: $a")
       }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Scala 2.13 forbids this and it has been ugly every since. Using the "proper" Unit value works just as well.

## Related issue and scope
Ref #4741 

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

