### PR TITLE
Updates repo diagram to reflect current components

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,32 @@ interested in:
 
 ### Repository Structure
 
-The OpenWhisk system is built from a [number of components](docs/dev/modules.md).  The picture below groups the components by their GitHub repos. Please open issues for a component against the appropriate repo (if in doubt just open against the main openwhisk repo).
+The OpenWhisk system is built from a [number of components](docs/dev/modules.md).  The charts below group the components by their GitHub repos. Please open issues for a component against the appropriate repo (if in doubt just open against the main openwhisk repo).
 
-![component/repo mapping](docs/images/components_to_repos.png)
+#### Main
+
+| openwhisk | Runtimes | API Management | Catalog | Packages | Clients
+|---    |---    |---    |---    |---    |---
+|ansible  |openwhisk-runtime-ballerina  |openwhisk-api-gateway  |github  |openwhisk-package-alarms  |openwhisk-client-go
+|controller  |openwhisk-runtime-docker  |  |slack  |openwhisk-package-cloudant  |openwhisk-client-js
+|couchdb  |openwhisk-runtime-dotnet  |  |utils  |openwhisk-package-kafka  |
+|docs  |openwhisk-runtime-go  |  |weather  |openwhisk-package-pushnotifications  |
+|invoker  |openwhisk-runtime-java  |  |websocket  |  |
+|kafka  |openwhisk-runtime-nodejs  |  |samples  |  |
+|   |openwhisk-runtime-php   |  |  |  |
+|  |openwhisk-runtime-python  |  |  |  |
+|   |openwhisk-runtime-ruby  |  |  |  |
+|   |openwhisk-runtime-rust  |  |  |  |
+|*openwhisk-deploy-kube*  |openwhisk-runtime-swift  |  |  |  |
+
+#### Other Components
+
+| Tools | Composers | Utilities | Other
+|---    |---    |---    |---
+|openwhisk-cli  |openwhisk-composer-javascript  |openwhisk-utilities-scancode  |openwhisk-pluggable-provider
+|openwhisk-release  |openwhisk-composer-python  |  |openwhisk-slackinvite
+|openwhisk-wskdebug  |  |  |openwhisk-test
+|openwhisk-wskdeploy  |  |  |openwhisk-website
 
 ### Issues
 


### PR DESCRIPTION
## Description
Fixes issue #3553: This change converts the repo diagram to two tables instead of a static image. It updates the components to reflect components that are active today. After discussion with @mrutkows, we decided to use a markdown table instead of an image to promote maintainability.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#???)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.