### PR TITLE
add activationId to events message

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -289,6 +289,7 @@ object EventMessageBody extends DefaultJsonProtocol {
 }
 
 case class Activation(name: String,
+                      activationId: String,
                       statusCode: Int,
                       duration: Duration,
                       waitTime: Duration,
@@ -338,6 +339,7 @@ object Activation extends DefaultJsonProtocol {
     jsonFormat(
       Activation.apply _,
       "name",
+      "activationId",
       "statusCode",
       "duration",
       "waitTime",
@@ -375,6 +377,7 @@ object Activation extends DefaultJsonProtocol {
     } yield {
       Activation(
         fqn,
+        a.activationId.asString,
         a.response.statusCode,
         toDuration(a.duration.getOrElse(0)),
         toDuration(a.annotations.getAs[Long](WhiskActivation.waitTimeAnnotation).getOrElse(0)),

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
@@ -25,7 +25,7 @@ import kamon.module.MetricReporter
 import kamon.Kamon
 import kamon.tag.Lookups
 import org.apache.openwhisk.core.connector.{Activation, EventMessage}
-import org.apache.openwhisk.core.entity.{ActivationResponse, Subject, UUID}
+import org.apache.openwhisk.core.entity.{ActivationId, ActivationResponse, Subject, UUID}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
@@ -118,7 +118,17 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
   private def newActivationEvent(actionPath: String) =
     EventMessage(
       "test",
-      Activation(actionPath, 2, 3.millis, 5.millis, 11.millis, kind, false, memory, None),
+      Activation(
+        actionPath,
+        ActivationId.generate().asString,
+        2,
+        3.millis,
+        5.millis,
+        11.millis,
+        kind,
+        false,
+        memory,
+        None),
       Subject("testuser"),
       initiator,
       UUID("test"),

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
@@ -19,7 +19,7 @@ package org.apache.openwhisk.core.monitoring.metrics
 
 import io.prometheus.client.CollectorRegistry
 import org.apache.openwhisk.core.connector.{Activation, EventMessage}
-import org.apache.openwhisk.core.entity.{ActivationResponse, Subject, UUID}
+import org.apache.openwhisk.core.entity.{ActivationId, ActivationResponse, Subject, UUID}
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.junit.JUnitRunner
@@ -83,7 +83,17 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
   private def newActivationEvent(actionPath: String, kind: String, memory: String) =
     EventMessage(
       "test",
-      Activation(actionPath, 2, 1254.millis, 30.millis, 433433.millis, kind, false, memory.toInt, None),
+      Activation(
+        actionPath,
+        ActivationId.generate().asString,
+        2,
+        1254.millis,
+        30.millis,
+        433433.millis,
+        kind,
+        false,
+        memory.toInt,
+        None),
       Subject("testuser"),
       initiator,
       UUID("test"),

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/test/EventMessageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/test/EventMessageTests.scala
@@ -40,11 +40,12 @@ class EventMessageTests extends FlatSpec with Matchers {
 
   behavior of "Activation"
 
+  val activationId = ActivationId.generate()
   val fullActivation = WhiskActivation(
     namespace = EntityPath("ns"),
     name = EntityName("a"),
     Subject(),
-    activationId = ActivationId.generate(),
+    activationId = activationId,
     start = Instant.now(),
     end = Instant.now(),
     response = ActivationResponse.success(Some(JsObject("res" -> JsNumber(1))), Some(42)),
@@ -60,6 +61,7 @@ class EventMessageTests extends FlatSpec with Matchers {
     Activation.from(fullActivation) shouldBe Success(
       Activation(
         "ns2/a",
+        activationId.asString,
         0,
         toDuration(123),
         toDuration(5),
@@ -87,7 +89,18 @@ class EventMessageTests extends FlatSpec with Matchers {
             "ns2/a"))
 
     Activation.from(a) shouldBe Success(
-      Activation("ns2/a", 0, toDuration(0), toDuration(0), toDuration(0), "testkind", false, 0, None, Some(42)))
+      Activation(
+        "ns2/a",
+        activationId.asString,
+        0,
+        toDuration(0),
+        toDuration(0),
+        toDuration(0),
+        "testkind",
+        false,
+        0,
+        None,
+        Some(42)))
   }
 
   it should "Transform a activation with status code" in {

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationCompatTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ActivationCompatTests.scala
@@ -145,6 +145,7 @@ class ActivationCompatTests extends FlatSpec with Matchers with WhiskInstants wi
   val activationJs = """
      |{
      |  "causedBy": "sequence",
+     |  "activationId": "be97c2fed5dc43d097c2fed5dc73d085",
      |  "conductor": false,
      |  "duration": 123,
      |  "initTime": 10,
@@ -159,6 +160,7 @@ class ActivationCompatTests extends FlatSpec with Matchers with WhiskInstants wi
     """
       |{
       |  "userDefinedStatusCode": 404,
+      |  "activationId": "be97c2fed5dc43d097c2fed5dc73d085",
       |  "causedBy": "sequence",
       |  "conductor": false,
       |  "duration": 123,


### PR DESCRIPTION
## Description

This change adds the activationId to messages on the events topic of type `Activation`. This is useful for external services that listen in on the events topic that may want to make reference to the activations
it is consuming.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

