### PR TITLE
fix deploy description in readme

### DIFF
--- a/docs/actions-go.md
+++ b/docs/actions-go.md
@@ -73,9 +73,9 @@ The runtime `action-golang-v1.11` accepts:
 - executable binaries in Linux ELF executable compiled for the AMD64 architecture
 - zip files containing a binary executable named `exec` at the top level, again a Linux ELF executable compiled for the AMD64 architecture
 - a single source file in Go, that will be compiled
-- a zip file not containing in the top level a binary file `exec`, it will be interpreted as a collection of zip files, and compiled
+- a zip file not containing in the top level a binary file `exec`, it will be interpreted as a collection of source files in Go, and compiled
 
-You can create a binary in the correct format on any GO platform cross-compiling with `GOOS=Linux` and `GOARCH=amd64`. However it is recommended you use the compiler embedded in the Docker image for this purpose using the precompilation feature, as described below.
+You can create a binary in the correct format on any Go platform cross-compiling with `GOOS=Linux` and `GOARCH=amd64`. However it is recommended you use the compiler embedded in the Docker image for this purpose using the precompilation feature, as described below.
 
 ## Using packages and vendor folder
 


### PR DESCRIPTION
Readme appears to have an incorrect description of how the deploy process works when it's a zip file.

## Description
I'm not super familiar with OpenWhisk yet, but from tinkering with IBM Cloud Functions, and doing deploys involving both raw source code files and zip archives, this description in the readme doesn't sound accurate. I think what it was meant to say was that the zip archive would have either an executable or one or more Go source code files.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

