### PR TITLE
drop healthcheck activations from invoker that are over threshold age

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -320,7 +320,7 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
         // the load balancer's activation map. Inform the invoker pool supervisor of the user action completion.
         // guard this
         invoker.foreach(invokerPool ! InvocationFinishedMessage(_, invocationResult))
-      case None if tid == TransactionId.invokerHealth =>
+      case None if tid.id == TransactionId.invokerHealth.id =>
         // Health actions do not have an ActivationEntry as they are written on the message bus directly. Their result
         // is important to pass to the invokerPool because they are used to determine if the invoker can be considered
         // healthy again.

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -406,7 +406,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
     InvokerPool.healthAction(controllerInstance).map { action =>
       val activationMessage = ActivationMessage(
         // Use the sid of the InvokerSupervisor as tid
-        transid = transid,
+        transid = TransactionId(transid.id),
         action = action.fullyQualifiedName(true),
         // Use empty DocRevision to force the invoker to pull the action from db all the time
         revision = DocRevision.empty,

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -120,6 +120,9 @@ whisk {
     pdb-enabled = false
   }
 
+  # used to drain healthcheck messages on the invoker topics that are backlogged
+  max-health-activation-age = "30 minutes"
+
   # Timeouts for runc commands. Set to "Inf" to disable timeout.
   runc.timeouts {
     pause: 10 seconds

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -120,6 +120,7 @@ class InvokerReactive(
   /** Initialize message consumers */
   private val topic = s"invoker${instance.toInt}"
   private val maximumContainers = (poolConfig.userMemory / MemoryLimit.MIN_MEMORY).toInt
+  private val maximumHealthcheckAge = loadConfigOrThrow[FiniteDuration]("whisk.max-healthcheck-activation-age")
   private val msgProvider = SpiLoader.get[MessagingProvider]
 
   //number of peeked messages - increasing the concurrentPeekFactor improves concurrent usage, but adds risk for message loss in case of crash
@@ -232,8 +233,15 @@ class InvokerReactive(
         //set trace context to continue tracing
         WhiskTracerProvider.tracer.setTraceContext(transid, msg.traceContext)
 
-        if (!namespaceBlacklist.isBlacklisted(msg.user)) {
-          val start = transid.started(this, LoggingMarkers.INVOKER_ACTIVATION, logLevel = InfoLevel)
+        if (transid.id.contains("invokerHealth") && transid.deltaToStart > maximumHealthcheckAge.toMillis) {
+          // Do not process message because healthcheck is too old to be indicative of service health.
+          activationFeed ! MessageFeed.Processed
+          logging.warn(
+            this,
+            s"invokerHealth activation is too old to process with an age of ${transid.deltaToStart} milliseconds.")
+          Future.successful(())
+        } else if (!namespaceBlacklist.isBlacklisted(msg.user)) {
+          transid.started(this, LoggingMarkers.INVOKER_ACTIVATION, logLevel = InfoLevel)
           handleActivationMessage(msg)
         } else {
           // Iff the current namespace is blacklisted, an active-ack is only produced to keep the loadbalancer protocol


### PR DESCRIPTION

## Description

The invoker will now drop healthcheck activations read from kafka that are older than a configurable threshold. The default is 30 minutes. The max backlog of healthcheck activations backlogged in the invoker topics that will be processed are therefore # controllers * number of minutes threshold since each controller sends a healthcheck once per minute when unhealthy. The invoker also will no longer become healthy prior to eating through these old messages and processing a young enough healthcheck message at which point should be the end of the kafka backlog and safe to mark the invoker as healthy.

## Related issue and scope
- [x] I opened an issue to propose and discuss this change (#5053 )

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

