### PR TITLE
Fix scala usage in :tools:admin and :core:standalone.

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -152,6 +152,7 @@ bootJar {
 install.dependsOn(bootJar)
 
 dependencies {
+    compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':core:controller')
     compile project(':tools:admin')
     compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
@@ -162,10 +163,6 @@ dependencies {
 
     testCompile "junit:junit:4.11"
     testCompile "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }
 
 gradle.projectsEvaluated {

--- a/tools/admin/build.gradle
+++ b/tools/admin/build.gradle
@@ -42,10 +42,7 @@ bootJar {
 }
 
 dependencies {
+    compile "org.scala-lang:scala-library:${gradle.scala.version}"
     compile project(':common:scala')
     compile "org.rogach:scallop_${gradle.scala.depVersion}:3.3.2"
-}
-
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = gradle.scala.compileFlags
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description

Scala 2.13 compilation breaks horribly if these are not set accordingly. Arguably, they are kinda wrong anyway as the top-level is supposed to set the compiler flags and these projects clearly depend on the scala library.

## Related issue and scope
Ref #4741 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] General tooling

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

