### PR TITLE
Change return type for some errors:

### DIFF
--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -581,7 +581,7 @@
             "$ref": "#/responses/ApplicationError"
           },
           "400": {
-            "$ref": "#/responses/DeveloperError",
+            "$ref": "#/responses/DeveloperError"
           },
           "401": {
             "$ref": "#/responses/UnauthorizedRequest"

--- a/core/controller/src/main/resources/apiv1swagger.json
+++ b/core/controller/src/main/resources/apiv1swagger.json
@@ -333,6 +333,12 @@
           "202": {
             "$ref": "#/responses/AcceptedActivation"
           },
+          "207": {
+            "$ref": "#/responses/ApplicationError"
+          },
+          "400": {
+            "$ref": "#/responses/DeveloperError"
+          },
           "401": {
             "$ref": "#/responses/UnauthorizedRequest"
           },
@@ -570,6 +576,12 @@
           },
           "202": {
             "$ref": "#/responses/AcceptedActivation"
+          },
+          "207": {
+            "$ref": "#/responses/ApplicationError"
+          },
+          "400": {
+            "$ref": "#/responses/DeveloperError",
           },
           "401": {
             "$ref": "#/responses/UnauthorizedRequest"
@@ -2902,6 +2914,12 @@
     },
     "AcceptedRuleStateChange": {
       "description": "Rule has been enabled or disabled"
+    },
+    "ApplicationError": {
+      "description": "Activation failed with an application error"
+    },
+    "DeveloperError": {
+      "description": "Activation failed with a developer error"
     },
     "RequestEntityTooLarge": {
       "description": "Request entity too large",

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -296,14 +296,13 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
             complete(OK, response)
           } else if (activation.response.isApplicationError) {
             // actions that result is ApplicationError status are considered a 'success'
-            // and will have an 'error' property in the result - the HTTP status is OK
+            // and will have an 'error' property in the result - the HTTP status is MultiStatus
             // and clients must check the response status if it exists
             // NOTE: response status will not exist in the JSON object if ?result == true
             // and instead clients must check if 'error' is in the JSON
-            // PRESERVING OLD BEHAVIOR and will address defect in separate change
-            complete(BadGateway, response)
+            complete(MultiStatus, response)
           } else if (activation.response.isContainerError) {
-            complete(BadGateway, response)
+            complete(BadRequest, response)
           } else {
             complete(InternalServerError, response)
           }

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestEntitlementTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestEntitlementTests.scala
@@ -17,7 +17,7 @@
 
 package org.apache.openwhisk.core.cli.test
 
-import akka.http.scaladsl.model.StatusCodes.BadGateway
+import akka.http.scaladsl.model.StatusCodes.BadRequest
 import akka.http.scaladsl.model.StatusCodes.Forbidden
 import akka.http.scaladsl.model.StatusCodes.NotFound
 import org.junit.runner.RunWith
