### PR TITLE
Adjust "nightly" dockerhub Jenkins job on 1.0.0 branch

### DIFF
--- a/tools/jenkins/apache/dockerhub.groovy
+++ b/tools/jenkins/apache/dockerhub.groovy
@@ -33,8 +33,7 @@ node('ubuntu') {
       def gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
       def shortCommit = gitCommit.take(7)
       sh "./gradlew clean"
-      sh "${PUSH_CMD} -PdockerImageTag=nightly"
-      sh "${PUSH_CMD} -PdockerImageTag=${shortCommit}"
+      sh "${PUSH_CMD} -PdockerImageTag=1.0.0"
     }
   }
 


### PR DESCRIPTION
To prepare for making a 1.0.0 release, change to using 1.0.0
instead of nightly as the tag for docker images produced  by
building this branch.  Also drop the git commit hash tag, as
that is intended to be used only by the master branch.

NOTE: This PR should be merged to the 1.0.0 branch, not the master branch.