### PR TITLE
adapt to change in JDK naming scheme in Apache Jenkins

### DIFF
--- a/tools/jenkins/apache/dockerhub.groovy
+++ b/tools/jenkins/apache/dockerhub.groovy
@@ -24,7 +24,7 @@ node('ubuntu') {
   checkout scm
 
   stage("Build and Deploy to DockerHub") {
-    def JAVA_JDK_8=tool name: 'JDK 1.8 (latest)', type: 'hudson.model.JDK'
+    def JAVA_JDK_8=tool name: 'jdk_1.8_latest', type: 'hudson.model.JDK'
     withEnv(["Path+JDK=$JAVA_JDK_8/bin","JAVA_HOME=$JAVA_JDK_8"]) {
       withCredentials([usernamePassword(credentialsId: 'openwhisk_dockerhub', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USER')]) {
           sh 'docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}'


### PR DESCRIPTION
Apache Infra changed the way JDKs are named in Jenkins on Oct 18.
