### PR TITLE
change the kubernetes pod wait logic to use akka after pattern 

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -27,6 +27,7 @@ import akka.event.Logging.ErrorLevel
 import akka.event.Logging.InfoLevel
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.pattern.after
 import akka.stream.scaladsl.Source
 import akka.stream.stage._
 import akka.stream.{ActorMaterializer, Attributes, Outlet, SourceShape}
@@ -69,6 +70,12 @@ case class KubernetesClientTimeoutConfig(run: FiniteDuration, logs: FiniteDurati
 case class KubernetesCpuScalingConfig(millicpus: Int, memory: ByteSize, maxMillicpus: Int)
 
 /**
+ * Exception to indicate a pod took too long to become ready.
+ */
+case class KubernetesPodReadyTimeoutException(timeout: FiniteDuration)
+    extends Exception(s"Pod readiness timed out after ${timeout.toSeconds}s")
+
+/**
  * Configuration for node affinity for the pods that execute user action containers
  * The key,value pair should match the <key,value> pair with which the invoker worker nodes
  * are labeled in the Kubernetes cluster.  The default pair is <openwhisk-role,invoker>,
@@ -101,6 +108,7 @@ class KubernetesClient(
     with ProcessRunner {
   implicit protected val ec = executionContext
   implicit protected val am = ActorMaterializer()
+  implicit protected val scheduler = as.scheduler
   implicit protected val kubeRestClient = {
     val configBuilder = new ConfigBuilder()
       .withConnectionTimeout(config.timeouts.logs.toMillis.toInt)
@@ -129,7 +137,7 @@ class KubernetesClient(
       logLevel = akka.event.Logging.InfoLevel)
 
     //create the pod; catch any failure to end the transaction timer
-    try {
+    val createdPod = try {
       kubeRestClient.pods.inNamespace(namespace).create(pod)
     } catch {
       case e: Throwable =>
@@ -137,17 +145,10 @@ class KubernetesClient(
         throw e
     }
     //wait for the pod to become ready; catch any failure to end the transaction timer
-    Future {
-      blocking {
-        val createdPod = kubeRestClient.pods
-          .inNamespace(namespace)
-          .withName(name)
-          .waitUntilReady(config.timeouts.run.length, config.timeouts.run.unit)
-        toContainer(createdPod)
-      }
-    }.map { container =>
+    waitForPod(namespace, createdPod, start.start, config.timeouts.run)
+      .map { readyPod =>
         transid.finished(this, start, logLevel = InfoLevel)
-        container
+        toContainer(readyPod)
       }
       .recoverWith {
         case e =>
@@ -273,6 +274,29 @@ class KubernetesClient(
     val nativeContainerId = pod.getStatus.getContainerStatuses.get(0).getContainerID.stripPrefix("docker://")
     implicit val kubernetes = this
     new KubernetesContainer(id, addr, workerIP, nativeContainerId, portFwd)
+  }
+  // check for ready status every 1 second until timeout (minus the start time, which is the time for the pod create call) has past
+  private def waitForPod(namespace: String,
+                         pod: Pod,
+                         start: Instant,
+                         timeout: FiniteDuration,
+                         deadlineOpt: Option[Deadline] = None): Future[Pod] = {
+    val readyPod = kubeRestClient
+      .pods()
+      .inNamespace(namespace)
+      .withName(pod.getMetadata.getName)
+    val deadline = deadlineOpt.getOrElse((timeout - (System.currentTimeMillis() - start.toEpochMilli).millis).fromNow)
+    if (!readyPod.isReady) {
+      if (deadline.isOverdue()) {
+        Future.failed(KubernetesPodReadyTimeoutException(timeout))
+      } else {
+        after(1.seconds, scheduler) {
+          waitForPod(namespace, pod, start, timeout, Some(deadline))
+        }
+      }
+    } else {
+      Future.successful(readyPod.get())
+    }
   }
 }
 


### PR DESCRIPTION
instead of fabric8 client waitUntilReady. See discussion in #4812


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
This allows more precision for config specified at `whisk.kubernetes.timeouts.run`


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4812)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

