### PR TITLE
Allow build to use either Scala 2.12 or 2.13 and test that in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,9 @@ install:
 jobs:
   include:
     - script:
+        - TERM=dumb OW_SCALA_VERSION=2.13 ./gradlew :tests:compileTestScala
+      name: "Scala 2.13 compilation"
+    - script:
         - ./tools/travis/runUnitTests.sh
         - ./tools/travis/checkAndUploadLogs.sh unit db
       name: "Unit Tests"

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,11 +34,26 @@ include 'tools:admin'
 
 rootProject.name = 'openwhisk'
 
-gradle.ext.scala = [
-    version: '2.12.10',
-    depVersion: '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
+
+def scalaVersion = System.getenv().getOrDefault('OW_SCALA_VERSION', '2.12')
+
+if (scalaVersion == '2.12') {
+    println("Build using Scala 2.12")
+    gradle.ext.scala = [
+            version     : '2.12.10',
+            depVersion  : '2.12',
+            compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
+    ]
+} else {
+    println("Build using Scala 2.13")
+    gradle.ext.scala = [
+            version     : '2.13.1',
+            depVersion  : '2.13',
+            // We can't use fatal warnings yet because there are deprecated things in 2.13 that are not fixable
+            // in 2.12.
+            compileFlags: ['-feature', '-unchecked', '-deprecation']
+    ]
+}
 
 gradle.ext.scalafmt = [
     version: '1.5.0',


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Running a build with the `OW_SCALA_VERSION` environment variable set now allows you to switch between building with 2.12 and 2.13 to allow for a smooth migration in downstream systems to 2.13 and to allow us to try it out "in the wild" more easily.

## Related issue and scope
Ref #4741 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] General tooling

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.

