### PR TITLE
Add Activation Error Logging Config to Container Proxy

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -248,6 +248,7 @@ object ConfigKeys {
   val containerProxy = "whisk.container-proxy"
   val containerProxyTimeouts = s"$containerProxy.timeouts"
   val containerProxyHealth = s"$containerProxy.action-health-check"
+  val containerProxyActivationErrorLogs = s"$containerProxy.log-activation-errors"
 
   val s3 = "whisk.s3"
   val query = "whisk.query-limit"

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -157,6 +157,12 @@ whisk {
       check-period = 3 seconds # how often should prewarm containers be pinged (tcp connection attempt)
       max-fails = 3 # prewarm containers that fail this number of times will be destroyed and replaced
     }
+
+    log-activation-errors {
+      application-errors = false
+      developer-errors = false
+      whisk-errors = true
+    }
   }
 
   # tracing configuration

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -937,7 +937,7 @@ class ContainerProxy(factory: (TransactionId,
     activationWithLogs.flatMap {
       case Right(act) if !act.response.isSuccess && !act.response.isApplicationError =>
         val truncatedResult = truncatedError(act)
-        logging.info(
+        logging.warn(
           this,
           s"Activation ${act.activationId} was unsuccessful at container ${stateData.getContainer} (with ${activeCount} still active) due to ${truncatedResult}")
         Future.failed(ActivationUnsuccessfulError(act))
@@ -945,7 +945,7 @@ class ContainerProxy(factory: (TransactionId,
       case Right(act) =>
         if (act.response.isApplicationError) {
           val truncatedResult = truncatedError(act)
-          logging.error(
+          logging.info(
             this,
             s"Activation ${act.activationId} at container ${stateData.getContainer} (with ${activeCount} still active) returned an error ${truncatedResult}")
         }


### PR DESCRIPTION
## Description
Change new activation error logs to warn level and add a config on whether to output the activation errors to log for each activation error type. Application and developer errors default to false. Whisk errors default to true as a whisk error implies an internal system error.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

