### PR TITLE
Prewarm eviction variance

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -47,7 +47,8 @@ case class ContainerArgsConfig(network: String,
 case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
-                               prewarmExpirationCheckInterval: FiniteDuration) {
+                               prewarmExpirationCheckInterval: FiniteDuration,
+                               prewarmExpirationLimit: Int) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,
     s"concurrentPeekFactor must be > 0 and <= 1.0; was $concurrentPeekFactor")

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -48,7 +48,7 @@ case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
                                prewarmExpirationCheckInterval: FiniteDuration,
-                               prewarmExpirationCheckIntervalVariance: FiniteDuration,
+                               prewarmExpirationCheckIntervalVariance: Option[FiniteDuration],
                                prewarmExpirationLimit: Int) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerFactory.scala
@@ -48,6 +48,7 @@ case class ContainerPoolConfig(userMemory: ByteSize,
                                concurrentPeekFactor: Double,
                                akkaClient: Boolean,
                                prewarmExpirationCheckInterval: FiniteDuration,
+                               prewarmExpirationCheckIntervalVariance: FiniteDuration,
                                prewarmExpirationLimit: Int) {
   require(
     concurrentPeekFactor > 0 && concurrentPeekFactor <= 1.0,

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -60,7 +60,8 @@ whisk {
     user-memory: 1024 m
     concurrent-peek-factor: 0.5 #factor used to limit message peeking: 0 < factor <= 1.0 - larger number improves concurrent processing, but increases risk of message loss during invoker crash
     akka-client:  false # if true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
-    prewarm-expiration-check-interval: 1 minute
+    prewarm-expiration-check-interval: 1 minute # period to check for prewarm expiration
+    prewarm-expiration-check-interval-variance: 10 seconds # varies expiration across invokers to avoid many concurrent expirations
     prewarm-expiration-limit: 100 # number of prewarms to expire in one expiration cycle (remaining expired will be considered for expiration in next cycle)
   }
 

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -61,6 +61,7 @@ whisk {
     concurrent-peek-factor: 0.5 #factor used to limit message peeking: 0 < factor <= 1.0 - larger number improves concurrent processing, but increases risk of message loss during invoker crash
     akka-client:  false # if true, use PoolingContainerClient for HTTP from invoker to action container (otherwise use ApacheBlockingContainerClient)
     prewarm-expiration-check-interval: 1 minute
+    prewarm-expiration-limit: 100 # number of prewarms to expire in one expiration cycle (remaining expired will be considered for expiration in next cycle)
   }
 
   kubernetes {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -333,7 +333,6 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
 
   /** adjust prewarm containers up to the configured requirements for each kind/memory combination. */
   def adjustPrewarmedContainer(init: Boolean, scheduled: Boolean): Unit = {
-    println("adjusting...")
     //fill in missing prewarms
     ContainerPool
       .increasePrewarms(init, scheduled, coldStartCount, prewarmConfig, prewarmedPool, prewarmStartingPool)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -17,8 +17,6 @@
 
 package org.apache.openwhisk.core.containerpool.mesos.test
 
-import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
@@ -86,7 +84,7 @@ class MesosContainerFactoryTest
   }
 
   // 80 slots, each 265MB
-  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, FiniteDuration(1, TimeUnit.MINUTES))
+  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, 1.minute, 1.minute, 100)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/mesos/test/MesosContainerFactoryTest.scala
@@ -84,7 +84,7 @@ class MesosContainerFactoryTest
   }
 
   // 80 slots, each 265MB
-  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, 1.minute, 1.minute, 100)
+  val poolConfig = ContainerPoolConfig(21200.MB, 0.5, false, 1.minute, None, 100)
   val actionMemory = 265.MB
   val mesosCpus = poolConfig.cpuShare(actionMemory) / 1024.0
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -17,6 +17,7 @@
 
 package org.apache.openwhisk.core.containerpool.test
 
+import java.io.{ByteArrayOutputStream, PrintStream}
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -35,7 +36,7 @@ import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import akka.testkit.TestProbe
 import common.{StreamLogging, WhiskProperties}
-import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.common.{Logging, PrintStreamLogging, TransactionId}
 import org.apache.openwhisk.core.connector.ActivationMessage
 import org.apache.openwhisk.core.containerpool._
 import org.apache.openwhisk.core.entity._
