### PR TITLE
Replace parallel collections with future based concurrency in tests.

### DIFF
--- a/tests/src/test/scala/common/ConcurrencyHelpers.scala
+++ b/tests/src/test/scala/common/ConcurrencyHelpers.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+trait ConcurrencyHelpers {
+  def concurrently[T](times: Int, timeout: FiniteDuration)(op: => T)(implicit ec: ExecutionContext): Iterable[T] =
+    Await.result(Future.sequence((1 to times).map(_ => Future(op))), timeout)
+
+  def concurrently[B, T](over: Iterable[B], timeout: FiniteDuration)(op: B => T)(
+    implicit ec: ExecutionContext): Iterable[T] =
+    Await.result(Future.sequence(over.map(v => Future(op(v)))), timeout)
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -1161,7 +1161,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       action.publish,
       action.annotations ++ systemAnnotations(kind))
 
-    (0 until 5).par.map { i =>
+    (0 until 5).map { i =>
       Get(s"$collectionPath/$name") ~> Route.seal(routes(creds)(transid())) ~> check {
         status should be(OK)
         val response = responseAs[WhiskAction]

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/MaxActionDurationTests.scala
@@ -18,18 +18,12 @@
 package org.apache.openwhisk.core.limits
 
 import java.io.File
-import scala.concurrent.duration.DurationInt
 
+import scala.concurrent.duration.DurationInt
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-
-import common.TestHelpers
-import common.TestUtils
+import common.{ConcurrencyHelpers, TestHelpers, TestUtils, WskActorSystem, WskProps, WskTestHelpers}
 import common.rest.WskRestOperations
-import common.WskProps
-import common.WskTestHelpers
-import common.WskActorSystem
-
 import org.apache.openwhisk.core.entity._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -41,7 +35,7 @@ import org.scalatest.tagobjects.Slow
  * Tests for action duration limits. These tests require a deployed backend.
  */
 @RunWith(classOf[JUnitRunner])
-class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskActorSystem {
+class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskActorSystem with ConcurrencyHelpers {
 
   implicit val wskprops = WskProps()
   val wsk = new WskRestOperations
@@ -65,41 +59,41 @@ class MaxActionDurationTests extends TestHelpers with WskTestHelpers with WskAct
   "node-, python, and java-action" should s"run up to the max allowed duration (${TimeLimit.MAX_DURATION})" taggedAs (Slow) in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     // When you add more runtimes, keep in mind, how many actions can be processed in parallel by the Invokers!
-    Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar")
+    val runtimes = Map("node" -> "helloDeadline.js", "python" -> "sleep.py", "java" -> "sleep.jar")
       .filter {
         case (_, name) =>
           new File(TestUtils.getTestActionFilename(name)).exists()
       }
-      .par
-      .map {
-        case (k, name) =>
-          println(s"Testing action kind '${k}' with action '${name}'")
-          assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-            val main = if (k == "java") Some("Sleep") else None
-            action.create(
-              name,
-              Some(TestUtils.getTestActionFilename(name)),
-              timeout = Some(TimeLimit.MAX_DURATION),
-              main = main)
-          }
 
-          val run = wsk.action.invoke(
+    concurrently(runtimes.toSeq, TimeLimit.MAX_DURATION + 2.minutes) {
+      case (k, name) =>
+        println(s"Testing action kind '${k}' with action '${name}'")
+        assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+          val main = if (k == "java") Some("Sleep") else None
+          action.create(
             name,
-            Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson))
-          withActivation(
-            wsk.activation,
-            run,
-            initialWait = 1.minute,
-            pollPeriod = 1.minute,
-            totalWait = TimeLimit.MAX_DURATION + 2.minutes) { activation =>
-            withClue("Activation result not as expected:") {
-              activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-              activation.response.result shouldBe Some(
-                JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson))
-              activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
-            }
+            Some(TestUtils.getTestActionFilename(name)),
+            timeout = Some(TimeLimit.MAX_DURATION),
+            main = main)
+        }
+
+        val run = wsk.action.invoke(
+          name,
+          Map("forceHang" -> true.toJson, "sleepTimeInMs" -> (TimeLimit.MAX_DURATION + 30.seconds).toMillis.toJson))
+
+        withActivation(
+          wsk.activation,
+          run,
+          initialWait = 1.minute,
+          pollPeriod = 1.minute,
+          totalWait = TimeLimit.MAX_DURATION + 2.minutes) { activation =>
+          withClue("Activation result not as expected:") {
+            activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
+            activation.response.result shouldBe Some(
+              JsObject("error" -> Messages.timedoutActivation(TimeLimit.MAX_DURATION, init = false).toJson))
+            activation.duration.toInt should be >= TimeLimit.MAX_DURATION.toMillis.toInt
           }
-          () // explicitly map to Unit
-      }
+        }
+    }
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -497,7 +497,7 @@ class ShardingContainerPoolBalancerTests
     val stepSize = stepSizes(hash % stepSizes.size)
     val uuid = UUID()
     //initiate activation
-    val published = (0 until numActivations).par.map { _ =>
+    val published = (0 until numActivations).map { _ =>
       val aid = ActivationId.generate()
       val msg = ActivationMessage(
         TransactionId.testing,
@@ -545,12 +545,12 @@ class ShardingContainerPoolBalancerTests
     }
 
     //complete all
-    val acks = ids.par.map { aid =>
+    val acks = ids.map { aid =>
       val invoker = balancer.activationSlots(aid).invokerName
       completeActivation(invoker, balancer, aid)
     }
 
-    Await.ready(Future.sequence(acks.toList), 10.seconds)
+    Await.ready(Future.sequence(acks), 10.seconds)
 
     //verify invokers go back to unused state
     invokers.foreach { i =>


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Scala 2.13 puts parallel collections into a separate module that's not compatible with Scala 2.12. To avoid having to work around things and to keep cross-compilation compatibility this just exchanges the approach for concurrency in tests to not use parallel collections at all.

## Related issue and scope
Ref #4741 

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

