### PR TITLE
Fix wsk action create command in Rust example

### DIFF
--- a/docs/actions-rust.md
+++ b/docs/actions-rust.md
@@ -64,7 +64,7 @@ the action with the `wsk` CLI using `--main`, as with any other action type.
 You can create an OpenWhisk action called `helloRust` from this function as follows:
 
 ```
-wsk action create helloRust hello.rs
+wsk action create helloRust --kind rust:1.34 hello.rs
 ```
 The CLI automatically infers the type of the action from the source file extension.
 For `.rs` source files, the action runs using a Rust v1.34 runtime.


### PR DESCRIPTION
The command given `wsk action create helloRust hello.rs` does not work as given, yielding an error message. This can be corrected by specifying the action type via `--kind rust:1.34`


<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

