### PR TITLE
Use 'iterator' instead of 'toIterator'.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/ActivationFileStorage.scala
@@ -127,7 +127,7 @@ class ActivationFileStorage(logFilePrefix: String,
 
     // Write each log line to file and then write the activation metadata
     Source
-      .fromIterator(() => transcribedLogs.toIterator)
+      .fromIterator(() => transcribedLogs.iterator)
       .runWith(Flow[ByteString].concat(Source.single(transcribedActivation)).to(writeToFile))
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description

`toIterator` is deprecated in 2.13 and it's an alias anyway.

## Related issue and scope
Ref #4741 

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

