### PR TITLE
Force Delete Non-Empty Packages

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1443,7 +1443,7 @@
           },
           {
             "name": "force",
-            "in": "path",
+            "in": "query",
             "description": "Force delete a package if it contains entities removing everything in it. Default is false.",
             "required": false,
             "type": "string",

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -1440,6 +1440,17 @@
             "description": "Name of package",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "path",
+            "description": "Force delete a package if it contains entities removing everything in it. Default is false.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ]
           }
         ],
         "responses": {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -135,15 +135,26 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
           } getOrElse {
             // may only delete a package if all its ingredients are deleted already or force flag is set
             WhiskAction
-              .listCollectionInNamespace(entityStore, wp.namespace.addPath(wp.name), includeDocs = true, skip = 0, limit = 0) flatMap {
+              .listCollectionInNamespace(
+                entityStore,
+                wp.namespace.addPath(wp.name),
+                includeDocs = true,
+                skip = 0,
+                limit = 0) flatMap {
               case Right(list) if list.nonEmpty && force =>
                 Future sequence {
                   list.map(action => {
-                    WhiskAction.get(entityStore, wp.fullyQualifiedName(false).add(action.fullyQualifiedName(false).name).toDocId) flatMap { actionWithRevision =>
+                    WhiskAction.get(
+                      entityStore,
+                      wp.fullyQualifiedName(false)
+                        .add(action.fullyQualifiedName(false).name)
+                        .toDocId) flatMap { actionWithRevision =>
                       WhiskAction.del(entityStore, actionWithRevision.docinfo)
                     }
                   })
-                } flatMap { _ => Future.successful({}) }
+                } flatMap { _ =>
+                  Future.successful({})
+                }
               case Right(list) if list.nonEmpty && !force =>
                 Future failed {
                   RejectRequest(

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -112,7 +112,8 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
   }
 
   /**
-   * Deletes package/binding. If a package, may only be deleted if there are no entities in the package.
+   * Deletes package/binding. If a package, may only be deleted if there are no entities in the package
+   * or force parameter is set to true, which will delete all contents of the package before deleting.
    *
    * Responses are one of (Code, Message)
    * - 200 WhiskPackage as JSON
@@ -121,29 +122,42 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
    * - 500 Internal Server Error
    */
   override def remove(user: Identity, entityName: FullyQualifiedEntityName)(implicit transid: TransactionId) = {
-    deleteEntity(
-      WhiskPackage,
-      entityStore,
-      entityName.toDocId,
-      (wp: WhiskPackage) => {
-        wp.binding map {
-          // this is a binding, it is safe to remove
-          _ =>
-            Future.successful({})
-        } getOrElse {
-          // may only delete a package if all its ingredients are deleted already
-          WhiskAction
-            .listCollectionInNamespace(entityStore, wp.namespace.addPath(wp.name), skip = 0, limit = 0) flatMap {
-            case Left(list) if (list.size != 0) =>
-              Future failed {
-                RejectRequest(
-                  Conflict,
-                  s"Package not empty (contains ${list.size} ${if (list.size == 1) "entity" else "entities"})")
-              }
-            case _ => Future.successful({})
+    parameter('force ? false) { force =>
+      deleteEntity(
+        WhiskPackage,
+        entityStore,
+        entityName.toDocId,
+        (wp: WhiskPackage) => {
+          wp.binding map {
+            // this is a binding, it is safe to remove
+            _ =>
+              Future.successful({})
+          } getOrElse {
+            // may only delete a package if all its ingredients are deleted already or force flag is set
+            WhiskAction
+              .listCollectionInNamespace(entityStore, wp.namespace.addPath(wp.name), includeDocs = true, skip = 0, limit = 0) flatMap {
+              case Right(list) if list.nonEmpty =>
+                if (force) {
+                  Future sequence {
+                    list.map(action => {
+                      WhiskAction.get(entityStore, wp.fullyQualifiedName(false).add(action.fullyQualifiedName(false).name).toDocId) flatMap { actionWithRevision =>
+                        WhiskAction.del(entityStore, actionWithRevision.docinfo)
+                      }
+                    })
+                  } flatMap { _ => Future.successful({}) }
+                } else {
+                  Future failed {
+                    RejectRequest(
+                      Conflict,
+                      s"Package not empty (contains ${list.size} ${if (list.size == 1) "entity" else "entities"}). Set force param or delete package contents.")
+                  }
+                }
+              case _ =>
+                Future.successful({})
+            }
           }
-        }
-      })
+        })
+    }
   }
 
   /**

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -316,6 +316,15 @@ curl -u $AUTH https://$APIHOST/api/v1/namespaces/_/packages/iot?overwrite=true \
 -d '{"namespace":"_","name":"iot"}'
 ```
 
+To force delete a package that contains entities, set the force parameter to true. Failure
+will return an error either for failure to delete an action within the package or the package itself.
+The package will not be attempted to be deleted until all actions are successfully deleted.
+
+```bash
+curl -u $AUTH https://$APIHOST/api/v1/namespaces/_/packages/iot?force=true \
+-X DELETE
+```
+
 ## Activations
 
 To get the list of the last 3 activations use a HTTP request with a `GET` method, passing the query parameter `limit=3`

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -832,10 +832,11 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
       }
     }
 
+    val exceptionString = "Package not empty (contains 1 entity). Set force param or delete package contents."
     Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(Conflict)
       val response = responseAs[ErrorResponse]
-      response.error should include("Package not empty (contains 1 entity). Set force param or delete package contents.")
+      response.error should include(exceptionString)
       response.code.id should not be empty
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -797,7 +797,28 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     }
   }
 
-  it should "reject delete non-empty package" in {
+  it should "delete package and its actions if force flag is set to true" in {
+    implicit val tid = transid()
+    val provider = WhiskPackage(namespace, aname())
+    val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
+    put(entityStore, provider)
+    put(entityStore, action)
+    org.apache.openwhisk.utils.retry {
+      Get(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
+        status should be(OK)
+        val response = responseAs[JsObject]
+        response.fields("actions").asInstanceOf[JsArray].elements.length should be(1)
+      }
+    }
+
+    Delete(s"$collectionPath/${provider.name}?force=true") ~> Route.seal(routes(creds)) ~> check {
+      status should be(OK)
+      val response = responseAs[WhiskPackage]
+      response should be(provider)
+    }
+  }
+
+  it should "reject delete non-empty package if force flag is not set" in {
     implicit val tid = transid()
     val provider = WhiskPackage(namespace, aname())
     val action = WhiskAction(provider.namespace.addPath(provider.name), aname(), jsDefault("??"))
@@ -814,7 +835,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     Delete(s"$collectionPath/${provider.name}") ~> Route.seal(routes(creds)) ~> check {
       status should be(Conflict)
       val response = responseAs[ErrorResponse]
-      response.error should include("Package not empty (contains 1 entity)")
+      response.error should include("Package not empty (contains 1 entity). Set force param or delete package contents.")
       response.code.id should not be empty
     }
   }


### PR DESCRIPTION
## Description
Adds a force parameter to the delete package api so any actions in the package are deleted with it before confirming and deleting the package. If force is not set (by default), it still returns the same error of needing to delete the actions first before deleting the package. 

I could use some help on optimizing the package deletion because currently I need to do a get action list to get the list of actions in the package to check if it's non-empty which was already a part of the route, and then I have to do a get on the actions to get the revision id before I can delete the action. I don't think this is too much of an issue because normal action deletes have to do this get then delete anyways I believe. Any advice here would be appreciated because of my lack of familiarity with the code. It does work as is though currently.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#1824)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

