### PR TITLE
attempt to migrate dockerhub Jenkins job to generic ubuntu nodes

### DIFF
--- a/tools/jenkins/apache/dockerhub.groovy
+++ b/tools/jenkins/apache/dockerhub.groovy
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-node('openwhisk1||openwhisk2||openwhisk3') {
+node('ubuntu') {
   sh "env"
   sh "docker version"
   sh "docker info"


### PR DESCRIPTION
Apache Jenkins service is migrating to a new CloudBees instance.  The dedicated OpenWhisk nodes are not being migrated.  Attempt to use a generic ubuntu worker node for the job to periodically build docker images from the core repo.
