### PR TITLE
fix: add new Windows docker.exe location

### DIFF
--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -190,7 +190,11 @@ object StandaloneDockerSupport {
     //TODO Logic duplicated from DockerClient and WindowsDockerClient for now
     val executable = loadConfig[String]("whisk.docker.executable").toOption
     val alternatives =
-      List("/usr/bin/docker", "/usr/local/bin/docker", """C:\Program Files\Docker\Docker\resources\bin\docker.exe""", """C:\Program Files\Docker\Docker\resources\docker.exe""") ++ executable
+      List(
+        "/usr/bin/docker",
+        "/usr/local/bin/docker",
+        """C:\Program Files\Docker\Docker\resources\bin\docker.exe""",
+        """C:\Program Files\Docker\Docker\resources\docker.exe""") ++ executable
     Try {
       alternatives.find(a => Files.isExecutable(Paths.get(a))).get
     } getOrElse {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -190,7 +190,7 @@ object StandaloneDockerSupport {
     //TODO Logic duplicated from DockerClient and WindowsDockerClient for now
     val executable = loadConfig[String]("whisk.docker.executable").toOption
     val alternatives =
-      List("/usr/bin/docker", "/usr/local/bin/docker", """C:\Program Files\Docker\Docker\resources\bin\docker.exe""") ++ executable
+      List("/usr/bin/docker", "/usr/local/bin/docker", """C:\Program Files\Docker\Docker\resources\bin\docker.exe""", """C:\Program Files\Docker\Docker\resources\docker.exe""") ++ executable
     Try {
       alternatives.find(a => Files.isExecutable(Paths.get(a))).get
     } getOrElse {


### PR DESCRIPTION
See https://github.com/docker/for-win/issues/7898
See https://github.com/adobe/aio-cli-plugin-app/issues/304


<!--- Provide a concise summary of your changes in the Title -->

## Description

The Windows docker.exe location has been changed, so the openwhisk.jar will fail to run since the search locations are hard-coded. This PR adds the new path to the search paths.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [X] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

