### PR TITLE
Add Get Namespace Limits API

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -37,6 +37,9 @@
     },
     {
       "name": "Namespaces"
+    },
+    {
+      "name": "Limits"
     }
   ],
   "paths": {
@@ -1676,6 +1679,42 @@
           }
         }
       }
+    },
+    "/namespaces/{namespace}/limits": {
+      "get": {
+        "tags": [
+          "Limits"
+        ],
+        "summary": "Get the limits for a namespace",
+        "description": "Get limits.",
+        "operationId": "getLimits",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "The entity namespace",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return output",
+            "schema": {
+              "$ref": "#/definitions/UserLimits"
+            }
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedRequest"
+          },
+          "500": {
+            "$ref": "#/responses/ServerError"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -2611,6 +2650,30 @@
             "$ref": "#/definitions/KeyValue"
           },
           "description": "parameter bindings included in the context passed to the provider"
+        }
+      }
+    },
+    "UserLimits": {
+      "properties": {
+        "invocationsPerMinute": {
+          "type": "int",
+          "description": "Max allowed invocations per minute for namespace"
+        },
+        "concurrentInvocations": {
+          "type": "int",
+          "description": "Max allowed concurrent in flight invocations for namespace"
+        },
+        "firesPerMinute": {
+          "type": "int",
+          "description": "Max allowed trigger fires per minute for namespace"
+        },
+        "allowedKinds": {
+          "type": "array",
+          "description": "List of runtimes whitelisted to be used by namespace (all if none returned)"
+        },
+        "storeActivations": {
+          "type": "boolean",
+          "description": "Whether storing activation is turned on for namespace (default is true)"
         }
       }
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Limits.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller
+
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.{Directive1, Directives}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonMarshaller
+import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.entitlement.{Collection, Privilege, Resource}
+import org.apache.openwhisk.core.entitlement.Privilege.READ
+import org.apache.openwhisk.core.entity.Identity
+
+trait WhiskLimitsApi extends Directives with AuthenticatedRouteProvider with AuthorizedRouteProvider {
+
+  protected val whiskConfig: WhiskConfig
+
+  protected override val collection = Collection(Collection.LIMITS)
+
+  protected val invocationsPerMinuteSystemDefault = whiskConfig.actionInvokePerMinuteLimit.toInt
+  protected val concurrentInvocationsSystemDefault = whiskConfig.actionInvokeConcurrentLimit.toInt
+  protected val firePerMinuteSystemDefault = whiskConfig.triggerFirePerMinuteLimit.toInt
+
+  override protected lazy val entityOps = get
+
+  /** JSON response formatter. */
+  import RestApiCommons.jsonDefaultResponsePrinter
+
+  /** Dispatches resource to the proper handler depending on context. */
+  protected override def dispatchOp(user: Identity, op: Privilege, resource: Resource)(
+    implicit transid: TransactionId) = {
+
+    resource.entity match {
+      case Some(_) =>
+        //TODO: Process entity level requests for an individual limit here
+        reject //should never get here
+      case None =>
+        op match {
+          case READ =>
+            val limits = user.limits.copy(
+              Some(user.limits.invocationsPerMinute.getOrElse(invocationsPerMinuteSystemDefault)),
+              Some(user.limits.concurrentInvocations.getOrElse(concurrentInvocationsSystemDefault)),
+              Some(user.limits.firesPerMinute.getOrElse(firePerMinuteSystemDefault)))
+            pathEndOrSingleSlash { complete(OK, limits) }
+          case _ => reject //should never get here
+        }
+    }
+  }
+
+  protected override def entityname(n: String): Directive1[String] = {
+    validate(false, "Inner entity level routes for limits are not yet implemented.") & extract(_ => n)
+  }
+}

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/RestAPIs.scala
@@ -206,7 +206,8 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
                   triggers.routes(user) ~
                   rules.routes(user) ~
                   activations.routes(user) ~
-                  packages.routes(user)
+                  packages.routes(user) ~
+                  limits.routes(user)
               }
           } ~
           swaggerRoutes
