### PR TITLE
make generation of git.properties optional

### DIFF
--- a/core/standalone/build.gradle
+++ b/core/standalone/build.gradle
@@ -146,6 +146,11 @@ bootJar {
     finalizedBy copyBootJarToBin
 }
 
+// Support building standalone from source release (no .git)
+gitProperties {
+    failOnNoGitDirectory = false
+}
+
 // Gradle boot disables the default jar task. So need to now make
 // install task depend on bootJar such that it finds the required jar file
 // https://github.com/spring-projects/spring-boot/issues/13187


### PR DESCRIPTION
To support building from a source release, allow the gitProperties task to fail without failing the build.