@@ -132,7 +133,7 @@ class ContainerPoolTests
   }
 
   def poolConfig(userMemory: ByteSize) =
-    ContainerPoolConfig(userMemory, 0.5, false, FiniteDuration(1, TimeUnit.MINUTES))
+    ContainerPoolConfig(userMemory, 0.5, false, 1.minute, 1.minute, 100)
 
   behavior of "ContainerPool"
 
@@ -792,7 +793,13 @@ class ContainerPoolTests
 
     stream.reset()
     val prewarmExpirationCheckIntervel = FiniteDuration(2, TimeUnit.SECONDS)
-    val poolConfig = ContainerPoolConfig(MemoryLimit.STD_MEMORY * 4, 0.5, false, prewarmExpirationCheckIntervel)
+    val poolConfig = ContainerPoolConfig(
+      MemoryLimit.STD_MEMORY * 4,
+      0.5,
+      false,
+      prewarmExpirationCheckIntervel,
+      prewarmExpirationCheckIntervel,
+      100)
     val initialCount = 2
     val pool =
       system.actorOf(
@@ -826,7 +833,13 @@ class ContainerPoolTests
 
     stream.reset()
     val prewarmExpirationCheckIntervel = FiniteDuration(2, TimeUnit.SECONDS)
-    val poolConfig = ContainerPoolConfig(MemoryLimit.STD_MEMORY * 8, 0.5, false, prewarmExpirationCheckIntervel)
+    val poolConfig = ContainerPoolConfig(
+      MemoryLimit.STD_MEMORY * 8,
+      0.5,
+      false,
+      prewarmExpirationCheckIntervel,
+      prewarmExpirationCheckIntervel,
+      100)
     val minCount = 0
     val initialCount = 2
     val maxCount = 4
@@ -984,7 +997,8 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     WarmingColdData(EntityName(namespace), action, lastUsed, active)
 
   /** Helper to create PreWarmedData with sensible defaults */
-  def preWarmedData(kind: String = "anyKind") = PreWarmedData(stub[MockableContainer], kind, 256.MB)
+  def preWarmedData(kind: String = "anyKind", expires: Option[Deadline] = None) =
+    PreWarmedData(stub[MockableContainer], kind, 256.MB, expires = expires)
 
   /** Helper to create NoData */
   def noData() = NoData()
@@ -1195,4 +1209,27 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     pool = pool - 'first
     ContainerPool.remove(pool, MemoryLimit.STD_MEMORY) shouldBe List('second)
   }
+
+  it should "remove expired in order of expiration" in {
+    val poolConfig = ContainerPoolConfig(0.MB, 0.5, false, 10.seconds, 10.seconds, 1)
+    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+    val memoryLimit = 256.MB
+    val prewarmConfig =
+      List(PrewarmingConfig(1, exec, memoryLimit, Some(ReactivePrewarmingConfig(0, 10, 10.seconds, 1, 1))))
+    val oldestDeadline = Deadline.now - 1.seconds
+    val newerDeadline = Deadline.now
+    val newestDeadline = Deadline.now + 1.seconds
+    println(s"deadline ${oldestDeadline.isOverdue()}")
+    val prewarmedPool = Map(
+      'newest -> preWarmedData("actionKind", Some(newestDeadline)),
+      'oldest -> preWarmedData("actionKind", Some(oldestDeadline)),
+      'newer -> preWarmedData("actionKind", Some(newerDeadline)))
+    lazy val stream = new ByteArrayOutputStream
+    lazy val printstream = new PrintStream(stream)
+    lazy implicit val logging: Logging = new PrintStreamLogging(printstream)
+    println(s"pool ${prewarmedPool}")
+    println(s"configs ${prewarmConfig}")
+    ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List('oldest))
+  }
+
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -830,7 +830,7 @@ class ContainerPoolTests
     val prewarmExpirationCheckIntervel = 2.seconds
     val poolConfig =
       ContainerPoolConfig(MemoryLimit.STD_MEMORY * 8, 0.5, false, prewarmExpirationCheckIntervel, None, 100)
-    val minCount = 1
+    val minCount = 0
     val initialCount = 2
     val maxCount = 4
     val deadline: Option[Deadline] = Some(ttl.fromNow)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -1203,15 +1203,19 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
   it should "remove expired in order of expiration" in {
     val poolConfig = ContainerPoolConfig(0.MB, 0.5, false, 10.seconds, None, 1)
     val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+    //use a second kind so that we know sorting is not isolated to the expired of each kind
+    val exec2 = CodeExecAsString(RuntimeManifest("actionKind2", ImageName("testImage")), "testCode", None)
     val memoryLimit = 256.MB
     val prewarmConfig =
-      List(PrewarmingConfig(1, exec, memoryLimit, Some(ReactivePrewarmingConfig(0, 10, 10.seconds, 1, 1))))
+      List(
+        PrewarmingConfig(1, exec, memoryLimit, Some(ReactivePrewarmingConfig(0, 10, 10.seconds, 1, 1))),
+        PrewarmingConfig(1, exec2, memoryLimit, Some(ReactivePrewarmingConfig(0, 10, 10.seconds, 1, 1))))
     val oldestDeadline = Deadline.now - 1.seconds
     val newerDeadline = Deadline.now
     val newestDeadline = Deadline.now + 1.seconds
     val prewarmedPool = Map(
       'newest -> preWarmedData("actionKind", Some(newestDeadline)),
-      'oldest -> preWarmedData("actionKind", Some(oldestDeadline)),
+      'oldest -> preWarmedData("actionKind2", Some(oldestDeadline)),
       'newer -> preWarmedData("actionKind", Some(newerDeadline)))
     lazy val stream = new ByteArrayOutputStream
     lazy val printstream = new PrintStream(stream)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -840,6 +840,7 @@ class ContainerPoolTests
       system.actorOf(
         ContainerPool
           .props(factory, poolConfig, feed.ref, List(PrewarmingConfig(initialCount, exec, memoryLimit, reactive))))
+    //start 2 prewarms
     containers(0).expectMsg(Start(exec, memoryLimit, Some(ttl)))
     containers(1).expectMsg(Start(exec, memoryLimit, Some(ttl)))
     containers(0).send(pool, NeedWork(preWarmedData(exec.kind, expires = deadline)))
@@ -855,7 +856,7 @@ class ContainerPoolTests
 
     // Make sure AdjustPrewarmedContainer is sent by ContainerPool's scheduler after prewarmExpirationCheckIntervel time
     Thread.sleep(prewarmExpirationCheckIntervel.toMillis)
-
+    //expire 2 prewarms
     containers(0).expectMsg(Remove)
     containers(1).expectMsg(Remove)
     containers(0).send(pool, ContainerRemoved(false))
@@ -876,7 +877,7 @@ class ContainerPoolTests
       exec,
       limits = ActionLimits(memory = MemoryLimit(memoryLimit)))
     val run = createRunMessage(action, invocationNamespace)
-    // 2 code start happened
+    // 2 cold start happened
     pool ! run
     pool ! run
     containers(2).expectMsg(run)
@@ -891,7 +892,7 @@ class ContainerPoolTests
       // the desiredCount should equal with 2 due to cold start happened
       stream.toString should include(s"desired count: 2")
     }
-
+    //add 2 prewarms due to increments
     containers(4).expectMsg(Start(exec, memoryLimit, Some(ttl)))
     containers(5).expectMsg(Start(exec, memoryLimit, Some(ttl)))
     containers(4).send(pool, NeedWork(preWarmedData(exec.kind, expires = deadline)))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -1250,7 +1250,7 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List('oldest, 'newer))
   }
 
-  it should "remove only the expired prewarms up to minCount" in {
+  it should "remove only the expired prewarms regardless of minCount" in {
     //limit prewarm removal to 100
     val poolConfig = ContainerPoolConfig(0.MB, 0.5, false, 10.seconds, None, 100)
     val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
@@ -1274,6 +1274,11 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     lazy val stream = new ByteArrayOutputStream
     lazy val printstream = new PrintStream(stream)
     lazy implicit val logging: Logging = new PrintStreamLogging(printstream)
-    ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List('oldest, 'newer, 'newest))
+    ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List(
+      'oldest,
+      'newer,
+      'newest,
+      'newest2,
+      'newest3))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerPoolTests.scala
@@ -1249,4 +1249,30 @@ class ContainerPoolObjectTests extends FlatSpec with Matchers with MockFactory {
     ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List('oldest, 'newer))
   }
 
+  it should "remove only the expired prewarms up to minCount" in {
+    //limit prewarm removal to 100
+    val poolConfig = ContainerPoolConfig(0.MB, 0.5, false, 10.seconds, None, 100)
+    val exec = CodeExecAsString(RuntimeManifest("actionKind", ImageName("testImage")), "testCode", None)
+    val memoryLimit = 256.MB
+    //minCount is 2 - should leave at least 2 prewarms when removing expired
+    val prewarmConfig =
+      List(PrewarmingConfig(3, exec, memoryLimit, Some(ReactivePrewarmingConfig(2, 10, 10.seconds, 1, 1))))
+    //all are overdue, with different expiration times
+    val oldestDeadline = Deadline.now - 5.seconds
+    val newerDeadline = Deadline.now - 4.seconds
+    //the newest* ones are expired, but not the oldest, and not within the limit of 2 prewarms, so won't be removed
+    val newestDeadline = Deadline.now - 3.seconds
+    val newestDeadline2 = Deadline.now - 2.seconds
+    val newestDeadline3 = Deadline.now - 1.seconds
+    val prewarmedPool = Map(
+      'newest -> preWarmedData("actionKind", Some(newestDeadline)),
+      'oldest -> preWarmedData("actionKind", Some(oldestDeadline)),
+      'newest3 -> preWarmedData("actionKind", Some(newestDeadline3)),
+      'newer -> preWarmedData("actionKind", Some(newerDeadline)),
+      'newest2 -> preWarmedData("actionKind", Some(newestDeadline2)))
+    lazy val stream = new ByteArrayOutputStream
+    lazy val printstream = new PrintStream(stream)
+    lazy implicit val logging: Logging = new PrintStreamLogging(printstream)
+    ContainerPool.removeExpired(poolConfig, prewarmConfig, prewarmedPool) shouldBe (List('oldest, 'newer, 'newest))
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -27,7 +27,6 @@ import akka.testkit.{CallingThreadDispatcher, ImplicitSender, TestKit, TestProbe
 import akka.util.ByteString
 import common.{LoggedFunction, StreamLogging, SynchronizedLoggedFunction, WhiskProperties}
 import java.time.temporal.ChronoUnit
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.io.Tcp.{Close, CommandFailed, Connect, Connected}
@@ -275,7 +274,7 @@ class ContainerProxyTests
     (transid: TransactionId, activation: WhiskActivation, isBlockingActivation: Boolean, context: UserContext) =>
       Future.successful(())
   }
-  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, FiniteDuration(1, TimeUnit.MINUTES))
+  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, 1.minute, 1.minute, 100)
   def healthchecksConfig(enabled: Boolean = false) = ContainerProxyHealthCheckConfig(enabled, 100.milliseconds, 2)
   val filterEnvVar = (k: String) => Character.isUpperCase(k.charAt(0))
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -274,7 +274,7 @@ class ContainerProxyTests
     (transid: TransactionId, activation: WhiskActivation, isBlockingActivation: Boolean, context: UserContext) =>
       Future.successful(())
   }
-  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, 1.minute, 1.minute, 100)
+  val poolConfig = ContainerPoolConfig(2.MB, 0.5, false, 1.minute, None, 100)
   def healthchecksConfig(enabled: Boolean = false) = ContainerProxyHealthCheckConfig(enabled, 100.milliseconds, 2)
   val filterEnvVar = (k: String) => Character.isUpperCase(k.charAt(0))
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
When enabling reactive prewarm configs, if batches of prewarms are removed at the same time across invokers, we end up with a herd of container deletion and creation at the same time, especially if invokers startup at the same time.  This can cause scheduling challenges particularly in mesos or kubernetes. Given that these prewarm containers are not in use, we should try to alleviate any extra issues the prewarm state changes may cause, and allow them to linger slightly longer, if there is a benefit to the scheduling system. 

## Description
<!--- Provide a detailed description of your changes. -->



<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->
This PR adds some configs and sensible defaults to allow the reactive prewarm config affects to be varied across invokers to smooth out deletion and rescheduling of prewarm containers:
```
    prewarm-expiration-check-interval: 1 minute # period to check for prewarm expiration
    prewarm-expiration-check-interval-variance: 10 seconds # varies expiration across invokers to avoid many concurrent expirations
    prewarm-expiration-limit: 100 # number of prewarms to expire in one expiration cycle (remaining expired will be considered for expiration in next cycle)
```

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

