### PR TITLE
Fix warnings in travis file, remove scala again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,10 @@
 # limitations under the License.
 #
 
-sudo: required
-
+os: linux
 dist: xenial
-
-language: scala
-scala:
-   - 2.12.7
-
-jdk:
-  - openjdk11
+language: java
+jdk: openjdk11
 
 services:
   - docker
@@ -75,8 +69,8 @@ jobs:
         - ./tools/travis/checkAndUploadLogs.sh unit db
       name: "Unit Tests"
     - script:
-       - ./tools/travis/runSystemTests.sh
-       - ./tools/travis/checkAndUploadLogs.sh system
+      - ./tools/travis/runSystemTests.sh
+      - ./tools/travis/checkAndUploadLogs.sh system
       name: "System Tests"
     - script:
       - ./tools/travis/runMultiRuntimeTests.sh


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
- I had already removed the not-needed Scala stanza in #4737 but it got added back, possibly due to merge issues?
- Removed `sudo:`, it has no effect.
- Added explicit `os:` stanza.
- Fixed bad indentation.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [X] General tooling

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).

