### PR TITLE
Make activation response truncation length configurable 

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -351,8 +351,8 @@ whisk {
 
     activation {
         payload {
-            max = 1048576
-            truncation = 1048576
+            max = 1 m
+            truncation = 1 m
         }
         # Action responses sent through Kafka can contain up to 3018 bytes of metadata
         #   CompletionMessage

--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -352,6 +352,7 @@ whisk {
     activation {
         payload {
             max = 1048576
+            truncation = 1048576
         }
         # Action responses sent through Kafka can contain up to 3018 bytes of metadata
         #   CompletionMessage

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -220,12 +220,19 @@ trait Container {
   }
   private def openConnections(timeout: FiniteDuration, maxConcurrent: Int) = {
     if (Container.config.akkaClient) {
-      new AkkaContainerClient(addr.host, addr.port, timeout, ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT, 1024)
+      new AkkaContainerClient(
+        addr.host,
+        addr.port,
+        timeout,
+        ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT,
+        ActivationEntityLimit.MAX_ACTIVATION_ENTITY_TRUNCATION_LIMIT,
+        1024)
     } else {
       new ApacheBlockingContainerClient(
         s"${addr.host}:${addr.port}",
         timeout,
         ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT,
+        ActivationEntityLimit.MAX_ACTIVATION_ENTITY_TRUNCATION_LIMIT,
         maxConcurrent)
     }
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
@@ -20,7 +20,7 @@ package org.apache.openwhisk.core.entity
 import pureconfig._
 import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
-import org.apache.openwhisk.core.entity.size.SizeLong
+import org.apache.openwhisk.core.entity.size._
 
 case class ActivationEntityPayload(max: ByteSize, truncation: ByteSize)
 case class ActivationEntityLimitConf(serdesOverhead: ByteSize, payload: ActivationEntityPayload)
@@ -31,7 +31,6 @@ case class ActivationEntityLimitConf(serdesOverhead: ByteSize, payload: Activati
  * parameters for triggers.
  */
 protected[core] object ActivationEntityLimit {
-  private implicit val pureconfigLongReader: ConfigReader[ByteSize] = ConfigReader[Long].map(_.bytes)
   private val config = loadConfigOrThrow[ActivationEntityLimitConf](ConfigKeys.activation)
 
   protected[core] val MAX_ACTIVATION_ENTITY_LIMIT: ByteSize = config.payload.max

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationEntityLimit.scala
@@ -22,7 +22,7 @@ import pureconfig.generic.auto._
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.size.SizeLong
 
-case class ActivationEntityPayload(max: ByteSize)
+case class ActivationEntityPayload(max: ByteSize, truncation: ByteSize)
 case class ActivationEntityLimitConf(serdesOverhead: ByteSize, payload: ActivationEntityPayload)
 
 /**
@@ -35,5 +35,6 @@ protected[core] object ActivationEntityLimit {
   private val config = loadConfigOrThrow[ActivationEntityLimitConf](ConfigKeys.activation)
 
   protected[core] val MAX_ACTIVATION_ENTITY_LIMIT: ByteSize = config.payload.max
+  protected[core] val MAX_ACTIVATION_ENTITY_TRUNCATION_LIMIT: ByteSize = config.payload.truncation
   protected[core] val MAX_ACTIVATION_LIMIT: ByteSize = config.payload.max + config.serdesOverhead
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/DockerContainer.scala
@@ -220,12 +220,19 @@ class DockerContainer(protected val id: ContainerId,
     val started = Instant.now()
     val http = httpConnection.getOrElse {
       val conn = if (Container.config.akkaClient) {
-        new AkkaContainerClient(addr.host, addr.port, timeout, ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT, 1024)
+        new AkkaContainerClient(
+          addr.host,
+          addr.port,
+          timeout,
+          ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT,
+          ActivationEntityLimit.MAX_ACTIVATION_ENTITY_TRUNCATION_LIMIT,
+          1024)
       } else {
         new ApacheBlockingContainerClient(
           s"${addr.host}:${addr.port}",
           timeout,
           ActivationEntityLimit.MAX_ACTIVATION_ENTITY_LIMIT,
+          ActivationEntityLimit.MAX_ACTIVATION_ENTITY_TRUNCATION_LIMIT,
           maxConcurrent)
       }
       httpConnection = Some(conn)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/AkkaContainerClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/AkkaContainerClientTests.scala
@@ -109,7 +109,7 @@ class AkkaContainerClientTests
 
   it should "not wait longer than set timeout" in {
     val timeout = 5.seconds
-    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 100)
+    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 1.B, 100)
     testHang = timeout * 2
     val start = Instant.now()
     val result = Await.result(connection.post("/init", JsObject.empty, retry = true), 10.seconds)
@@ -123,7 +123,7 @@ class AkkaContainerClientTests
 
   it should "handle empty entity response" in {
     val timeout = 5.seconds
-    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 100)
+    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 1.B, 100)
     testStatusCode = 204
     val result = Await.result(connection.post("/init", JsObject.empty, retry = true), 10.seconds)
     result shouldBe Left(NoResponseReceived())
@@ -131,7 +131,7 @@ class AkkaContainerClientTests
 
   it should "retry till timeout on StreamTcpException" in {
     val timeout = 5.seconds
-    val connection = new AkkaContainerClient("0.0.0.0", 12345, timeout, 1.B, 100)
+    val connection = new AkkaContainerClient("0.0.0.0", 12345, timeout, 1.B, 1.B, 100)
     val start = Instant.now()
     val result = Await.result(connection.post("/init", JsObject.empty, retry = true), 10.seconds)
     val end = Instant.now()
@@ -146,7 +146,7 @@ class AkkaContainerClientTests
 
   it should "throw ContainerHealthError on HttpHostConnectException if reschedule==true" in {
     val timeout = 5.seconds
-    val connection = new AkkaContainerClient("0.0.0.0", 12345, timeout, 1.B, 100)
+    val connection = new AkkaContainerClient("0.0.0.0", 12345, timeout, 1.B, 1.B, 100)
     assertThrows[ContainerHealthError] {
       Await.result(connection.post("/run", JsObject.empty, retry = false, reschedule = true), 10.seconds)
     }
@@ -156,7 +156,7 @@ class AkkaContainerClientTests
     val timeout = 5.seconds
     val retryInterval = 500.milliseconds
     val connection =
-      new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 100, retryInterval)
+      new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout, 1.B, 1.B, 100, retryInterval)
     val start = Instant.now()
     testConnectionFailCount = 5
     testResponse = ""
@@ -173,7 +173,7 @@ class AkkaContainerClientTests
 
   it should "not truncate responses within limit" in {
     val timeout = 1.minute.toMillis
-    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, 50.B, 100)
+    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, 50.B, 50.B, 100)
     Seq(true, false).foreach { success =>
       Seq(null, "", "abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
         testStatusCode = if (success) 200 else 500
@@ -188,15 +188,17 @@ class AkkaContainerClientTests
 
   it should "truncate responses that exceed limit" in {
     val timeout = 1.minute.toMillis
-    val limit = 1.B
-    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, limit, 100)
+    val limit = 2.B
+    val truncationLimit = 1.B
+    val connection =
+      new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, limit, truncationLimit, 100)
     Seq(true, false).foreach { success =>
       Seq("abc", """{"a":"B"}""", """["a", "b"]""").foreach { r =>
         testStatusCode = if (success) 200 else 500
         testResponse = r
         val result = Await.result(connection.post("/init", JsObject.empty, retry = true), 10.seconds)
         result shouldBe Right {
-          ContainerResponse(okStatus = success, r.take(limit.toBytes.toInt), Some((r.length.B, limit)))
+          ContainerResponse(okStatus = success, r.take(truncationLimit.toBytes.toInt), Some((r.length.B, limit)))
         }
       }
     }
@@ -207,7 +209,9 @@ class AkkaContainerClientTests
     //use a limit large enough to not fit into a single ByteString as response entity is parsed into multiple ByteStrings
     //seems like this varies, but often is ~64k or ~128k
     val limit = 300.KB
-    val connection = new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, limit, 100)
+    val truncationLimit = 299.B
+    val connection =
+      new AkkaContainerClient(httpHost.getHostName, httpHost.getPort, timeout.millis, limit, truncationLimit, 100)
     Seq(true, false).foreach { success =>
       // Generate a response that's 1MB
       val response = "0" * 1024 * 1024
@@ -215,7 +219,10 @@ class AkkaContainerClientTests
       testResponse = response
       val result = Await.result(connection.post("/init", JsObject.empty, retry = true), 10.seconds)
       result shouldBe Right {
-        ContainerResponse(okStatus = success, response.take(limit.toBytes.toInt), Some((response.length.B, limit)))
+        ContainerResponse(
+          okStatus = success,
+          response.take(truncationLimit.toBytes.toInt),
+          Some((response.length.B, limit)))
       }
 
     }


### PR DESCRIPTION
## Description
By default activation responses can be 1MB in size and they will be truncated to 1MB in case the size is bigger. 
This PR makes the truncation length configurable too. This means that the response size could be configured to 1MB for example, but the truncation length can be 512KB. 
The reason for this change is the fact that once the response is truncated, it does not make a lot of sense to store the entire payload to the database. 

As an example, for the following configuration:
```
whisk {
    activation {
        payload {
            max = 512
            truncation = 10
        }
    }
}
```
the response of a truncated activation result will have the following format:
```
{
    "error": "The action produced a response that exceeded the allowed length: 600 > 512 bytes. The truncated response was: {\"body\":\"H"
}
```
and the database will store only 10 bytes of the response. 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

