### PR TITLE
improve http graceful termination

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -97,8 +97,17 @@ kamon {
         }
     }
 }
-
+akka {
+    # required to allow longer shutdown-termination-limit below
+    coordinated-shutdown.default-phase-timeout = 61 s
+}
 whisk {
+    http {
+        shutdown-unready-delay = 15 seconds # /ready will return 500 for this amount of time before connection draining starts
+        shutdown-termination-limit = 61 seconds # hard limit on how long (after unready delay) requests have to complete
+    }
+
+
     shared-packages-execute-only = false
     metrics {
         # Enable/disable Prometheus support. If enabled then metrics would be exposed at `/metrics` endpoint

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/BasicRasService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/BasicRasService.scala
@@ -18,15 +18,16 @@
 package org.apache.openwhisk.http
 
 import akka.event.Logging
-import org.apache.openwhisk.common.{MetricsRoute, TransactionId}
+import akka.http.scaladsl.model.StatusCodes
+import org.apache.openwhisk.common.{Logging, MetricsRoute, TransactionId}
 
 /**
  * This trait extends the BasicHttpService with a standard "ping" endpoint which
  * responds to health queries, intended for monitoring.
  */
-trait BasicRasService extends BasicHttpService {
+class BasicRasService(implicit val logging: Logging) extends BasicHttpService {
 
-  override def routes(implicit transid: TransactionId) = ping ~ MetricsRoute()
+  override def routes(implicit transid: TransactionId) = ping ~ ready ~ MetricsRoute()
 
   override def loglevelForRoute(route: String): Logging.LogLevel = {
     if (route == "/ping" || route == "/metrics") {
@@ -38,5 +39,15 @@ trait BasicRasService extends BasicHttpService {
 
   val ping = path("ping") {
     get { complete("pong") }
+  }
+  val ready = path("ready") {
+    get {
+      if (BasicHttpService.ready) {
+        complete("ok")
+      } else {
+        logging.warn(this, "not ready...")
+        complete(StatusCodes.ServiceUnavailable, "notready")
+      }
+    }
   }
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Controller.scala
@@ -77,7 +77,7 @@ class Controller(val instance: ControllerInstanceId,
                  implicit val whiskConfig: WhiskConfig,
                  implicit val actorSystem: ActorSystem,
                  implicit val materializer: ActorMaterializer,
-                 implicit val logging: Logging)
+                 override implicit val logging: Logging)
     extends BasicRasService {
 
   TransactionId.controller.mark(
@@ -288,7 +288,8 @@ object Controller {
 
         BasicHttpService.startHttpService(controller.route, port, httpsConfig, interface)(
           actorSystem,
-          controller.materializer)
+          controller.materializer,
+          logger)
 
       case Failure(t) =>
         abort(s"Invalid runtimes manifest: $t")

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -194,7 +194,8 @@ object Invoker {
     val invokerServer = SpiLoader.get[InvokerServerProvider].instance(invoker)
     BasicHttpService.startHttpService(invokerServer.route, port, httpsConfig)(
       actorSystem,
-      ActorMaterializer.create(actorSystem))
+      ActorMaterializer.create(actorSystem),
+      logger)
   }
 }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Deploying controller to kubernetes, we see some case where using /ping as livenessProbe and readinessProbe does not provide great resilience when deleting a controller pod while under load. A typical case for controller unexpected shutdown under load is eviction process for cluster autoscaler, or node maintenance.

This PR provides:
* a separate /ready endpoint that will return 503 for a configurable amount of time upon SIGTERM
* better logging for http service shutdown procedure
* use of CoordinatedShutdown (instead of system hook) to terminate akka http service

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

