### PR TITLE
fix start.sh to work on macos

### DIFF
--- a/core/standalone/start.sh
+++ b/core/standalone/start.sh
@@ -20,7 +20,7 @@ shift
 docker run --rm -d \
   -h openwhisk --name openwhisk \
   -p 3233:3233 -p 3232:3232 \
-  -v //var/run/docker.sock:/var/run/docker.sock \
+  -v /var/run/docker.sock:/var/run/docker.sock \
  "$IMAGE" "$@"
 docker exec openwhisk waitready
 case "$(uname)" in


### PR DESCRIPTION
remove extra leading / in volume mount command

Fixes #5016 
