### PR TITLE
kubernetes: fix exception handing when api-server connection fails

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -81,6 +81,11 @@ case class KubernetesPodReadyTimeoutException(timeout: FiniteDuration)
     extends Exception(s"Pod readiness timed out after ${timeout.toSeconds}s")
 
 /**
+ * Exception to indicate a pod could not be created at the apiserver.
+ */
+case class KubernetesPodApiException(e: Throwable) extends Exception(s"Pod was not created at apiserver: ${e}")
+
+/**
  * Configuration for node affinity for the pods that execute user action containers
  * The key,value pair should match the <key,value> pair with which the invoker worker nodes
  * are labeled in the Kubernetes cluster.  The default pair is <openwhisk-role,invoker>,
@@ -110,14 +115,15 @@ case class KubernetesClientConfig(timeouts: KubernetesClientTimeoutConfig,
  * You only need one instance (and you shouldn't get more).
  */
 class KubernetesClient(
-  config: KubernetesClientConfig = loadConfigOrThrow[KubernetesClientConfig](ConfigKeys.kubernetes))(
-  executionContext: ExecutionContext)(implicit log: Logging, as: ActorSystem)
+  config: KubernetesClientConfig = loadConfigOrThrow[KubernetesClientConfig](ConfigKeys.kubernetes),
+  testClient: Option[DefaultKubernetesClient] = None)(executionContext: ExecutionContext)(implicit log: Logging,
+                                                                                          as: ActorSystem)
     extends KubernetesApi
     with ProcessRunner {
   implicit protected val ec = executionContext
   implicit protected val am = ActorMaterializer()
   implicit protected val scheduler = as.scheduler
-  implicit protected val kubeRestClient = {
+  implicit protected val kubeRestClient = testClient.getOrElse {
     val configBuilder = new ConfigBuilder()
       .withConnectionTimeout(config.timeouts.logs.toMillis.toInt)
       .withRequestTimeout(config.timeouts.logs.toMillis.toInt)
@@ -145,7 +151,7 @@ class KubernetesClient(
       logLevel = akka.event.Logging.InfoLevel)
 
     //create the pod; catch any failure to end the transaction timer
-    val createdPod = try {
+    Try {
       val created = kubeRestClient.pods.inNamespace(namespace).create(pod)
       pdb.map(
         p =>
@@ -154,36 +160,41 @@ class KubernetesClient(
             .withName(name)
             .create(p))
       created
-    } catch {
-      case e: Throwable =>
+    } match {
+      case Failure(e) =>
+        //call to api-server failed
         transid.failed(this, start, s"Failed create pod for '$name': ${e.getClass} - ${e.getMessage}", ErrorLevel)
-        throw e
-    }
-    //wait for the pod to become ready; catch any failure to end the transaction timer
-    waitForPod(namespace, createdPod, start.start, config.timeouts.run)
-      .map { readyPod =>
-        transid.finished(this, start, logLevel = InfoLevel)
-        toContainer(readyPod)
-      }
-      .recoverWith {
-        case e =>
-          transid.failed(this, start, s"Failed create pod for '$name': ${e.getClass} - ${e.getMessage}", ErrorLevel)
-          //log pod events to diagnose pod readiness failures
-          val podEvents = kubeRestClient.events
-            .inNamespace(namespace)
-            .withField("involvedObject.name", name)
-            .list()
-            .getItems
-            .asScala
-          if (podEvents.isEmpty) {
-            log.info(this, s"No pod events for failed pod '$name'")
-          } else {
-            podEvents.foreach { podEvent =>
-              log.info(this, s"Pod event for failed pod '$name' ${podEvent.getLastTimestamp}: ${podEvent.getMessage}")
-            }
+        Future.failed(KubernetesPodApiException(e))
+      case Success(createdPod) => {
+        //call to api-server succeeded; wait for the pod to become ready; catch any failure to end the transaction timer
+        waitForPod(namespace, createdPod, start.start, config.timeouts.run)
+          .map { readyPod =>
+            transid.finished(this, start, logLevel = InfoLevel)
+            toContainer(readyPod)
           }
-          Future.failed(new Exception(s"Failed to create pod '$name'"))
+          .recoverWith {
+            case e =>
+              transid.failed(this, start, s"Failed create pod for '$name': ${e.getClass} - ${e.getMessage}", ErrorLevel)
+              //log pod events to diagnose pod readiness failures
+              val podEvents = kubeRestClient.events
+                .inNamespace(namespace)
+                .withField("involvedObject.name", name)
+                .list()
+                .getItems
+                .asScala
+              if (podEvents.isEmpty) {
+                log.info(this, s"No pod events for failed pod '$name'")
+              } else {
+                podEvents.foreach { podEvent =>
+                  log.info(
+                    this,
+                    s"Pod event for failed pod '$name' ${podEvent.getLastTimestamp}: ${podEvent.getMessage}")
+                }
+              }
+              Future.failed(e)
+          }
       }
+    }
   }
 
   def rm(container: KubernetesContainer)(implicit transid: TransactionId): Future[Unit] = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -70,6 +70,9 @@ object KubernetesContainer {
 
     for {
       container <- kubernetes.run(podName, image, memory, environment, labels).recoverWith {
+        case _: KubernetesPodApiException =>
+          //apiserver call failed - this will expose a different error to users
+          Future.failed(WhiskContainerStartupError(Messages.resourceProvisionError))
         case _ =>
           kubernetes
             .rm(podName)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/Fabric8ClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/Fabric8ClientTests.scala
@@ -54,7 +54,8 @@ class Fabric8ClientTests
       configMap,
       Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
       false,
-      Some(Map("POD_UID" -> "metadata.uid")))
+      Some(Map("POD_UID" -> "metadata.uid")),
+      None)
 
   it should "fail activation on cold start when apiserver fails" in {
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/Fabric8ClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/Fabric8ClientTests.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.containerpool.kubernetes.test
+
+import java.net.HttpURLConnection
+
+import common.{StreamLogging, WskActorSystem}
+import io.fabric8.kubernetes.api.model.{EventBuilder, PodBuilder}
+import io.fabric8.kubernetes.client.utils.HttpClientUtils.createHttpClientForMockServer
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
+import okhttp3.TlsVersion.TLS_1_0
+import org.apache.openwhisk.common.{ConfigMapValue, TransactionId}
+import org.apache.openwhisk.core.containerpool.kubernetes._
+import org.apache.openwhisk.core.entity.size._
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class Fabric8ClientTests
+    extends FlatSpec
+    with Matchers
+    with WskActorSystem
+    with ScalaFutures
+    with KubeClientSupport
+    with StreamLogging {
+  implicit val tid: TransactionId = TransactionId.testing
+  behavior of "Fabric8Client"
+  val runTimeout = 2.seconds
+  def config(configMap: Option[ConfigMapValue] = None, affinity: Option[KubernetesInvokerNodeAffinity] = None) =
+    KubernetesClientConfig(
+      KubernetesClientTimeoutConfig(runTimeout, 2.seconds),
+      affinity.getOrElse(KubernetesInvokerNodeAffinity(false, "k", "v")),
+      false,
+      None,
+      configMap,
+      Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
+      false,
+      Some(Map("POD_UID" -> "metadata.uid")))
+
+  it should "fail activation on cold start when apiserver fails" in {
+
+    //use an invalid client to simulate broken api server
+    def defaultClient = {
+      val config = new ConfigBuilder()
+        .withMasterUrl("http://localhost:11111") //test assumes that port 11111 will fail in some way
+        .withTrustCerts(true)
+        .withTlsVersions(TLS_1_0)
+        .withNamespace("test")
+        .build
+      new DefaultKubernetesClient(createHttpClientForMockServer(config), config)
+    }
+    val restClient = new KubernetesClient(config(), testClient = Some(defaultClient))(executionContext)
+    restClient.run("fail", "fail", 256.MB).failed.futureValue shouldBe a[KubernetesPodApiException]
+  }
+  it should "fail activation on cold start when pod ready times out" in {
+    val podName = "failWait"
+    server
+      .expect()
+      .post()
+      .withPath("/api/v1/namespaces/test/pods")
+      .andReturn(
+        HttpURLConnection.HTTP_CREATED,
+        new PodBuilder().withNewMetadata().withName(podName).endMetadata().build())
+      .once();
+    server
+      .expect()
+      .get()
+      .withPath("/api/v1/namespaces/test/pods/failWait")
+      .andReturn(HttpURLConnection.HTTP_OK, new PodBuilder().withNewMetadata().withName(podName).endMetadata().build())
+      .times(3)
+    server
+      .expect()
+      .get()
+      .withPath("/api/v1/namespaces/test/events?fieldSelector=involvedObject.name%3DfailWait")
+      .andReturn(
+        HttpURLConnection.HTTP_OK,
+        new EventBuilder().withNewMetadata().withName(podName).endMetadata().build())
+      .once
+
+    implicit val patienceConfig = PatienceConfig(timeout = runTimeout + 1.seconds, interval = 0.5.seconds)
+
+    val restClient = new KubernetesClient(config(), testClient = Some(kubeClient))(executionContext)
+    restClient.run(podName, "anyimage", 256.MB).failed.futureValue shouldBe a[KubernetesPodReadyTimeoutException]
+  }
+}


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
In a previous PR, I attempted to introduce exception handling for when the kubernetes client call `kubeRestClient.pods.inNamespace(namespace).create(pod)` directly throws an exception using logic like:
```
try {
      kubeRestClient.pods.inNamespace(namespace).create(pod)
      ...
    } catch {
      case e: Throwable =>
        throw e
    }
```
But this doesn't return a Future.failed as desired for handling in `KubernetesContainer.create`, rather it just exits the `create()` function, and the activation is never completed with the failure information.

This PR addresses that by capturing the exception via `Try` and explicitly returning an appropriate `Future.failed`. 
Also added tests for this exception handling, and exception handling around timeout while waiting for pod to become ready. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