@@ -31,7 +31,7 @@ import common.WskActorSystem
 class WskRestEntitlementTests extends WskEntitlementTests with WskActorSystem {
   override lazy val wsk = new WskRestOperations
   override lazy val forbiddenCode = Forbidden.intValue
-  override lazy val timeoutCode = BadGateway.intValue
+  override lazy val timeoutCode = BadRequest.intValue
   override lazy val notFoundCode = NotFound.intValue
 
   override def verifyAction(action: RunResult): org.scalatest.Assertion = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/SequenceApiTests.scala
@@ -71,7 +71,7 @@ class SequenceApiTests extends ControllerTestCommon with WhiskActionsApi {
     Post(s"$collectionPath/$seqName?blocking=true") ~> Route.seal(routes(creds)) ~> check {
       deleteAction(DocId(s"$namespace/$seqName"))
       deleteAction(DocId(s"$namespace/$compName1"))
-      status should be(BadGateway)
+      status should be(MultiStatus)
       val response = responseAs[JsObject]
       response.fields("response") shouldBe ActivationResponse.applicationError(sequenceComponentNotFound).toExtendedJson
       val logs = response.fields("logs").convertTo[JsArray]

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.core.limits
 
 import akka.http.scaladsl.model.StatusCodes.PayloadTooLarge
-import akka.http.scaladsl.model.StatusCodes.BadGateway
+import akka.http.scaladsl.model.StatusCodes.MultiStatus
 import java.io.File
 import java.io.PrintWriter
 import java.time.Instant
@@ -324,7 +324,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
 
       // this tests an active ack failure to post from invoker
       val args = Map("size" -> (allowedSize + 1).toJson, "char" -> "a".toJson)
-      val code = if (blocking) BadGateway.intValue else TestUtils.ACCEPTED
+      val code = if (blocking) MultiStatus.intValue else TestUtils.ACCEPTED
       if (blocking) {
         val start = Instant.now
         val rr = wsk.action.invoke(name, args, blocking = blocking, expectedExitCode = code)

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ConcurrencyTests.scala
@@ -180,7 +180,7 @@ class ConcurrencyTests extends TestHelpers with WskTestHelpers with WskActorSyst
       val results = Await.result(Future.sequence(runs), 30.seconds)
       //some will be 200, some will be 400, but all should be completed (no forced acks that take > 30s)
       results.count(_.statusCode == StatusCodes.OK) should be > 0
-      results.count(_.statusCode == StatusCodes.BadGateway) should be > 0
+      results.count(_.statusCode == StatusCodes.BadRequest) should be > 0
   }
   it should "allow concurrent activations to gracefully complete when one fails catastrophically" in withAssetCleaner(
     wskprops) {
@@ -210,6 +210,6 @@ class ConcurrencyTests extends TestHelpers with WskTestHelpers with WskActorSyst
       //some will no 200, since each each container gets at least 5 concurrent activations,
       //and each container crashes on the 5 activation.
       results.count(_.statusCode == StatusCodes.OK) shouldBe 0
-      results.count(_.statusCode == StatusCodes.BadGateway) shouldBe 4
+      results.count(_.statusCode == StatusCodes.BadRequest) shouldBe 4
   }
 }

--- a/tests/src/test/scala/system/basic/WskRestBasicTests.scala
+++ b/tests/src/test/scala/system/basic/WskRestBasicTests.scala
@@ -18,7 +18,7 @@
 package system.basic
 
 import akka.http.scaladsl.model.StatusCodes.Accepted
-import akka.http.scaladsl.model.StatusCodes.BadGateway
+import akka.http.scaladsl.model.StatusCodes.MultiStatus
 import akka.http.scaladsl.model.StatusCodes.Conflict
 import akka.http.scaladsl.model.StatusCodes.Unauthorized
 import akka.http.scaladsl.model.StatusCodes.NotFound
@@ -450,7 +450,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
     }
 
     Seq(strErrInput, numErrInput, boolErrInput) foreach { input =>
-      val result = wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = BadGateway.intValue)
+      val result = wsk.action.invoke(name, parameters = input, blocking = true, expectedExitCode = MultiStatus.intValue)
       val response = result.getFieldJsObject("response")
       val res = RestResult.getFieldJsObject(response, "result")
       res shouldBe input.toJson.asJsObject
@@ -460,7 +460,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
           parameters = input,
           blocking = true,
           result = true,
-          expectedExitCode = BadGateway.intValue)
+          expectedExitCode = MultiStatus.intValue)
       resultTrue.respData shouldBe input.toJson.asJsObject.toString()
     }
   }
@@ -472,7 +472,7 @@ class WskRestBasicTests extends TestHelpers with WskTestHelpers with WskActorSys
         action.create(name, Some(TestUtils.getTestActionFilename("asyncError.js")))
       }
 
-      val result = wsk.action.invoke(name, blocking = true, expectedExitCode = BadGateway.intValue)
+      val result = wsk.action.invoke(name, blocking = true, expectedExitCode = MultiStatus.intValue)
       val response = result.getFieldJsObject("response")
       val res = RestResult.getFieldJsObject(response, "result")
       res shouldBe JsObject("error" -> JsObject("msg" -> "failed activation on purpose".toJson))


### PR DESCRIPTION
- Use MultiStatus for ApplicationError
- Use BadRequest for DeveloperError


## Description
Use 502 BadGateway seems not suitable for `ApplicationError` and `DeveloperError`

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

