### PR TITLE
Fix slight compilation differences between Scala 2.12 -> 2.13.

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -701,7 +701,8 @@ class ContainerProxy(factory: (TransactionId,
       case data: WarmedData =>
         Future.successful(None)
       case _ =>
-        val owEnv = (authEnvironment ++ environment + ("deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)) map {
+        val owEnv = (authEnvironment ++ environment ++ Map(
+          "deadline" -> (Instant.now.toEpochMilli + actionTimeout.toMillis).toString.toJson)) map {
           case (key, value) => "__OW_" + key.toUpperCase -> value
         }
 

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -204,7 +204,7 @@ class StandaloneDockerClient(pullDisabled: Boolean)(implicit log: Logging, as: A
     with WindowsDockerClient {
 
   override def pull(image: String)(implicit transid: TransactionId): Future[Unit] = {
-    if (pullDisabled) Future.successful(Unit) else super.pull(image)
+    if (pullDisabled) Future.successful(()) else super.pull(image)
   }
 
   override def runCmd(args: Seq[String], timeout: Duration)(implicit transid: TransactionId): Future[String] =

--- a/tests/src/test/scala/common/RunCliCmd.scala
+++ b/tests/src/test/scala/common/RunCliCmd.scala
@@ -75,14 +75,13 @@ trait RunCliCmd extends Matchers {
       params.filter(s =>
         !s.equals("--auth") && !(params.indexOf(s) > 0 && params(params.indexOf(s) - 1).equals("--auth")))
     }
-    if (showCmd) println(args.mkString(" ") + " " + finalParams.mkString(" "))
+    args.appendAll(finalParams)
+    if (showCmd) println(args.mkString(" "))
 
-    val rr = retry(
-      0,
-      retriesOnNetworkError,
-      () => runCmd(DONTCARE_EXIT, workingDir, sys.env ++ env, stdinFile, args ++ finalParams))
+    val rr =
+      retry(0, retriesOnNetworkError, () => runCmd(DONTCARE_EXIT, workingDir, sys.env ++ env, stdinFile, args.toSeq))
 
-    withClue(hideStr(reportFailure(args ++ finalParams, expectedExitCode, rr).toString(), hideFromOutput)) {
+    withClue(hideStr(reportFailure(args, expectedExitCode, rr).toString(), hideFromOutput)) {
       if (expectedExitCode != TestUtils.DONTCARE_EXIT) {
         val ok = (rr.exitCode == expectedExitCode) || (expectedExitCode == TestUtils.ANY_ERROR_EXIT && rr.exitCode != 0)
         if (!ok) {

--- a/tests/src/test/scala/common/rest/SwaggerValidator.scala
+++ b/tests/src/test/scala/common/rest/SwaggerValidator.scala
@@ -106,6 +106,7 @@ trait SwaggerValidator {
       .asScala
       .filter(m => m.getLevel == ValidationReport.Level.ERROR)
       .map(_.toString)
+      .toSeq
   }
 
   def strictEntityBodyAsString(entity: HttpEntity): String = entity match {

--- a/tests/src/test/scala/org/apache/openwhisk/common/SchedulerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/SchedulerTests.scala
@@ -98,7 +98,7 @@ class SchedulerTests extends FlatSpec with Matchers with WskActorSystem with Str
     waitForCalls()
     scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
+    val differences = calculateDifferences(calls.toSeq)
     withClue(s"expecting all $differences to be >= $timeBetweenCalls") {
       differences.forall(_ >= timeBetweenCalls)
     }
@@ -158,7 +158,7 @@ class SchedulerTests extends FlatSpec with Matchers with WskActorSystem with Str
     waitForCalls(interval = timeBetweenCalls)
     scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
+    val differences = calculateDifferences(calls.toSeq)
     withClue(s"expecting all $differences to be <= $timeBetweenCalls") {
       differences should not be 'empty
       differences.forall(_ <= timeBetweenCalls + schedulerSlack)
@@ -221,7 +221,7 @@ class SchedulerTests extends FlatSpec with Matchers with WskActorSystem with Str
     waitForCalls(interval = timeBetweenCalls)
     scheduled ! PoisonPill
 
-    val differences = calculateDifferences(calls)
+    val differences = calculateDifferences(calls.toSeq)
     withClue(s"expecting all $differences to be <= $computationTime") {
       differences should not be 'empty
       differences.forall(_ <= computationTime + schedulerSlack)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
@@ -119,7 +119,7 @@ class DockerContainerFactoryTests
     (dockerApiStub
       .rm(_: ContainerId)(_: TransactionId))
       .expects(ContainerId("fakecontainerid"), *)
-      .returning(Future.successful(Unit))
+      .returning(Future.successful(()))
     //setup clientVersion exceptation
     (dockerApiStub.clientVersion _)
       .expects()

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -263,7 +263,7 @@ class ContainerProxyTests
   }
 
   def createCollector(response: Future[ActivationLogs] = Future.successful(ActivationLogs()),
-                      invokeCallback: () => Unit = () => Unit) =
+                      invokeCallback: () => Unit = () => ()) =
     new LoggedCollector(response, invokeCallback)
 
   def createStore = LoggedFunction { (transid: TransactionId, activation: WhiskActivation, context: UserContext) =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -293,7 +293,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskPackageWithActions]
-      response should be(provider withActions ())
+      response should be(provider.withActions())
     }
   }
 
@@ -308,7 +308,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskPackageWithActions]
-      response should be(provider copy (updated = pkg.updated) withActions ())
+      response should be(provider.copy(updated = pkg.updated).withActions())
     }
   }
 
@@ -321,7 +321,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Get(s"$collectionPath/${reference.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(OK)
       val response = responseAs[WhiskPackageWithActions]
-      response should be(reference inherit provider.parameters withActions ())
+      response should be(reference.inherit(provider.parameters).withActions())
       // this is redundant in case the precedence orders on inherit are changed incorrectly
       response.wp.parameters should be(Parameters("a", "A") ++ Parameters("b", "b") ++ Parameters("c", "C"))
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupportTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/CosmosDBSupportTests.scala
@@ -108,7 +108,7 @@ class CosmosDBSupportTests
 
   private def newMapper(paths: Set[String]) = {
     val mapper = stub[CosmosDBViewMapper]
-    mapper.indexingPolicy _ when () returns newTestIndexingPolicy(paths)
+    (mapper.indexingPolicy _).when().returns(newTestIndexingPolicy(paths))
     mapper
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
A selection of small compilation differences between 2.12 to 2.13, most notably:
- Removing the last Unit values
- Fix usages of mutable collections as `Seq` to explicitly call that out (`toSeq`).
- Infix and Postfix notation removal in places where the 2.13 compiler stumbles.

**Note:** This is the last PR needed to make 2.13 fully compilable 😀 

## Related issue and scope
Ref #4741 

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

