### PR TITLE
Add jq to ow-utils image

### DIFF
--- a/tools/ow-utils/Dockerfile
+++ b/tools/ow-utils/Dockerfile
@@ -24,6 +24,7 @@ ENV WHISKDEPLOY_CLI_VERSION latest
 
 RUN apt-get update && apt-get install -y \
   git \
+  jq \
   libffi-dev \
   nodejs \
   npm \


### PR DESCRIPTION
Add the jq cli to the ow-utils to enable easy parsing of
results curls against the Kubernetes API server.  This will
simplify the definition of init containers used to wait
for services to be ready before dependent pods are started.
