### PR TITLE
CosmosDB cache invalidator refactor

### DIFF
--- a/core/cosmosdb/cache-invalidator/src/main/resources/application.conf
+++ b/core/cosmosdb/cache-invalidator/src/main/resources/application.conf
@@ -20,5 +20,7 @@ akka.kafka.producer {
   # can be defined in this configuration section.
   kafka-clients {
     bootstrap.servers = ${?KAFKA_HOSTS}
+    //change the default producer timeout so that it will quickly fail when kafka topic cannot be written
+    max.block.ms = 2000
   }
 }

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/ChangeFeedConsumer.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/ChangeFeedConsumer.scala
@@ -100,14 +100,13 @@ class ChangeFeedConsumer(collName: String, config: CacheInvalidatorConfig, obser
       .map { p =>
         // be careful about exceptions thrown during ChangeFeedProcessor.stop()
         // e.g. calling stop() before start() completed, etc will throw exceptions
-        val stop = try {
-          p.stop().toFuture.toScala
+        try {
+          p.stop().toFuture.toScala.map(_ => Done)
         } catch {
           case t: Throwable =>
             log.warn(this, s"Failed to stop processor ${t}")
-            Future.successful(Void)
+            Future.failed(t)
         }
-        stop.map(_ => Done)
       }
       .getOrElse(Future.successful(Done))
       .andThen {

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/ChangeFeedConsumer.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/ChangeFeedConsumer.scala
@@ -37,6 +37,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 trait ChangeFeedObserver {
   def process(context: ChangeFeedObserverContext, docs: Seq[CosmosItemProperties]): Future[Done]
@@ -48,52 +49,73 @@ class ChangeFeedConsumer(collName: String, config: CacheInvalidatorConfig, obser
   import ChangeFeedConsumer._
 
   log.info(this, s"Watching changes in $collName with lease managed in ${config.feedConfig.leaseCollection}")
+  val clients = scala.collection.mutable.Map[ConnectionInfo, CosmosClient]().withDefault(createCosmosClient)
 
-  private val clients = scala.collection.mutable.Map[ConnectionInfo, CosmosClient]().withDefault(createCosmosClient)
-  private val targetContainer = getContainer(collName)
-  private val leaseContainer = getContainer(config.feedConfig.leaseCollection, createIfNotExist = true)
-  private val (processor, startFuture) = {
-    val clusterId = config.invalidatorConfig.clusterId
-    val prefix = clusterId.map(id => s"$id-$collName").getOrElse(collName)
+  var processor: Option[ChangeFeedProcessor] = None
+  def start: Future[Done] = {
 
-    val feedOpts = new ChangeFeedProcessorOptions
-    feedOpts.leasePrefix(prefix)
-    feedOpts.startFromBeginning(config.feedConfig.startFromBeginning)
+    def getContainer(name: String, createIfNotExist: Boolean = false): CosmosContainer = {
+      val info = config.getCollectionInfo(name)
+      val client = clients(info)
+      val db = client.getDatabase(info.db)
+      val container = db.getContainer(name)
 
-    val builder = ChangeFeedProcessor.Builder
-      .hostName(config.feedConfig.hostname)
-      .feedContainer(targetContainer)
-      .leaseContainer(leaseContainer)
-      .options(feedOpts)
-      .asInstanceOf[ChangeFeedProcessorBuilderImpl] //observerFactory is not exposed hence need to cast to impl
+      val resp = if (createIfNotExist) {
+        db.createContainerIfNotExists(name, "/id", info.throughput)
+      } else container.read()
 
-    builder.observerFactory(() => ObserverBridge)
-    val p = builder.build()
-    (p, p.start().toFuture.toScala.map(_ => Done))
+      resp.block().container()
+    }
+    try {
+      val targetContainer = getContainer(collName)
+      val leaseContainer = getContainer(config.feedConfig.leaseCollection, createIfNotExist = true)
+
+      val clusterId = config.invalidatorConfig.clusterId
+      val prefix = clusterId.map(id => s"$id-$collName").getOrElse(collName)
+
+      val feedOpts = new ChangeFeedProcessorOptions
+      feedOpts.leasePrefix(prefix)
+      feedOpts.startFromBeginning(config.feedConfig.startFromBeginning)
+
+      val builder = ChangeFeedProcessor.Builder
+        .hostName(config.feedConfig.hostname)
+        .feedContainer(targetContainer)
+        .leaseContainer(leaseContainer)
+        .options(feedOpts)
+        .asInstanceOf[ChangeFeedProcessorBuilderImpl] //observerFactory is not exposed hence need to cast to impl
+
+      builder.observerFactory(() => ObserverBridge)
+      val p = builder.build()
+
+      processor = Some(p)
+      p.start().toFuture.toScala.map(_ => Done)
+    } catch {
+      case t: Throwable => Future.failed(t)
+    }
+
   }
-
-  def isStarted: Future[Done] = startFuture
 
   def close(): Future[Done] = {
-    val f = processor.stop().toFuture.toScala.map(_ => Done)
-    f.andThen {
-      case _ =>
-        clients.values.foreach(c => c.close())
-        Future.successful(Done)
-    }
-  }
 
-  private def getContainer(name: String, createIfNotExist: Boolean = false): CosmosContainer = {
-    val info = config.getCollectionInfo(name)
-    val client = clients(info)
-    val db = client.getDatabase(info.db)
-    val container = db.getContainer(name)
+    processor
+      .map(
+        p =>
+          Try(p.stop().toFuture.toScala)
+            .recover {
+              case t: Throwable =>
+                log.warn(this, s"Failed to stop processor ${t}")
+                Future.successful(Unit)
+            }
+            .get
+            .map(_ => Done))
+      .getOrElse(Future.successful(Done))
+      .andThen {
+        case _ =>
+          log.info(this, "Closing cosmos clients.")
+          clients.values.foreach(c => c.close())
+          Future.successful(Done)
+      }
 
-    val resp = if (createIfNotExist) {
-      db.createContainerIfNotExists(name, "/id", info.throughput)
-    } else container.read()
-
-    resp.block().container()
   }
 
   private object ObserverBridge extends com.azure.data.cosmos.internal.changefeed.ChangeFeedObserver {

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
@@ -51,7 +51,5 @@ object Main {
               }
           }
       }
-
   }
-
 }

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
@@ -23,17 +23,33 @@ import kamon.Kamon
 import org.apache.openwhisk.common.{AkkaLogging, ConfigMXBean, Logging}
 import org.apache.openwhisk.http.{BasicHttpService, BasicRasService}
 
+import scala.concurrent.ExecutionContext
+
 object Main {
   def main(args: Array[String]): Unit = {
     implicit val system: ActorSystem = ActorSystem("cache-invalidator-actor-system")
     implicit val materializer: ActorMaterializer = ActorMaterializer()
     implicit val log: Logging = new AkkaLogging(akka.event.Logging.getLogger(system, this))
-
+    implicit val ec: ExecutionContext = system.dispatcher
     ConfigMXBean.register()
     Kamon.init()
     val port = CacheInvalidatorConfig(system.settings.config).invalidatorConfig.port
     BasicHttpService.startHttpService(new BasicRasService {}.route, port, None)
-    CacheInvalidator.start(system.settings.config)
-    log.info(this, s"Started the server at http://localhost:$port")
+    CacheInvalidator
+      .start(system.settings.config)
+      .map(_ => log.info(this, s"Started the server at http://localhost:$port"))
+      .andThen {
+        case _ =>
+          Kamon.stopModules().andThen {
+            case _ =>
+              system.terminate().andThen {
+                case _ =>
+                  log.info(this, "Exiting")
+                  sys.exit(0)
+              }
+          }
+      }
+
   }
+
 }

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
@@ -35,9 +35,10 @@ object Main {
     Kamon.init()
     val port = CacheInvalidatorConfig(system.settings.config).invalidatorConfig.port
     BasicHttpService.startHttpService(new BasicRasService {}.route, port, None)
-    CacheInvalidator
-      .start(system.settings.config)
+    val (start, finish) = new CacheInvalidator(system.settings.config).start()
+    start
       .map(_ => log.info(this, s"Started the server at http://localhost:$port"))
+    finish
       .andThen {
         case _ =>
           Kamon.stopModules().andThen {

--- a/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
+++ b/core/cosmosdb/cache-invalidator/src/main/scala/org/apache/openwhisk/core/database/cosmosdb/cache/Main.scala
@@ -45,6 +45,7 @@ object Main {
             case _ =>
               system.terminate().andThen {
                 case _ =>
+                  //it is possible that the cosmos sdk reactor system does not cleanly shut down, so we will explicitly terminate jvm here.
                   log.info(this, "Exiting")
                   sys.exit(0)
               }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
The cosmosdb cache invalidator needs to be more defensive about downstream sdk errors like:
* cosmosdb failures at startup
* kafka producer failures during processing

## Description
These types of issues are most commonly related to configuration problems, so this refactoring mainly addresses these issues by exiting the application when these failure scenarios occur. 
Deployments should handle termination by restarting the application, but typically the configuration issues will not be resolvable until the configuration is repaired, and exiting the application is aimed to bring increased visibility to the configuration problems as they happen.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

