### PR TITLE
Add defensive code to the controller for when it gets bad query parameters

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -120,7 +120,15 @@ trait BasicHttpService extends Directives {
   protected def logRequestInfo(req: HttpRequest)(implicit tid: TransactionId): LogEntry = {
     val m = req.method.name
     val p = req.uri.path.toString
-    val q = req.uri.query().toString
+
+    val q: String = {
+      try {
+        req.uri.query().toString
+      } catch {
+        case _: IllegalUriException => s"Bad query parameters:${req.uri.toString()}"
+        case e: Exception => s"Query parsing error: ${e.getMessage}"
+      }
+    }
     val l = loglevelForRoute(p)
     LogEntry(s"[$tid] $m $p $q", l)
   }

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicHttpService.scala
@@ -126,7 +126,7 @@ trait BasicHttpService extends Directives {
         req.uri.query().toString
       } catch {
         case _: IllegalUriException => s"Bad query parameters:${req.uri.toString()}"
-        case e: Exception => s"Query parsing error: ${e.getMessage}"
+        case e: Exception           => s"Query parsing error: ${e.getMessage}"
       }
     }
     val l = loglevelForRoute(p)


### PR DESCRIPTION
## Description
When you sent the controller a malformed query string it would incorrectly return a 500 error, on top of that it wouldn't even log things properly. This adds some simple defensive code to prevent both issues.

For example:

```
curl -v "http://<controller_ip>:<controller_port>/?p=%2"
```
Would result in a 500 error from the controller. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

