### PR TITLE
CVE patches

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -98,6 +98,38 @@ dependencies {
     compile ("com.azure:azure-storage-blob:12.6.0") {
         exclude group: "com.azure", module: "azure-core-test"
     }
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2015-5237
+    compile "com.google.protobuf:protobuf-java:${gradle.protobuf.version}"
+    compile "com.google.protobuf:protobuf-java-util:${gradle.protobuf.version}"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2017-18640
+    compile "org.yaml:snakeyaml:1.27"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2018-8023
+    compile "org.apache.mesos:mesos:1.4.3"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2018-20200
+    compile "com.squareup.okhttp3:okhttp:3.12.12"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2020-7014
+    compile "org.elasticsearch.client:elasticsearch-rest-client:6.8.13"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2020-11612
+    compile "io.netty:netty-buffer:${gradle.netty.version}"
+    compile "io.netty:netty-handler:${gradle.netty.version}"
+    compile "io.netty:netty-handler-proxy:${gradle.netty.version}"
+    compile "io.netty:netty-codec-socks:${gradle.netty.version}"
+    compile "io.netty:netty-codec-http:${gradle.netty.version}"
+    compile "io.netty:netty-codec-http2:${gradle.netty.version}"
+    compile "io.netty:netty-transport-native-epoll:${gradle.netty.version}"
+    compile "io.netty:netty-transport-native-unix-common:${gradle.netty.version}"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2020-13956
+    compile "org.apache.httpcomponents:httpclient:4.5.13"
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2020-25649
+    compile "com.fasterxml.jackson.core:jackson-databind:2.10.5.1"
 }
 
 configurations {

--- a/core/invoker/build.gradle
+++ b/core/invoker/build.gradle
@@ -41,7 +41,9 @@ dependencies {
     compile ("org.apache.curator:curator-recipes:${gradle.curator.version}") {
         exclude group: 'org.apache.zookeeper', module:'zookeeper'
     }
-    compile ("org.apache.zookeeper:zookeeper:3.4.11") {
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2019-0201
+    compile ("org.apache.zookeeper:zookeeper:3.4.14") {
         exclude group: 'org.slf4j'
         exclude group: 'log4j'
         exclude group: 'jline'

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,3 +68,6 @@ gradle.ext.akka_management = [version : '1.0.5']
 
 gradle.ext.curator = [version : '4.0.0']
 gradle.ext.kube_client = [version: '4.4.2']
+
+gradle.ext.netty = [version : '4.1.55.Final']
+gradle.ext.protobuf = [version : '3.14.0']


### PR DESCRIPTION
Upgrade various gradle dependencies to fix CVEs.

## Description
The following CVEs were patched. Shown are the versions before and after the patch.

https://nvd.nist.gov/vuln/detail/CVE-2015-5237 `com.google.protobuf:protobuf-java 3.3.1 -> 3.14.0`
https://nvd.nist.gov/vuln/detail/CVE-2017-18640 `org.yaml:snakeyaml 1.23 -> 1.27`
https://nvd.nist.gov/vuln/detail/CVE-2018-8023 `org.apache.mesos:mesos 1.2.3 -> 1.4.3`
https://nvd.nist.gov/vuln/detail/CVE-2018-20200 `com.squareup.okhttp3:okhttp 3.12.0 -> 3.12.12`
https://nvd.nist.gov/vuln/detail/CVE-2020-7014 `org.elasticsearch.client:elasticsearch-rest-client 6.7.2 -> 6.8.13`
https://nvd.nist.gov/vuln/detail/CVE-2020-11612 `io.netty:netty-buffer (and others) 4.1.45.Final -> 4.1.55.Final`
https://nvd.nist.gov/vuln/detail/CVE-2020-13956 `org.apache.httpcomponents:httpclient 4.5.5 -> 4.5.13`
https://nvd.nist.gov/vuln/detail/CVE-2020-25649 `com.fasterxml.jackson.core:jackson-databind 2.10.1 -> 2.10.5.1`
https://nvd.nist.gov/vuln/detail/CVE-2019-0201 `org.apache.zookeeper:zookeeper 3.4.11 -> 3.4.14`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

