### PR TITLE
Update Kafka version to 2.4.0, make kafka related dependencies consistent.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -149,7 +149,7 @@ kafka:
     protocols:
     - TLSv1.2
   protocol: "{{ kafka_protocol_for_setup }}"
-  version: 2.12-2.3.1
+  version: 2.12-2.4.0
   port: 9072
   advertisedPort: 9093
   ras:

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -149,7 +149,7 @@ kafka:
     protocols:
     - TLSv1.2
   protocol: "{{ kafka_protocol_for_setup }}"
-  version: 2.12-2.4.0
+  version: 2.12-2.3.1
   port: 9072
   advertisedPort: 9093
   ras:

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile "commons-codec:commons-codec:1.9"
     compile "commons-io:commons-io:2.6"
     compile "commons-collections:commons-collections:3.2.2"
-    compile "org.apache.kafka:kafka-clients:2.0.0"
+    compile "org.apache.kafka:kafka-clients:2.4.0"
     compile "org.apache.httpcomponents:httpclient:4.5.5"
     compile "com.fasterxml.uuid:java-uuid-generator:3.1.3"
     compile "com.github.ben-manes.caffeine:caffeine:2.6.2"

--- a/core/monitoring/user-events/build.gradle
+++ b/core/monitoring/user-events/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
     testCompile "junit:junit:4.11"
     testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
+    testCompile "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
     testCompile "com.typesafe.akka:akka-stream-kafka-testkit_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
     testCompile "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     testCompile "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,7 @@ gradle.ext.scalafmt = [
 ]
 
 gradle.ext.akka = [version : '2.5.26']
-gradle.ext.akka_kafka = [version : '1.1.0']
+gradle.ext.akka_kafka = [version : '2.0.2']
 gradle.ext.akka_http = [version : '10.1.11']
 gradle.ext.akka_management = [version : '1.0.5']
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -207,8 +207,8 @@ dependencies {
     compile "io.opentracing:opentracing-mock:0.31.0"
     compile "org.apache.curator:curator-test:${gradle.curator.version}"
     compile "com.atlassian.oai:swagger-request-validator-core:1.4.5"
+    compile "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
     compile "com.typesafe.akka:akka-stream-kafka-testkit_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
-    compile "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     compile "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     compile "io.fabric8:kubernetes-server-mock:${gradle.kube_client.version}"
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
The rabbit hole started with embeddedkafka only being available on Scala 2.13 at version 2.4.0.

1. Our Kafka clients and the used Kafka version doesn't match. That's not necessarily an issue but I think we should use matching versions unless we've seen issues there.
2. Updated akka-kafka to the latest and greatest.

## Related issue and scope
Ref #4741 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] Message Bus (e.g., Kafka)

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

