### PR TITLE
[WIP/Seeking Feedback] Add cold start containers to busy pool

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerPool.scala
@@ -172,32 +172,6 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
           } else None
 
         createdContainer match {
-          case None =>
-            // None can happen if createContainer fails to start a new container, or
-            // if a job is rescheduled but the container it was allocated to has not yet destroyed itself
-            // (and a new container would over commit the pool)
-            val isErrorLogged = r.retryLogDeadline.map(_.isOverdue).getOrElse(true)
-            val retryLogDeadline = if (isErrorLogged) {
-              logging.warn(
-                this,
-                s"Rescheduling Run message, too many message in the pool, " +
-                  s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
-                  s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
-                  s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
-                  s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
-                  s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
-                  s"waiting messages: ${runBuffer.size}")(r.msg.transid)
-              MetricEmitter.emitCounterMetric(LoggingMarkers.CONTAINER_POOL_RESCHEDULED_ACTIVATION)
-              Some(logMessageInterval.fromNow)
-            } else {
-              r.retryLogDeadline
-            }
-            if (!isResentFromBuffer) {
-              // Add this request to the buffer, as it is not there yet.
-              runBuffer = runBuffer.enqueue(Run(r.action, r.msg, retryLogDeadline))
-            }
-          //buffered items will be processed via processBufferOrFeed()
-
           case Some(((actor, data), "cold")) =>
             // Initialize the container and re-queue the activation
             // This avoids blocking (with respect to the current activation) while the container is starting up.
@@ -205,7 +179,6 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
             actor ! PreRun(r.action, r.msg, r.retryLogDeadline)
             busyPool = busyPool + (actor -> data)
             runBuffer = runBuffer.enqueue(r)
-
           case Some(((actor, data), containerState)) =>
             //increment active count before storing in pool map
             val newData = data.nextRun(r)
@@ -239,6 +212,31 @@ class ContainerPool(childFactory: ActorRefFactory => ActorRef,
             }
             actor ! r // forwards the run request to the container
             logContainerStart(r, containerState, newData.activeActivationCount, container)
+          case None =>
+            // this can also happen if createContainer fails to start a new container, or
+            // if a job is rescheduled but the container it was allocated to has not yet destroyed itself
+            // (and a new container would over commit the pool)
+            val isErrorLogged = r.retryLogDeadline.map(_.isOverdue).getOrElse(true)
+            val retryLogDeadline = if (isErrorLogged) {
+              logging.warn(
+                this,
+                s"Rescheduling Run message, too many message in the pool, " +
+                  s"freePoolSize: ${freePool.size} containers and ${memoryConsumptionOf(freePool)} MB, " +
+                  s"busyPoolSize: ${busyPool.size} containers and ${memoryConsumptionOf(busyPool)} MB, " +
+                  s"maxContainersMemory ${poolConfig.userMemory.toMB} MB, " +
+                  s"userNamespace: ${r.msg.user.namespace.name}, action: ${r.action}, " +
+                  s"needed memory: ${r.action.limits.memory.megabytes} MB, " +
+                  s"waiting messages: ${runBuffer.size}")(r.msg.transid)
+              MetricEmitter.emitCounterMetric(LoggingMarkers.CONTAINER_POOL_RESCHEDULED_ACTIVATION)
+              Some(logMessageInterval.fromNow)
+            } else {
+              r.retryLogDeadline
+            }
+            if (!isResentFromBuffer) {
+              // Add this request to the buffer, as it is not there yet.
+              runBuffer = runBuffer.enqueue(Run(r.action, r.msg, retryLogDeadline))
+            }
+          //buffered items will be processed via processBufferOrFeed()
         }
       } else {
         // There are currently actions waiting to be executed before this action gets executed.


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

The motivation for this change is essentially that some activations trigger the creation of new containers, which has the potentially to be a very long operation depending (e.g., if the creation of the container triggered a scale-up in cluster size), and OpenWhisk will block (with respect to that activation) until the container is created. This is not ideal since oftentimes, other containers become free and ready to service the request in the meantime.

This change:
* Immediately moves cold start containers into the busy queue and waits for them to send `NeedWork` to the `ContainerPool` (this means that the activation will run on the next available container that can service the request)
* Adds a `PreRun` event that is sent to the container to tell it how to initialize

### Current Issues
This doesn't currently pass all the tests, but I suspect I'm at the limit of what I can do here (as I don't have lots of other context around the codebase and the project overall).

* There feels like a weird parallel-but-not-quite pathway between prewarm and cold-start containers now (since now, both have an initialization step, but the prewarm has the stem-cell-differentiation step as well). It would be nice to simplify that if possible.


> Quick note on my terminology, since I think I understand how these words are used, but want to make sure:
> * action = "specification for how to handle a request" (eg, using blackbox image or nodejs runtime)
> * activation = "specific request that is handled by an action"

The run buffer only considers the current head of the run queue (for activations that couldn't be immediately sent to containers), which is not ideal. Imagine this scenario:
* Run A (using image 1) triggers a cold start, A is enqueued on the run buffer
* Run B (using image 2) triggers a cold start, B is enqueued on the run buffer (position 1)
* Container 2 finishes initialization (maybe it didn't require pulling an image while image 1 did have to be pulled)
* The ContainerPool gets `NeedWork` from container 2, moves container 2 into the free pool, triggers `processBufferOrFeed()`
* `processBufferOrFeed` re-sends the first run on the buffer, which is run A
* There are no containers available to service run A (since it's still initializing)
* Run A is re-enqueued and nothing else happens (even though run B could have been serviced)
* Container 1 finishes initializing, sends `NeedWork`
* Run A is de-queued again, and now handled
* Run B is never actually handled???

One solution to this might be to add another layer between ContainerPool and ContainerProxy which would be something like `ActionPool`. The `ActionPool` would handle the creation of new containers and serving requests in the order in which they're received, but that gets messy when you need to restrict the total size of the ContainerPool (and it's also messy when there are resource contention issues - what happens when two different actions want to scale up the number of containers but the container pool is at the max size? right now, it would attempt to reap some old containers to service the next activation, so it's fair with respect to activation order). 

A (potentially simpler) solution might just be to have per-action buffers, so when you get a `NeedWork` corresponding to action 1, dequeue from that specific buffer.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
#4974 

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

