### PR TITLE
Adjust log format

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -101,8 +101,8 @@ class AkkaLogging(loggingAdapter: LoggingAdapter) extends Logging {
   }
 
   protected def format(id: TransactionId, name: String, logmsg: String) = {
-    val currentId = if (id.hasParent) id else ""
-    s"[${id.root}] [$currentId] [$name] $logmsg"
+    val currentId = if (id.hasParent) s"[$id] " else ""
+    s"[${id.root}] $currentId[$name] $logmsg"
   }
 }
 


### PR DESCRIPTION
Remove unnecessary `[] ` in logs

## Description
Since https://github.com/apache/openwhisk/pull/4819 introduce the child transactionID, it will add a `[] ` to logs when the transactionId have no child, this PR just remove the useless `[] `

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