@@ -233,9 +234,16 @@ class RestAPIVersion(config: WhiskConfig, apiPath: String, apiVersion: String)(
   private val triggers = new TriggersApi(apiPath, apiVersion)
   private val activations = new ActivationsApi(apiPath, apiVersion)
   private val rules = new RulesApi(apiPath, apiVersion)
+  private val limits = new LimitsApi(apiPath, apiVersion)
   private val web = new WebActionsApi(Seq("web"), new WebApiDirectives())
 
   class NamespacesApi(val apiPath: String, val apiVersion: String) extends WhiskNamespacesApi
+
+  class LimitsApi(val apiPath: String, val apiVersion: String)(
+    implicit override val entitlementProvider: EntitlementProvider,
+    override val executionContext: ExecutionContext,
+    override val whiskConfig: WhiskConfig)
+      extends WhiskLimitsApi
 
   class ActionsApi(val apiPath: String, val apiVersion: String)(
     implicit override val actorSystem: ActorSystem,

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Collection.scala
@@ -123,6 +123,7 @@ protected[core] object Collection {
   protected[core] val PACKAGES = WhiskPackage.collectionName
   protected[core] val ACTIVATIONS = WhiskActivation.collectionName
   protected[core] val NAMESPACES = "namespaces"
+  protected[core] val LIMITS = "limits"
 
   private val collections = scala.collection.mutable.Map[String, Collection]()
   private def register(c: Collection) = collections += c.path -> c
@@ -155,6 +156,13 @@ protected[core] object Collection {
       }
 
       protected override val allowedEntityRights: Set[Privilege] = Set(Privilege.READ)
+    })
+
+    register(new Collection(LIMITS) {
+      protected[core] override def determineRight(op: HttpMethod,
+                                                  resource: Option[String])(implicit transid: TransactionId) = {
+        if (op == GET) Privilege.READ else Privilege.REJECT
+      }
     })
   }
 }

--- a/docs/actions-docker.md
+++ b/docs/actions-docker.md
@@ -230,7 +230,7 @@ When the process ends, the last line of text output to `stdout` will be parsed a
 
 ```
 #!/bin/bash
-read ARGS
+ARGS=$@
 NAME=`echo "$ARGS" | jq -r '."name"'`
 DATE=`date`
 echo "{ \"message\": \"Hello $NAME! It is $DATE.\" }"

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -33,6 +33,7 @@ These are the collection endpoints:
 - `https://$APIHOST/api/v1/namespaces/{namespace}/rules`
 - `https://$APIHOST/api/v1/namespaces/{namespace}/packages`
 - `https://$APIHOST/api/v1/namespaces/{namespace}/activations`
+- `https://$APIHOST/api/v1/namespaces/{namespace}/limits`
 
 The `$APIHOST` is the OpenWhisk API hostname (for example, localhost, 172.17.0.1, and so on).
 For the `{namespace}`, the character `_` can be used to specify the user's *default
@@ -326,3 +327,11 @@ To get all the details of an activation including results and logs, send a HTTP 
 ```bash
 curl -u $AUTH https://$APIHOST/api/v1/namespaces/_/activations/f81dfddd7156401a8a6497f2724fec7b
 ```
