### PR TITLE
Make runtime delete timeout configurable

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -173,4 +173,5 @@ whisk {
   invoker {
     protocol: http
   }
+  runtime.delete.timeout = "30 seconds"
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainerFactory.scala
@@ -64,7 +64,7 @@ class KubernetesContainerFactory(
     logging.info(this, "Cleaning up function runtimes")
     val labels = Map("invoker" -> label, "release" -> KubernetesContainerFactoryProvider.release)
     val cleaning = kubernetes.rm(labels, true)(TransactionId.invokerNanny)
-    Await.ready(cleaning, 30.seconds)
+    Await.ready(cleaning, KubernetesContainerFactoryProvider.runtimeDeleteTimeout)
   }
 
   override def createContainer(tid: TransactionId,
@@ -90,6 +90,7 @@ class KubernetesContainerFactory(
 object KubernetesContainerFactoryProvider extends ContainerFactoryProvider {
 
   val release = loadConfigOrThrow[String]("whisk.helm.release")
+  val runtimeDeleteTimeout = loadConfigOrThrow[FiniteDuration]("whisk.runtime.delete.timeout")
 
   override def instance(actorSystem: ActorSystem,
                         logging: Logging,

--- a/core/standalone/src/main/resources/standalone-kcf.conf
+++ b/core/standalone/src/main/resources/standalone-kcf.conf
@@ -34,4 +34,5 @@ whisk {
     port-forwarding-enabled = true
   }
   helm.release = "release"
+  runtime.delete.timeout = "30 seconds"
 }

--- a/tests/src/test/resources/application.conf.j2
+++ b/tests/src/test/resources/application.conf.j2
@@ -103,6 +103,7 @@ whisk {
     }
 
     helm.release = "release"
+    runtime.delete.timeout = "30 seconds"
 }
 
 #test-only overrides so that tests can override defaults in application.conf (todo: move all defaults to reference.conf)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
In kubenetes env,  if runtime pod number is big and `akka.coordinated-shutdown.phases.actor-system-terminate_timeout` is low(e.g default value is `30 s`), this may lead to `the runtime pods are not deleted completely after execute helm delete/uninstall xxx`, because when timeout happens, the `cleanup` is not executed finished.

In such a case, need to increase relative timeout value, it is better to make these timeout value configurable.

Another brother pr: https://github.com/apache/openwhisk-deploy-kube/pull/653

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)
https://github.com/apache/openwhisk-deploy-kube/issues/652

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

