### PR TITLE
Allow docker.gradle to succeed using 'dockerBinary=podman'

### DIFF
--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -112,13 +112,14 @@ def prepareBuildArgs(List buildArgs) {
 task tagImage {
     doLast {
         def versionString = (dockerBinary + ['-v']).execute().text
-        def matched = (versionString =~ /(\d+)\.(\d+)\.(\d+)/)
+        def matched = (versionString =~ /^(\S+) version (\d+)\.(\d+)\.(\d+)/)
 
-        def major = matched[0][1] as int
-        def minor = matched[0][2] as int
+        def runner = matched[0][1]
+        def major = matched[0][2] as int
+        def minor = matched[0][3] as int
 
         def dockerCmd = ['tag']
-        if(major == 1 && minor < 12) {
+        if(runner == 'Docker' && major == 1 && minor < 12) {
             dockerCmd += ['-f']
         }
         retry(dockerBinary + dockerCmd + [dockerImageName, dockerTaggedImageName], dockerRetries, dockerTimeout)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
A set of logic in docker.gradle to test for old versions of docker for the `docker tag -f` flag breaks because it assumes a docker binary.  I added conditional logic to only apply this logic if the version line returned by the program begins with 'Docker'.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [X] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

