### PR TITLE
Fix deprecated override warning in ResourceLeakDetector.

### DIFF
--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/RecordingLeakDetectorFactory.java
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/RecordingLeakDetectorFactory.java
@@ -24,6 +24,7 @@ import org.apache.openwhisk.common.Counter;
 public class RecordingLeakDetectorFactory extends ResourceLeakDetectorFactory {
     static final Counter counter = new Counter();
     @Override
+    @SuppressWarnings("deprecation")
     public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval, long maxActive) {
         return new RecordingLeakDetector<T>(counter, resource, samplingInterval);
     }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
This class yields an annoying compiler warning like:

```
Note: /Users/mthoemme/dev/openwhisk/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/RecordingLeakDetectorFactory.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

Sadly, we need to override the method as it is abstract. Suppressing the warning should be fine in that case.

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

