### PR TITLE
Make k8s read action logs correctly

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -20,6 +20,7 @@ package org.apache.openwhisk.core.containerpool.kubernetes
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import java.time.{Instant, ZoneId}
 
 import akka.actor.ActorSystem
@@ -331,7 +332,8 @@ object KubernetesClient {
     .parseCaseInsensitive()
     .appendPattern("u-MM-dd")
     .appendLiteral('T')
-    .appendPattern("HH:mm:ss[.n]")
+    .appendPattern("HH:mm:ss")
+    .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
     .appendLiteral('Z')
     .toFormatter()
     .withZone(ZoneId.of("UTC"))
@@ -401,7 +403,7 @@ object KubernetesRestLogSourceStage {
         TypedLogLine(timestamp, stream, msg)
       }) match {
         case Some(logLine) =>
-          readLines(src, Option(logLine.time), lines :+ logLine)
+          readLines(src, lastTimestamp, lines :+ logLine)
         case None =>
           // we may have skipped a line for filtering conditions only; keep going
           readLines(src, lastTimestamp, lines)


### PR DESCRIPTION
Make k8s read action logs correctly

## Description

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#4932 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