+
+## Limits
+
+To get the limits set for a namespace (i.e. invocationsPerMinute, concurrentInvocations, firesPerMinute)
+```bash
+curl -u $AUTH https://$APIHOST/api/v1/namespaces/_/limits
+```
+Note that the default system values are returned if no limit is set in couchdb.

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/LimitsApiTests.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.controller.test
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, MethodNotAllowed, OK}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsonUnmarshaller
+import akka.http.scaladsl.server.Route
+import org.apache.openwhisk.core.controller.WhiskLimitsApi
+import org.apache.openwhisk.core.entity.{EntityPath, UserLimits}
+
+/**
+ * Tests Packages API.
+ *
+ * Unit tests of the controller service as a standalone component.
+ * These tests exercise a fresh instance of the service object in memory -- these
+ * tests do NOT communication with a whisk deployment.
+ *
+ * @Idioglossia
+ * "using Specification DSL to write unit tests, as in should, must, not, be"
+ * "using Specs2RouteTest DSL to chain HTTP requests for unit testing, as in ~>"
+ */
+@RunWith(classOf[JUnitRunner])
+class LimitsApiTests extends ControllerTestCommon with WhiskLimitsApi {
+
+  /** Limits API tests */
+  behavior of "Limits API"
+
+  // test namespace limit configurations
+  val testInvokesPerMinute = 100
+  val testConcurrent = 200
+  val testFiresPerMinute = 300
+  val testAllowedKinds = Set("java:8")
+  val testStoreActivations = false
+
+  val creds = WhiskAuthHelpers.newIdentity()
+  val credsWithSetLimits = WhiskAuthHelpers
+    .newIdentity()
+    .copy(
+      limits = UserLimits(
+        Some(testInvokesPerMinute),
+        Some(testConcurrent),
+        Some(testFiresPerMinute),
+        Some(testAllowedKinds),
+        Some(testStoreActivations)))
+  val namespace = EntityPath(creds.subject.asString)
+  val collectionPath = s"/${EntityPath.DEFAULT}/${collection.path}"
+
+  //// GET /limits
+  it should "list default system limits if no namespace limits are set" in {
+    implicit val tid = transid()
+    Seq("", "/").foreach { p =>
+      Get(collectionPath + p) ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        responseAs[UserLimits].invocationsPerMinute shouldBe Some(whiskConfig.actionInvokePerMinuteLimit.toInt)
+        responseAs[UserLimits].concurrentInvocations shouldBe Some(whiskConfig.actionInvokeConcurrentLimit.toInt)
+        responseAs[UserLimits].firesPerMinute shouldBe Some(whiskConfig.triggerFirePerMinuteLimit.toInt)
+        responseAs[UserLimits].allowedKinds shouldBe None
+        responseAs[UserLimits].storeActivations shouldBe None
+      }
+    }
+  }
+
+  it should "list set limits if limits have been set for the namespace" in {
+    implicit val tid = transid()
+    Seq("", "/").foreach { p =>
+      Get(collectionPath + p) ~> Route.seal(routes(credsWithSetLimits)) ~> check {
+        status should be(OK)
+        responseAs[UserLimits].invocationsPerMinute shouldBe Some(testInvokesPerMinute)
+        responseAs[UserLimits].concurrentInvocations shouldBe Some(testConcurrent)
+        responseAs[UserLimits].firesPerMinute shouldBe Some(testFiresPerMinute)
+        responseAs[UserLimits].allowedKinds shouldBe Some(testAllowedKinds)
+        responseAs[UserLimits].storeActivations shouldBe Some(testStoreActivations)
+      }
+    }
+  }
+
+  it should "reject requests for unsupported methods" in {
+    implicit val tid = transid()
+    Seq(Put, Post, Delete).foreach { m =>
+      m(collectionPath) ~> Route.seal(routes(creds)) ~> check {
+        status should be(MethodNotAllowed)
+      }
+    }
+  }
+
+  it should "reject all methods for entity level request" in {
+    implicit val tid = transid()
+    Seq(Put, Post, Delete).foreach { m =>
+      m(s"$collectionPath/limitsEntity") ~> Route.seal(routes(creds)) ~> check {
+        status should be(MethodNotAllowed)
+      }
+    }
+
+    Seq(Get).foreach { m =>
+      m(s"$collectionPath/limitsEntity") ~> Route.seal(routes(creds)) ~> check {
+        status should be(BadRequest)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description

This PR creates a limits api that will return the limits set for the namespace.

/namespaces/_/limits

In the future, it's extendable to return individual limits by entity such as 

/namespaces/_/limits/invocationsPerMinute

although that is not implemented in this PR.

Only Get is supported as setting limits is an admin operation. This allows clients to see what their namespace's limits are set to without going through an admin for the information. Also, since the route goes through the controller we can return the system defaults for invocationsPerMinute, concurrentInvocations, and firesPerMinute rather than just saying the system defaults apply if nothing is set in couchdb.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

