### PR TITLE
Remove explicit right biasing of Eithers.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Prometheus.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Prometheus.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.common
 import java.nio.charset.StandardCharsets.UTF_8
 
-import akka.http.scaladsl.model.{ContentType, HttpEntity}
+import akka.http.scaladsl.model.{ContentType, HttpCharsets, HttpEntity, MediaType}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import kamon.Kamon
@@ -26,7 +26,8 @@ import kamon.prometheus.PrometheusReporter
 
 class KamonPrometheus extends AutoCloseable {
   private val reporter = new PrometheusReporter
-  private val v4 = ContentType.parse("text/plain; version=0.0.4; charset=utf-8").right.get
+  private val v4: ContentType = ContentType.apply(
+    MediaType.textWithFixedCharset("plain", HttpCharsets.`UTF-8`).withParams(Map("version" -> "0.0.4")))
   Kamon.registerModule("prometheus", reporter)
 
   def route: Route = path("metrics") {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -261,7 +261,7 @@ case class Interval(start: Instant, end: Instant) {
 }
 
 case class RunResult(interval: Interval, response: Either[ContainerConnectionError, ContainerResponse]) {
-  def ok = response.right.exists(_.ok)
+  def ok = response.exists(_.ok)
   def toBriefString = response.fold(_.toString, _.toString)
 }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -160,9 +160,7 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
    */
   protected[core] def processInitResponseContent(response: Either[ContainerConnectionError, ContainerResponse],
                                                  logger: Logging): ActivationResponse = {
-    require(
-      response.isLeft || !response.right.exists(_.ok),
-      s"should not interpret init response when status code is OK")
+    require(response.isLeft || !response.exists(_.ok), s"should not interpret init response when status code is OK")
     response match {
       case Right(ContainerResponse(code, str, truncated)) =>
         val sizeOpt = Option(str).map(_.length)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
@@ -22,7 +22,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.apache.openwhisk.core.entity.size._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 object Attachments {
 
@@ -66,11 +66,13 @@ object Attachments {
     implicit val serdes = {
       implicit val contentTypeSerdes = new RootJsonFormat[ContentType] {
         override def write(c: ContentType) = JsString(c.value)
-        override def read(js: JsValue) = {
+
+        override def read(js: JsValue): ContentType = {
           Try(js.convertTo[String]).toOption.flatMap(ContentType.parse(_).toOption).getOrElse {
             throw new DeserializationException("Could not deserialize content-type")
           }
         }
+      }
 
       jsonFormat4(Attached.apply)
     }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/Attachments.scala
@@ -67,11 +67,10 @@ object Attachments {
       implicit val contentTypeSerdes = new RootJsonFormat[ContentType] {
         override def write(c: ContentType) = JsString(c.value)
         override def read(js: JsValue) = {
-          Try(js.convertTo[String])
-            .flatMap(ContentType.parse(_).fold(_ => Failure(new Exception("failed to parse content-type")), Success(_)))
-            .getOrElse(throw new DeserializationException("Could not deserialize content-type"))
+          Try(js.convertTo[String]).toOption.flatMap(ContentType.parse(_).toOption).getOrElse {
+            throw new DeserializationException("Could not deserialize content-type")
+          }
         }
-      }
 
       jsonFormat4(Attached.apply)
     }

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.core.monitoring.metrics
 
 import akka.http.scaladsl.model.StatusCodes.ServiceUnavailable
-import akka.http.scaladsl.model.{ContentType, HttpCharset, HttpCharsets, MediaType, MessageEntity}
+import akka.http.scaladsl.model.{ContentType, HttpCharsets, MediaType, MessageEntity}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.connector.kafka.KafkaMetricRoute

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusEventsApi.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.core.monitoring.metrics
 
 import akka.http.scaladsl.model.StatusCodes.ServiceUnavailable
-import akka.http.scaladsl.model.{ContentType, MessageEntity}
+import akka.http.scaladsl.model.{ContentType, HttpCharset, HttpCharsets, MediaType, MessageEntity}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import org.apache.openwhisk.connector.kafka.KafkaMetricRoute
@@ -30,7 +30,8 @@ trait PrometheusExporter {
 }
 
 object PrometheusExporter {
-  val textV4: ContentType = ContentType.parse("text/plain; version=0.0.4; charset=utf-8").right.get
+  val textV4: ContentType = ContentType.apply(
+    MediaType.textWithFixedCharset("plain", HttpCharsets.`UTF-8`).withParams(Map("version" -> "0.0.4")))
 }
 
 class PrometheusEventsApi(consumer: EventConsumer, prometheus: PrometheusExporter)(implicit ec: ExecutionContext) {

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/ExtendedCouchDbRestClient.scala
@@ -46,9 +46,8 @@ class ExtendedCouchDbRestClient(protocol: String,
 
   // http://docs.couchdb.org/en/1.6.1/api/server/common.html#all-dbs
   def dbs(): Future[Either[StatusCode, List[String]]] = {
-    requestJson[JsArray](mkRequest(HttpMethods.GET, uri("_all_dbs"), headers = baseHeaders)).map { either =>
-      either.right.map(_.convertTo[List[String]])
-    }
+    requestJson[JsArray](mkRequest(HttpMethods.GET, uri("_all_dbs"), headers = baseHeaders))
+      .map(_.map(_.convertTo[List[String]]))
   }
 
   // http://docs.couchdb.org/en/1.6.1/api/database/common.html#put--db


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Since Scala 2.12, [Either has been right biased](https://www.scala-lang.org/api/2.12.0/scala/util/Either.html) so explicitly calling `.right` before mapping etc is not necessary. Scala 2.13 deprecates this usage so... let's get rid of it now.

This also removes usages of `.right.get` for the same reason and to drop potential error cases where there are none.

No semantic change intended.

## Related issue and scope
Ref #4741 

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

