### PR TITLE
Hide version in activation's path generated by generateFallbackActivation

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -287,7 +287,7 @@ class InvokerReactive(
       duration = Some(0),
       response = response,
       annotations = {
-        Parameters(WhiskActivation.pathAnnotation, JsString(msg.action.asString)) ++
+        Parameters(WhiskActivation.pathAnnotation, JsString(msg.action.copy(version = None).asString)) ++
           Parameters(WhiskActivation.kindAnnotation, JsString(Exec.UNKNOWN)) ++ causedBy
       })
   }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description

If the activation is generated by the `generateFallbackActivation` method in the InvokerReactive, it contains the version in the path annotation.

In this case, the ES activation store can't search for activations by the name without version.


And also, all other components that generate activation don't store version, but only InvokerReactive stores the version in the path annotation. It must be consistent.


https://github.com/apache/openwhisk/blob/a1ba98778e3db80a06fe707c47c5f4c05d8b85ee/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala#L589

https://github.com/apache/openwhisk/blob/a1ba98778e3db80a06fe707c47c5f4c05d8b85ee/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala#L1070

https://github.com/apache/openwhisk/blob/8759cadeea6101a3693aac1d34d4069f516d5558/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/SequenceActions.scala#L243


#### Path annotation
```json
{
    "annotations": [
        {
            "key": "kind",
            "value": "nodejs:10"
        },
        {
            "key": "path",
            "value": "seonghyun/a2@0.0.154"
        }
    ]
}
```

#### Path annotation (expected)
```json
{
    "annotations": [
        {
            "key": "kind",
            "value": "nodejs:10"
        },
        {
            "key": "path",
            "value": "seonghyun/a2"
        }
    ]
}
```

## Related issue and scope
- None

## My changes affect the following components
- [x] Data stores (activation format)


## Types of changes
- [x] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

