### PR TITLE
Fix InstanceId Incompatibility

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/InstanceId.scala
@@ -103,6 +103,8 @@ object ControllerInstanceId extends DefaultJsonProtocol {
           } else {
             deserializationError("could not read ControllerInstanceId")
           }
+        case Seq(JsString(asString)) =>
+          new ControllerInstanceId(asString)
         case _ =>
           deserializationError("could not read ControllerInstanceId")
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ControllerInstanceIdTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ControllerInstanceIdTests.scala
@@ -46,6 +46,11 @@ class ControllerInstanceIdTests extends FlatSpec with Matchers {
     }
   }
 
+  it should "deserialize legacy ControllerInstanceId format" in {
+    val i = ControllerInstanceId("controller0")
+    ControllerInstanceId.parse(JsObject("asString" -> JsString("controller0")).compactPrint) shouldBe Success(i)
+  }
+
   it should "serialize and deserialize ControllerInstanceId" in {
     val i = ControllerInstanceId("controller0")
     i.serialize shouldBe JsObject("asString" -> JsString(i.asString), "instanceType" -> JsString(i.instanceType)).compactPrint


### PR DESCRIPTION
## Description
Fixes deserialization issue for new instance id format for upgrades of live services that cannot have downtime.  Fix will provide upgrade path to upgrade controllers and invokers safely.

1. When upgrading the invokers to latest, the `ControllerInstanceId` in `ActivationMessage` fails to deserialize because the `instanceType` is not included in the message sent from the non-upgraded controllers.
2. Vice versa controllers fail to upgrade if invokers have not been upgraded yet because the completion messages can not deserialize in the controller because the invokers aren't including `instanceType`.
3. The fix here fixes case 1 so that `ControllerInstanceId` will still deserialize if `instanceType` is not included.
4. Upgrade all invokers in your cluster, wait a few minutes so all completed topics are consuming post upgrade messages that now include `instanceType`
5. Upgrade controllers safely because invokers are now upgraded with the newly formatted messages.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [x] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

