### PR TITLE
Add ability to scale Ephemeral storage along with memory, similar to CPU

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -110,10 +110,12 @@ whisk {
     #}
 
     #if missing, the pod will be created without ephermal disk request/limit
-    #if specified, the pod will be created with ephemeral-storage request+limit set
+    #if specified, the pod will be created with ephemeral-storage request+limit set or using the scale factor
+    #as a multiple of the request memory. If both are set scale-factor takes precedence.
     #See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage
     #ephemeral-storage {
     #  limit = 2 g
+    #  scale-factor = 2.0
     #}
 
     #enable PodDisruptionBudget creation for pods? (will include same labels as pods, and specify minAvailable=1 to prevent termination of action pods during maintenance)

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -111,7 +111,8 @@ whisk {
 
     #if missing, the pod will be created without ephermal disk request/limit
     #if specified, the pod will be created with ephemeral-storage request+limit set or using the scale factor
-    #as a multiple of the request memory. If both are set scale-factor takes precedence.
+    #as a multiple of the request memory. If the scaled value exceeds the limit, the limit will be used so, it's good
+    #practice to set the limit if you plan on using the scale-factor.
     #See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage
     #ephemeral-storage {
     #  limit = 2 g

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -74,7 +74,7 @@ case class KubernetesCpuScalingConfig(millicpus: Int, memory: ByteSize, maxMilli
 /**
  * Configuration for kubernetes ephemeral storage limit for the action container
  */
-case class KubernetesEphemeralStorageConfig(limit: ByteSize)
+case class KubernetesEphemeralStorageConfig(limit: ByteSize, scaleFactor: Double)
 
 /**
  * Exception to indicate a pod took too long to become ready.

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
@@ -108,13 +108,14 @@ class WhiskPodBuilder(client: NamespacedKubernetesClient, config: KubernetesClie
       .getOrElse(Map.empty)
 
     val diskLimit = config.ephemeralStorage
-      .map(diskConfig =>
-        // Scale the ephemeral storage unless it exceeds the limit, if it exceeds the limit use the limit.
-        if ((diskConfig.scaleFactor > 0) && (diskConfig.scaleFactor * memory.toMB < diskConfig.limit.toMB)) {
-          Map("ephemeral-storage" -> new Quantity(diskConfig.scaleFactor * memory.toMB + "Mi"))
-        } else {
-          Map("ephemeral-storage" -> new Quantity(diskConfig.limit.toMB + "Mi"))
-      })
+      .map(
+        diskConfig =>
+          // Scale the ephemeral storage unless it exceeds the limit, if it exceeds the limit use the limit.
+          if ((diskConfig.scaleFactor > 0) && (diskConfig.scaleFactor * memory.toMB < diskConfig.limit.toMB)) {
+            Map("ephemeral-storage" -> new Quantity(diskConfig.scaleFactor * memory.toMB + "Mi"))
+          } else {
+            Map("ephemeral-storage" -> new Quantity(diskConfig.limit.toMB + "Mi"))
+        })
       .getOrElse(Map.empty)
 
     //In container its assumed that env, port, resource limits are set explicitly

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
@@ -108,7 +108,12 @@ class WhiskPodBuilder(client: NamespacedKubernetesClient, config: KubernetesClie
       .getOrElse(Map.empty)
 
     val diskLimit = config.ephemeralStorage
-      .map(diskConfig => Map("ephemeral-storage" -> new Quantity(diskConfig.limit.toMB + "Mi")))
+      .map(diskConfig =>
+        if (diskConfig.scaleFactor > 0) {
+          Map("ephemeral-storage" -> new Quantity(diskConfig.scaleFactor * memory.toMB + "Mi"))
+        } else {
+          Map("ephemeral-storage" -> new Quantity(diskConfig.limit.toMB + "Mi"))
+      })
       .getOrElse(Map.empty)
 
     //In container its assumed that env, port, resource limits are set explicitly

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/WhiskPodBuilder.scala
@@ -109,7 +109,8 @@ class WhiskPodBuilder(client: NamespacedKubernetesClient, config: KubernetesClie
 
     val diskLimit = config.ephemeralStorage
       .map(diskConfig =>
-        if (diskConfig.scaleFactor > 0) {
+        // Scale the ephemeral storage unless it exceeds the limit, if it exceeds the limit use the limit.
+        if ((diskConfig.scaleFactor > 0) && (diskConfig.scaleFactor * memory.toMB < diskConfig.limit.toMB)) {
           Map("ephemeral-storage" -> new Quantity(diskConfig.scaleFactor * memory.toMB + "Mi"))
         } else {
           Map("ephemeral-storage" -> new Quantity(diskConfig.limit.toMB + "Mi"))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
@@ -133,7 +133,7 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
       Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
       false,
       None,
-      Some(KubernetesEphemeralStorageConfig(1.GB, 0)))
+      Some(KubernetesEphemeralStorageConfig(1.GB, 0.0)))
     val builder = new WhiskPodBuilder(kubeClient, config)
 
     val (pod, _) = builder.buildPodSpec(name, testImage, 2.MB, Map("foo" -> "bar"), Map("fooL" -> "barV"), config)
@@ -161,6 +161,26 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
       val c = getActionContainer(pod)
       c.getResources.getLimits.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("2.5Mi")
       c.getResources.getRequests.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("2.5Mi")
+    }
+  }
+  it should "use ephemeral storage limit when scale factor suggests larger size" in {
+    val config = KubernetesClientConfig(
+      KubernetesClientTimeoutConfig(1.second, 1.second),
+      KubernetesInvokerNodeAffinity(false, "k", "v"),
+      true,
+      None,
+      None,
+      Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
+      false,
+      None,
+      Some(KubernetesEphemeralStorageConfig(1.GB, 1000)))
+    val builder = new WhiskPodBuilder(kubeClient, config)
+
+    val (pod, _) = builder.buildPodSpec(name, testImage, 2.MB, Map("foo" -> "bar"), Map("fooL" -> "barV"), config)
+    withClue(Serialization.asYaml(pod)) {
+      val c = getActionContainer(pod)
+      c.getResources.getLimits.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("1024Mi")
+      c.getResources.getRequests.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("1024Mi")
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/kubernetes/test/WhiskPodBuilderTests.scala
@@ -133,7 +133,7 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
       Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
       false,
       None,
-      Some(KubernetesEphemeralStorageConfig(1.GB)))
+      Some(KubernetesEphemeralStorageConfig(1.GB, 0)))
     val builder = new WhiskPodBuilder(kubeClient, config)
 
     val (pod, _) = builder.buildPodSpec(name, testImage, 2.MB, Map("foo" -> "bar"), Map("fooL" -> "barV"), config)
@@ -141,6 +141,26 @@ class WhiskPodBuilderTests extends FlatSpec with Matchers with KubeClientSupport
       val c = getActionContainer(pod)
       c.getResources.getLimits.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("1024Mi")
       c.getResources.getRequests.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("1024Mi")
+    }
+  }
+  it should "scale ephemeral storage when scale factor is given" in {
+    val config = KubernetesClientConfig(
+      KubernetesClientTimeoutConfig(1.second, 1.second),
+      KubernetesInvokerNodeAffinity(false, "k", "v"),
+      true,
+      None,
+      None,
+      Some(KubernetesCpuScalingConfig(300, 3.MB, 1000)),
+      false,
+      None,
+      Some(KubernetesEphemeralStorageConfig(1.GB, 1.25)))
+    val builder = new WhiskPodBuilder(kubeClient, config)
+
+    val (pod, _) = builder.buildPodSpec(name, testImage, 2.MB, Map("foo" -> "bar"), Map("fooL" -> "barV"), config)
+    withClue(Serialization.asYaml(pod)) {
+      val c = getActionContainer(pod)
+      c.getResources.getLimits.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("2.5Mi")
+      c.getResources.getRequests.asScala.get("ephemeral-storage").map(_.getAmount) shouldBe Some("2.5Mi")
     }
   }
 


### PR DESCRIPTION
Building on setting a simple limit for k8s ephemeral storage this introduces another config setting to also allow scaling the storage based on the memory.

<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Along with CPU it seems reasonable action developers may need more disk as their actions use more and more memory. Ideally, we'd start to tease all this apart to allow developers to request a variety of resources but this simply creates a similar setting as CPU to allow the disk capacity to stretch along with memory.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

