### PR TITLE
add defensive code for dealing with loadbalancer concurrency tracking

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/NestedSemaphore.scala
@@ -100,14 +100,19 @@ class NestedSemaphore[T](memoryPermits: Int) extends ForcibleSemaphore(memoryPer
     if (maxConcurrent == 1) {
       super.release(memoryPermits)
     } else {
-      val concurrentSlots = actionConcurrentSlotsMap(actionid)
-      val (memoryRelease, actionRelease) = concurrentSlots.release(1, true)
-      //concurrent slots
-      if (memoryRelease) {
-        super.release(memoryPermits)
-      }
-      if (actionRelease) {
-        actionConcurrentSlotsMap.remove(actionid)
+      //This map may be recreated (multiple times) due to cluster membership events, so don't assume the entry exists...
+      actionConcurrentSlotsMap.get(actionid) match {
+        case Some(concurrentSlots) =>
+          val (memoryRelease, actionRelease) = concurrentSlots.release(1, true)
+          //concurrent slots
+          if (memoryRelease) {
+            super.release(memoryPermits)
+          }
+          if (actionRelease) {
+            actionConcurrentSlotsMap.remove(actionid)
+          }
+        case None =>
+        //this case can occur if one or more cluster members is restarted, resetting the state of the outstanding activations
       }
     }
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/MessageConsumer.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/MessageConsumer.scala
@@ -213,7 +213,13 @@ class MessageFeed(description: String,
       outstandingMessages = outstandingMessages.tail
 
       if (logHandoff) logging.debug(this, s"processing $topic[$partition][$offset] ($occupancy/$handlerCapacity)")
-      handler(bytes)
+      handler(bytes).andThen {
+        {
+          case Failure(e) =>
+            logging.error(this, s"Failed to process message for topic $topic : $e  (stack trace included)")
+            e.printStackTrace()
+        }
+      }
       handlerCapacity -= 1
 
       sendOutstandingMessages()


### PR DESCRIPTION
Defensive code for concurrency tracking in sharding loadbalancer.

## Description
We saw some cases where controller ack processing was incomplete for some activations, which turned out to be:
* cluster state change would reset the concurrency tracking (for concurrent activations, -c > 1)
* the concurrency tracking logic did not tolerate the resets, which happen several times for each cluster state change
* the ack message processing would fail silently

This PR does 2 things:
* add defensive code to the concurrency tracking logic (to tolerate these state resets during cluster state changes)
* add extra logging to message processing to increase visibility of failed message handling

This was not caught in tests due to the multi-controller cluster state changes, plus concurrency, required to reproduce the symptom.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [x] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

