### PR TITLE
Copy JMX related files instead of moving to support jmx on k8s

### DIFF
--- a/common/scala/copyJMXFiles.sh
+++ b/common/scala/copyJMXFiles.sh
@@ -18,6 +18,11 @@
 
 if [[ $( ls /conf/jmxremote.* 2> /dev/null ) ]]
 then
-  mv /conf/jmxremote.* /home/owuser
+  # JMX auth files would be mounted as a symbolic link (read-only mode)
+  # with `root` privileges by the k8s secret.
+  cp -rL /conf/jmxremote.* /home/owuser
+  rm -f /conf/jmxremote.* 2>/dev/null || true
+
+  # The owner must be `owuser` and the file only have read permission.
   chmod 600 /home/owuser/jmxremote.*
 fi


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
JMX related auth files are mounted as a read-only mode by k8s secret.
(configMap and secrets volumeMount are always read-only by k8s.)

So, It can't use the `mv` command in the copyJMXFiles.sh script.

I'll open a new subsequent PR  at the `apache/openwhisk-deploy-kube` repository for supporting JMX on the k8s environment 

## Related issue and scope
No issues

## My changes affect the following components
- [x] Deployment

## Types of changes
- [x] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

