### PR TITLE
Add RestartSource to restart failing Kafka consumer for user-events service

### DIFF
--- a/core/monitoring/user-events/src/main/resources/application.conf
+++ b/core/monitoring/user-events/src/main/resources/application.conf
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+akka.kafka.committer {
+
+  max-batch = 20
+
+}
+
 akka.kafka.consumer {
   # Properties defined by org.apache.kafka.clients.consumer.ConsumerConfig
   # can be defined in this configuration section.

--- a/core/monitoring/user-events/src/main/resources/reference.conf
+++ b/core/monitoring/user-events/src/main/resources/reference.conf
@@ -31,5 +31,21 @@ whisk {
       # rename/relabel prometheus metrics tags
       # "namespace" = "ow_namespae"
     }
+
+    retry {
+      # minimum (initial) duration until the Kafka consumer is started again if it is terminated
+      min-backoff = 3 secs
+
+      # the exponential back-off is capped to this duration
+      max-backoff = 30 secs
+
+      # after calculation of the exponential back-off an additional
+      # random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay
+      random-factor = 0.2
+
+      # the amount of restarts is capped to this amount within a time frame of minBackoff
+      max-restarts = 10
+    }
+
   }
 }

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/OpenWhiskEvents.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import pureconfig._
 import pureconfig.generic.auto._
 
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 object OpenWhiskEvents extends SLF4JLogging {
@@ -36,7 +37,10 @@ object OpenWhiskEvents extends SLF4JLogging {
   case class MetricConfig(port: Int,
                           enableKamon: Boolean,
                           ignoredNamespaces: Set[String],
-                          renameTags: Map[String, String])
+                          renameTags: Map[String, String],
+                          retry: RetryConfig)
+
+  case class RetryConfig(minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)
 
   def start(config: Config)(implicit system: ActorSystem,
                             materializer: ActorMaterializer): Future[Http.ServerBinding] = {

--- a/core/monitoring/user-events/src/test/resources/application.conf
+++ b/core/monitoring/user-events/src/test/resources/application.conf
@@ -29,4 +29,20 @@ user-events {
   rename-tags {
     #namespace = "ow_namespace"
   }
+
+  retry {
+    # minimum (initial) duration until the Kafka consumer is started again if it is terminated
+    min-backoff = 3 secs
+
+    # the exponential back-off is capped to this duration
+    max-backoff = 30 secs
+
+    # after calculation of the exponential back-off an additional
+    # random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay
+    random-factor = 0.2
+
+    # the amount of restarts is capped to this amount within a time frame of minBackoff
+    max-restarts = 10
+  }
+
 }

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
@@ -99,6 +99,12 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
             |    rename-tags {
             |      namespace = "ow_namespace"
             |    }
+            |    retry {
+            |      min-backoff = 3 secs
+            |      max-backoff = 30 secs
+            |      random-factor = 0.2
+            |      max-restarts = 10
+            |    }
             |  }
             | }
          """.stripMargin)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
If there is a problem with the Kafka consumer, it no longer sends metrics. Because there is no error handling for user-events's Kafka consumer.

https://doc.akka.io/docs/alpakka-kafka/current/errorhandling.html

So I've added RestartSource to restart a failing consumer.


## Related issue and scope
- no related issue

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
-  User events

## Types of changes
- Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

