### PR TITLE
re-fix: add new Windows docker.exe location

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/StandaloneDockerContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/docker/StandaloneDockerContainerFactory.scala
@@ -100,7 +100,9 @@ trait WindowsDockerClient {
 
   override protected def executableAlternatives: List[String] = {
     val executable = loadConfig[String]("whisk.docker.executable").toOption
-    List("""C:\Program Files\Docker\Docker\resources\bin\docker.exe""") ++ executable
+    List(
+      """C:\Program Files\Docker\Docker\resources\bin\docker.exe""",
+      """C:\Program Files\Docker\Docker\resources\docker.exe""") ++ executable
   }
 }
 


### PR DESCRIPTION
The PR fix at https://github.com/apache/openwhisk/pull/4991 is incomplete. This fixes the docker exe not found error on Windows.

## Environment

Microsoft Windows version 10.0.18362 N/A Build 18362
Docker (Windows) version 19.03.13, build 4484c46d9d
node (Windows) version 10.22.1
java (Windows) 15 2020-09-15

## Repro
1. Build the standalone jar via `./gradlew :core:standalone:build`
2. Run the jar under Windows 10 via `java -jar bin\openwhisk-standalone.jar`
3.  See error:
```
$ java -jar openwhisk-standalone.jar
[36m
        ____      ___                   _    _ _     _     _
       /\   \    / _ \ _ __   ___ _ __ | |  | | |__ (_)___| | __
  /\  /__\   \  | | | | '_ \ / _ \ '_ \| |  | | '_ \| / __| |/ /
 /  \____ \  /  | |_| | |_) |  __/ | | | |/\| | | | | \__ \   <
 \   \  /  \/    \___/| .__/ \___|_| |_|__/\__|_| |_|_|___/_|\_\
  \___\/ tm           |_|
    [0m
Git Commit: 71b7d56, Build Date: 2020-06-17T21:21:03+0200
================================================================================
Running pre flight checks ...

Local Host Name: localhost
Local Internal Name: host.docker.internal

[[32m  OK   [0m] 'docker' cli found. (Docker version 19.03.13, build 4484c46d9d)
[[32m  OK   [0m] 'docker' version 19.3.13 is newer than minimum supported 18.3.0
[[32m  OK   [0m] 'docker' is running.
[[31mFAILURE[0m] 'wsk' cli not found.
        Download the cli from https://s.apache.org/openwhisk-cli-download
[[32m  OK   [0m] Server port [3233] is free

================================================================================
[2020-11-02T17:52:32.968Z] [34m[INFO][0;39m Starting OpenWhisk standalone on port 3233
[2020-11-02T17:52:33.828Z] [34m[INFO][0;39m Slf4jLogger started
[2020-11-02T17:52:34.238Z] [34m[INFO][0;39m Using [C:\Users\shazron\.openwhisk\standalone\server-3233] as data directory
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:564)
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:47)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:86)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:50)
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51)
Caused by: java.io.FileNotFoundException: Couldn't locate docker binary (tried: /usr/bin/docker, /usr/local/bin/docker, C:\Program Files\Docker\Docker\resources\bin\docker.exe).
        at org.apache.openwhisk.core.containerpool.docker.DockerClient.$anonfun$dockerCmd$3(DockerClient.scala:96)
        at scala.util.Failure.getOrElse(Try.scala:222)
        at org.apache.openwhisk.core.containerpool.docker.DockerClient.<init>(DockerClient.scala:96)
        at org.apache.openwhisk.standalone.StandaloneDockerClient.<init>(StandaloneDockerSupport.scala:203)
        at org.apache.openwhisk.standalone.StandaloneOpenWhisk$.prepareDocker(StandaloneOpenWhisk.scala:420)
        at org.apache.openwhisk.standalone.StandaloneOpenWhisk$.main(StandaloneOpenWhisk.scala:231)
        at org.apache.openwhisk.standalone.StandaloneOpenWhisk.main(StandaloneOpenWhisk.scala)
        ... 8 more
```
## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [X] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

