### PR TITLE
activation metrics are recorded for namespace even if set to ignore by user-events service.

### DIFF
--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/EventConsumer.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/EventConsumer.scala
@@ -55,7 +55,7 @@ case class EventConsumer(settings: ConsumerSettings[String, String],
   private implicit val ec: ExecutionContext = system.dispatcher
 
   //Record the rate of events received
-  private val activationNamespaceCounter = Kamon.counter("openwhisk.namespace.activations.total")
+  private val activationNamespaceCounter = Kamon.counter("openwhisk.namespace.activations")
   private val activationCounter = Kamon.counter("openwhisk.userevents.global.activations").withoutTags()
   private val metricCounter = Kamon.counter("openwhisk.userevents.global.metric").withoutTags()
 

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/EventConsumer.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/EventConsumer.scala
@@ -30,6 +30,7 @@ import javax.management.ObjectName
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import kamon.Kamon
 import kamon.metric.MeasurementUnit
+import kamon.tag.TagSet
 import org.apache.kafka.common
 import org.apache.kafka.common.MetricName
 import org.apache.openwhisk.connector.kafka.{KafkaMetricsProvider, KamonMetricsReporter}
@@ -41,7 +42,7 @@ import org.apache.openwhisk.core.entity.ActivationResponse
 import org.apache.openwhisk.core.monitoring.metrics.OpenWhiskEvents.MetricConfig
 
 trait MetricRecorder {
-  def processActivation(activation: Activation, initiatorNamespace: String, metricConfig: MetricConfig): Unit
+  def processActivation(activation: Activation, initiatorNamespace: String): Unit
   def processMetric(metric: Metric, initiatorNamespace: String): Unit
 }
 
@@ -54,6 +55,7 @@ case class EventConsumer(settings: ConsumerSettings[String, String],
   private implicit val ec: ExecutionContext = system.dispatcher
 
   //Record the rate of events received
+  private val activationNamespaceCounter = Kamon.counter("openwhisk.namespace.activations.total")
   private val activationCounter = Kamon.counter("openwhisk.userevents.global.activations").withoutTags()
   private val metricCounter = Kamon.counter("openwhisk.userevents.global.metric").withoutTags()
 
@@ -122,15 +124,22 @@ case class EventConsumer(settings: ConsumerSettings[String, String],
       .foreach { e =>
         e.body match {
           case a: Activation =>
-            recorders.foreach(_.processActivation(a, e.namespace, metricConfig))
-            updateGlobalMetrics(a)
+            // only record activation if not executed in an ignored namespace
+            if (!metricConfig.ignoredNamespaces.contains(e.namespace)) {
+              recorders.foreach(_.processActivation(a, e.namespace))
+            }
+            updateGlobalMetrics(a, e.namespace)
           case m: Metric =>
             recorders.foreach(_.processMetric(m, e.namespace))
         }
       }
   }
 
-  private def updateGlobalMetrics(a: Activation): Unit = {
+  private def updateGlobalMetrics(a: Activation, e: String): Unit = {
+    val namespaceTag: String = metricConfig.renameTags.getOrElse("namespace", "namespace")
+    val initiatorTag: String = metricConfig.renameTags.getOrElse("initiator", "initiator")
+    val tagSet = TagSet.from(Map(initiatorTag -> e, namespaceTag -> e))
+    activationNamespaceCounter.withTags(tagSet).increment()
     a.status match {
       case ActivationResponse.statusSuccess          => statusSuccess.increment()
       case ActivationResponse.statusApplicationError => statusApplicationError.increment()

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorder.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorder.scala
@@ -61,7 +61,9 @@ case class PrometheusRecorder(kamon: PrometheusReporter, config: MetricConfig)
   private val promMetrics = PrometheusMetrics()
 
   override def processActivation(activation: Activation, initiator: String, metricConfig: MetricConfig): Unit = {
-    lookup(activation, initiator).record(activation, initiator, metricConfig)
+    if (!metricConfig.ignoredNamespaces.contains(activation.namespace)) {
+      lookup(activation, initiator).record(activation, initiator, metricConfig)
+    }
   }
 
   override def processMetric(metric: Metric, initiator: String): Unit = {

--- a/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorder.scala
+++ b/core/monitoring/user-events/src/main/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorder.scala
@@ -37,7 +37,6 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 
 trait PrometheusMetricNames extends MetricNames {
-  val namespaceMetric = "openwhisk_namespace_activations_total"
   val activationMetric = "openwhisk_action_activations_total"
   val coldStartMetric = "openwhisk_action_coldStarts_total"
   val waitTimeMetric = "openwhisk_action_waitTime_seconds"
@@ -60,10 +59,8 @@ case class PrometheusRecorder(kamon: PrometheusReporter, config: MetricConfig)
   private val limitMetrics = new TrieMap[String, LimitPromMetrics]
   private val promMetrics = PrometheusMetrics()
 
-  override def processActivation(activation: Activation, initiator: String, metricConfig: MetricConfig): Unit = {
-    if (!metricConfig.ignoredNamespaces.contains(activation.namespace)) {
-      lookup(activation, initiator).record(activation, initiator, metricConfig)
-    }
+  override def processActivation(activation: Activation, initiator: String): Unit = {
+    lookup(activation, initiator).record(activation, initiator)
   }
 
   override def processMetric(metric: Metric, initiator: String): Unit = {
@@ -106,7 +103,6 @@ case class PrometheusRecorder(kamon: PrometheusReporter, config: MetricConfig)
                                    memory: String,
                                    initiatorNamespace: String) {
 
-    private val namespaceActivations = promMetrics.namespaceActivationCounter.labels(namespace, initiatorNamespace)
     private val activations = promMetrics.activationCounter.labels(namespace, initiatorNamespace, action, kind, memory)
     private val coldStarts = promMetrics.coldStartCounter.labels(namespace, initiatorNamespace, action)
     private val waitTime = promMetrics.waitTimeHisto.labels(namespace, initiatorNamespace, action)
@@ -125,13 +121,8 @@ case class PrometheusRecorder(kamon: PrometheusReporter, config: MetricConfig)
     private val statusInternalError =
       promMetrics.statusCounter.labels(namespace, initiatorNamespace, action, ActivationResponse.statusWhiskError)
 
-    def record(a: Activation, initiator: String, metricConfig: MetricConfig): Unit = {
-      namespaceActivations.inc()
-
-      // only record activation if not executed in an ignored namespace
-      if (!metricConfig.ignoredNamespaces.contains(a.namespace)) {
-        recordActivation(a, initiator)
-      }
+    def record(a: Activation, initiator: String): Unit = {
+      recordActivation(a, initiator)
     }
 
     def recordActivation(a: Activation, initiator: String): Unit = {
@@ -171,9 +162,6 @@ case class PrometheusRecorder(kamon: PrometheusReporter, config: MetricConfig)
     private val memory = config.renameTags.getOrElse(actionMemory, actionMemory)
     private val status = config.renameTags.getOrElse(actionStatus, actionStatus)
     private val statusCode = config.renameTags.getOrElse(userDefinedStatusCode, userDefinedStatusCode)
-
-    val namespaceActivationCounter =
-      counter(namespaceMetric, "Namespace activations Count", namespace, initiator)
 
     val activationCounter =
       counter(activationMetric, "Activation Count", namespace, initiator, action, kind, memory)

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
@@ -58,7 +58,6 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
 
   behavior of "KamonConsumer"
 
-  val initiator = "initiatorTest"
   val namespaceDemo = "demo"
   val namespaceGuest = "guest"
   val actionWithCustomPackage = "apimgmt/createApi"
@@ -109,10 +108,8 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
     TestReporter.histogram(durationMetric, namespaceDemo, actionWithDefaultPackage).size shouldBe 1
 
     // Blacklisted namespace should not be tracked
-    TestReporter.counter(activationMetric, namespaceGuest, actionWithDefaultPackage)(0).value shouldBe 0
+    TestReporter.counter(activationMetric, namespaceGuest, actionWithDefaultPackage) shouldBe empty
 
-    // Blacklisted should be counted in "openwhisk.namespace.activations" metric
-    TestReporter.namespaceCounter(namespaceActivationMetric, namespaceGuest)(0).value shouldBe 1
   }
 
   private def newActivationEvent(actionPath: String) =
@@ -130,7 +127,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
         memory,
         None),
       Subject("testuser"),
-      initiator,
+      actionPath.split("/")(0),
       UUID("test"),
       Activation.typeName)
 
@@ -154,7 +151,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
         .filter(_.name == metricName)
         .flatMap(_.instruments)
         .filter(_.tags.get(Lookups.plain(actionNamespace)) == namespace)
-        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == initiator)
+        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == namespace)
         .filter(_.tags.get(Lookups.plain(actionName)) == action)
     }
 
@@ -165,7 +162,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
         .filter(_.name == metricName)
         .flatMap(_.instruments)
         .filter(_.tags.get(Lookups.plain(actionNamespace)) == namespace)
-        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == initiator)
+        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == namespace)
     }
 
     def histogram(metricName: String, namespace: String, action: String) = {
@@ -175,7 +172,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
         .filter(_.name == metricName)
         .flatMap(_.instruments)
         .filter(_.tags.get(Lookups.plain(actionNamespace)) == namespace)
-        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == initiator)
+        .filter(_.tags.get(Lookups.plain(initiatorNamespace)) == namespace)
         .filter(_.tags.get(Lookups.plain(actionName)) == action)
     }
   }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
If a namespace is in `ignore-namespace` configuration, user-events service still sends activation metrics though they are not incremented in case of counter or not updated in case of the histogram. Even though the value of metrics is not updated, it still creates a large amount of time series in case of canary service or load is creating unique actions and eventually can cause high cardinality. 
  

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Monitoring
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

