### PR TITLE
Go version currency - add 1.15 and deprecate 1.11

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -196,6 +196,20 @@
         "go": [
             {
                 "kind": "go:1.11",
+                "default": false,
+                "deprecated": true,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                },
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-golang-v1.11",
+                    "tag": "nightly"
+                }
+            },
+            {
+                "kind": "go:1.15",
                 "default": true,
                 "deprecated": false,
                 "attached": {
@@ -204,7 +218,7 @@
                 },
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "action-golang-v1.11",
+                    "name": "action-golang-v1.15",
                     "tag": "nightly"
                 }
             }


### PR DESCRIPTION
Mark action kind go:1.11 as deprecated
Add action kind go:1.15 and make it default for Go actions.

