### PR TITLE
Use JDK 11 OpenJ9 to overcome observed performance degredations

### DIFF
--- a/common/scala/Dockerfile
+++ b/common/scala/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.3_7
+FROM adoptopenjdk/openjdk11-openj9:x86_64-alpine-jdk-11.0.6_10_openj9-0.18.1
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
## Description
Downstream tests showed major performance degradation with OpenJDK in latency and warm invocation tests which disappeared when using OpenJ9 instead.

OpenJ9 is Apache licensed.

Please see [this mail thread](https://lists.apache.org/thread.html/r6578ef3129e036911adf261382e304e145782d0633f13ff3dc9898eb%40%3Cdev.openwhisk.apache.org%3E) for more details

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#4831)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

