### PR TITLE
add go:1.15 kind to apiv1swagger

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -2009,6 +2009,7 @@
             "ruby:2.5",
             "ruby:default",
             "go:1.11",
+            "go:1.15",
             "go:default",
             "sequence",
             "swift:4.2",


### PR DESCRIPTION
Missing part of #4987 which added the go:1.15 kind.
