### PR TITLE
[New Scheduler] Implement KeepAliveService

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -338,6 +338,7 @@ object LoggingMarkers {
   val timeout = "timeout"
 
   private val controller = "controller"
+  private val scheduler = "scheduler"
   private val invoker = "invoker"
   private val database = "database"
   private val activation = "activation"
@@ -554,6 +555,9 @@ object LoggingMarkers {
     if (TransactionId.metricsKamonTags)
       LogMarkerToken(kafka, "topic", start, Some("delay"), Map("topic" -> topic))(MeasurementUnit.time.milliseconds)
     else LogMarkerToken(kafka, topic, start, Some("delay"))(MeasurementUnit.time.milliseconds)
+
+  def SCHEDULER_KEEP_ALIVE(leaseId: Long) =
+    LogMarkerToken(scheduler, "keepAlive", counter, None, Map("leaseId" -> leaseId.toString))(MeasurementUnit.none)
 
   /*
    * General markers

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -291,5 +291,7 @@ object ConfigKeys {
 
   val azBlob = "whisk.azure-blob"
 
+  val schedulerMaxPeek = "whisk.scheduler.max-peek"
+
   val whiskClusterName = "whisk.cluster.name"
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -266,6 +266,7 @@ object ConfigKeys {
   val controllerActivation = s"$controller.activation"
 
   val etcd = "whisk.etcd"
+  val etcdLeaseTimeout = "whisk.etcd.lease.timeout"
   val etcdPoolThreads = "whisk.etcd.pool.threads"
 
   val activationStore = "whisk.activation-store"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/service/LeaseKeepAliveService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/service/LeaseKeepAliveService.scala
@@ -42,7 +42,7 @@ case object NoData extends KeepAliveServiceData
 case class Lease(id: Long, ttl: Long) extends KeepAliveServiceData
 
 // Events received by the actor
-case object ReGrantLease
+case object RegrantLease
 case object GetLease
 case object GrantLease
 
@@ -98,7 +98,7 @@ class LeaseKeepAliveService(etcdClient: EtcdClient, instanceId: InstanceId, watc
       logging.info(this, s"endpoint ie removed so recreate a lease")
       recreateLease(lease)
 
-    case Event(ReGrantLease, lease: Lease) =>
+    case Event(RegrantLease, lease: Lease) =>
       logging.info(this, s"ReGrant a lease, old lease:${lease}")
       recreateLease(lease)
 
@@ -135,7 +135,7 @@ class LeaseKeepAliveService(etcdClient: EtcdClient, instanceId: InstanceId, watc
         case Success(_) => MetricEmitter.emitCounterMetric(LoggingMarkers.SCHEDULER_KEEP_ALIVE(lease.id))
         case Failure(t) =>
           logging.warn(this, s"Failed to keep-alive of ${lease.id} caused by ${t}")
-          self ! ReGrantLease
+          self ! RegrantLease
       }
   }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/service/LeaseKeepAliveService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/service/LeaseKeepAliveService.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.service
+
+import akka.actor.Status.{Failure => FailureMessage}
+import akka.actor.{ActorRef, ActorSystem, Cancellable, FSM, Props, Stash}
+import akka.pattern.pipe
+import org.apache.openwhisk.common.{Logging, LoggingMarkers, MetricEmitter}
+import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.entity.InstanceId
+import org.apache.openwhisk.core.etcd.EtcdClient
+import org.apache.openwhisk.core.etcd.EtcdKV.InstanceKeys.instanceLease
+import pureconfig.loadConfigOrThrow
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Failure, Success}
+
+// States
+sealed trait KeepAliveServiceState
+case object Ready extends KeepAliveServiceState
+case object Active extends KeepAliveServiceState
+
+// Data
+sealed trait KeepAliveServiceData
+case object NoData extends KeepAliveServiceData
+case class Lease(id: Long, ttl: Long) extends KeepAliveServiceData
+
+// Events received by the actor
+case object ReGrantLease
+case object GetLease
+case object GrantLease
+
+// Events internally used
+case class SetLease(lease: Lease)
+case object SetWatcher
+
+class LeaseKeepAliveService(etcdClient: EtcdClient, instanceId: InstanceId, watcherService: ActorRef)(
+  implicit logging: Logging,
+  actorSystem: ActorSystem)
+    extends FSM[KeepAliveServiceState, KeepAliveServiceData]
+    with Stash {
+
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
+
+  private val leaseTimeout = loadConfigOrThrow[Int](ConfigKeys.etcdLeaseTimeout).seconds
+  private var worker: Option[Cancellable] = None
+  private val key = instanceLease(instanceId)
+  private val watcherName = "lease-service"
+
+  self ! GrantLease
+  startWith(Ready, NoData)
+
+  when(Ready) {
+    case Event(GrantLease, _) =>
+      etcdClient
+        .grant(leaseTimeout.toSeconds)
+        .map { res =>
+          SetLease(Lease(res.getID, res.getTTL))
+        }
+        .pipeTo(self)
+      stay
+
+    case Event(SetLease(lease), _) =>
+      startKeepAliveService(lease)
+        .pipeTo(self)
+      logging.info(this, s"Granted a new lease $lease")
+      stay using lease
+
+    case Event(SetWatcher, lease: Lease) =>
+      goto(Active) using lease
+
+    case Event(t: FailureMessage, _) =>
+      logging.warn(this, s"Failed to grant new lease caused by: $t")
+      self ! GrantLease
+      stay()
+
+    case _ => delay
+  }
+
+  when(Active) {
+    case Event(WatchEndpointRemoved(`key`, `key`, _, false), lease: Lease) =>
+      logging.info(this, s"endpoint ie removed so recreate a lease")
+      recreateLease(lease)
+
+    case Event(ReGrantLease, lease: Lease) =>
+      logging.info(this, s"ReGrant a lease, old lease:${lease}")
+      recreateLease(lease)
+
+    case Event(GetLease, lease: Lease) =>
+      logging.info(this, s"send the lease(${lease}) to ${sender()}")
+      sender() ! lease
+      stay()
+
+    case _ => delay
+  }
+
+  initialize()
+
+  private def startKeepAliveService(lease: Lease): Future[SetWatcher.type] = {
+    worker = Some {
+      actorSystem.scheduler.schedule(initialDelay = 0.second, interval = 500.milliseconds)(keepAliveOnce(lease))
+    }
+
+    /**
+     * To verify that lease has been deleted since timeout,
+     * create a key using lease, watch the key, and receive an event for deletion.
+     */
+    etcdClient.put(key, s"${lease.id}", lease.id).map { _ =>
+      watcherService ! WatchEndpoint(key, s"${lease.id}", false, watcherName, Set(DeleteEvent))
+      SetWatcher
+    }
+  }
+
+  private def keepAliveOnce(lease: Lease): Future[Long] = {
+    etcdClient
+      .keepAliveOnce(lease.id)
+      .map(_.getID)
+      .andThen {
+        case Success(_) => MetricEmitter.emitCounterMetric(LoggingMarkers.SCHEDULER_KEEP_ALIVE(lease.id))
+        case Failure(t) =>
+          logging.warn(this, s"Failed to keep-alive of ${lease.id} caused by ${t}")
+          self ! ReGrantLease
+      }
+  }
+
+  private def recreateLease(lease: Lease) = {
+    logging.info(this, s"recreate a lease, old lease: $lease")
+    worker.foreach(_.cancel()) // stop scheduler
+    watcherService ! UnwatchEndpoint(key, false, watcherName) // stop watcher
+    etcdClient
+      .revoke(lease.id) // delete lease
+      .onComplete(_ => self ! GrantLease) // create lease
+    goto(Ready)
+  }
+
+  // Unstash all messages stashed while in intermediate state
+  onTransition {
+    case _ -> Ready  => unstashAll()
+    case _ -> Active => unstashAll()
+  }
+
+  /** Delays all incoming messages until unstashAll() is called */
+  def delay = {
+    stash()
+    stay
+  }
+
+  override def postStop(): Unit = {
+    worker.foreach(_.cancel()) // stop scheduler if that exist
+    watcherService ! UnwatchEndpoint(key, false, watcherName)
+  }
+}
+
+object LeaseKeepAliveService {
+  def props(etcdClient: EtcdClient, instanceId: InstanceId, watcherService: ActorRef)(
+    implicit logging: Logging,
+    actorSystem: ActorSystem): Props = {
+    Props(new LeaseKeepAliveService(etcdClient, instanceId, watcherService))
+      .withDispatcher("dispatchers.lease-service-dispatcher")
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/service/LeaseKeepAliveServiceTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/service/LeaseKeepAliveServiceTests.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.service
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.testkit.{ImplicitSender, TestFSMRef, TestKit, TestProbe}
+import akka.util.Timeout
+import com.ibm.etcd.api.{LeaseGrantResponse, LeaseKeepAliveResponse, LeaseRevokeResponse, PutResponse}
+import common.StreamLogging
+import org.apache.openwhisk.core.WhiskConfig
+import org.apache.openwhisk.core.entity.{ExecManifest, SchedulerInstanceId}
+import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdKV}
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+@RunWith(classOf[JUnitRunner])
+class LeaseKeepAliveServiceTests
+    extends TestKit(ActorSystem("LeaseKeepAliveService"))
+    with ImplicitSender
+    with FlatSpecLike
+    with ScalaFutures
+    with Matchers
+    with MockFactory
+    with BeforeAndAfterAll
+    with StreamLogging {
+
+  implicit val timeout: Timeout = Timeout(5.seconds)
+  implicit val ec: ExecutionContext = system.dispatcher
+  val config = new WhiskConfig(ExecManifest.requiredProperties)
+  val testInstanceId = SchedulerInstanceId("0")
+  val testLeaseId = 10
+  val newTestLeaseId = 20
+  val testTtl = 1
+  val testLease = Lease(testLeaseId, testTtl)
+  val newTestLease = Lease(newTestLeaseId, testTtl)
+  val testKey = EtcdKV.InstanceKeys.instanceLease(testInstanceId)
+  val newTestKey = EtcdKV.InstanceKeys.instanceLease(testInstanceId)
+
+  val watcherName = "lease-service"
+
+  def grant(etcd: EtcdClient): Unit = {
+    (etcd
+      .grant(_: Long))
+      .expects(*)
+      .returning(Future.successful(LeaseGrantResponse.newBuilder().setID(testLeaseId).setTTL(testTtl).build()))
+  }
+
+  def put(etcd: EtcdClient): Unit = {
+    (etcd
+      .put(_: String, _: String, _: Long))
+      .expects(testKey, *, *)
+      .returning(Future.successful(PutResponse.newBuilder().build()))
+  }
+
+  def keepAliveOnce(etcd: EtcdClient): Unit = {
+    (etcd
+      .keepAliveOnce(_: Long))
+      .expects(testLeaseId)
+      .returning(Future.successful(LeaseKeepAliveResponse.newBuilder().setID(testLeaseId).build()))
+      .anyNumberOfTimes()
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  behavior of "LeaseKeepAliveService"
+
+  it should "grant new lease" in {
+
+    val mockEtcd = mock[EtcdClient]
+    grant(mockEtcd)
+    put(mockEtcd)
+    keepAliveOnce(mockEtcd)
+
+    val watcher = TestProbe()
+    val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, watcher.ref))
+
+    Thread.sleep(1000)
+    service.stateName shouldBe Active
+    service.stateData shouldBe testLease
+    watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
+
+  }
+
+  it should "regrant a new lease while old lease is deleted" in {
+    val mockEtcd = mock[EtcdClient]
+    grant(mockEtcd)
+    put(mockEtcd)
+    keepAliveOnce(mockEtcd)
+
+    (mockEtcd
+      .revoke(_: Long))
+      .expects(testLeaseId)
+      .returning(Future.successful(LeaseRevokeResponse.newBuilder().build()))
+    (mockEtcd
+      .grant(_: Long))
+      .expects(*)
+      .returning(Future.successful(LeaseGrantResponse.newBuilder().setID(newTestLeaseId).setTTL(testTtl).build()))
+    (mockEtcd
+      .put(_: String, _: String, _: Long))
+      .expects(newTestKey, *, *)
+      .returning(Future.successful(PutResponse.newBuilder().build()))
+    (mockEtcd
+      .keepAliveOnce(_: Long))
+      .expects(newTestLeaseId)
+      .returning(Future.successful(LeaseKeepAliveResponse.newBuilder().setID(newTestLeaseId).build()))
+      .anyNumberOfTimes()
+
+    val watcher = TestProbe()
+    val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, watcher.ref))
+
+    service.stateName shouldBe Active
+    service.stateData shouldBe testLease
+    watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
+
+    service ! WatchEndpointRemoved(testKey, testKey, testLease.id.toString, false)
+
+    watcher.expectMsg(UnwatchEndpoint(testKey, false, watcherName))
+    Thread.sleep(500) //wait for the lease to be granted
+
+    service.stateName shouldBe Active
+    service.stateData shouldBe newTestLease
+    watcher.expectMsg(WatchEndpoint(newTestKey, newTestLease.id.toString, false, watcherName, Set(DeleteEvent)))
+  }
+
+  it should "get lease" in {
+    val mockEtcd = mock[EtcdClient]
+    grant(mockEtcd)
+    put(mockEtcd)
+    keepAliveOnce(mockEtcd)
+
+    val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, TestProbe().ref))
+
+    (service ? GetLease).mapTo[Lease].futureValue shouldBe testLease
+  }
+
+  it should "regrant a new lease when keepalive is failed" in {
+    val mockEtcd = mock[EtcdClient]
+    grant(mockEtcd)
+    put(mockEtcd)
+
+    (mockEtcd
+      .keepAliveOnce(_: Long))
+      .expects(testLeaseId)
+      .returning(Future.successful(LeaseKeepAliveResponse.newBuilder().setID(testLeaseId).build()))
+      .noMoreThanTwice()
+
+    (mockEtcd
+      .keepAliveOnce(_: Long))
+      .expects(testLeaseId)
+      .returning(Future.failed(new RuntimeException("failed to keep alive the lease")))
+      .noMoreThanOnce()
+
+    (mockEtcd
+      .revoke(_: Long))
+      .expects(testLeaseId)
+      .returning(Future.successful(LeaseRevokeResponse.newBuilder().build()))
+
+    (mockEtcd
+      .keepAliveOnce(_: Long))
+      .expects(newTestLeaseId)
+      .returning(Future.successful(LeaseKeepAliveResponse.newBuilder().setID(newTestLeaseId).build()))
+      .anyNumberOfTimes()
+
+    (mockEtcd
+      .grant(_: Long))
+      .expects(*)
+      .returning(Future.successful(LeaseGrantResponse.newBuilder().setID(newTestLeaseId).setTTL(testTtl).build()))
+    (mockEtcd
+      .put(_: String, _: String, _: Long))
+      .expects(newTestKey, *, *)
+      .returning(Future.successful(PutResponse.newBuilder().build()))
+
+    val watcher = TestProbe()
+    val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, watcher.ref))
+    service.stateName shouldBe Active
+    service.stateData shouldBe testLease
+    watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
+
+    watcher.expectMsg(UnwatchEndpoint(testKey, false, watcherName))
+    Thread.sleep(1500) //wait for the lease to be granted
+
+    service.stateName shouldBe Active
+    service.stateData shouldBe newTestLease
+    watcher.expectMsg(WatchEndpoint(newTestKey, newTestLease.id.toString, false, watcherName, Set(DeleteEvent)))
+  }
+
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/service/LeaseKeepAliveServiceTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/service/LeaseKeepAliveServiceTests.scala
@@ -101,7 +101,11 @@ class LeaseKeepAliveServiceTests
 
     Thread.sleep(1000)
     service.stateName shouldBe Active
-    service.stateData shouldBe testLease
+    service.stateData shouldBe a[ActiveStates]
+    service.stateData match {
+      case ActiveStates(_, lease) => lease shouldBe testLease
+      case _                      => fail()
+    }
     watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
 
   }
@@ -134,7 +138,11 @@ class LeaseKeepAliveServiceTests
     val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, watcher.ref))
 
     service.stateName shouldBe Active
-    service.stateData shouldBe testLease
+    service.stateData shouldBe a[ActiveStates]
+    service.stateData match {
+      case ActiveStates(_, lease) => lease shouldBe testLease
+      case _                      => fail()
+    }
     watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
 
     service ! WatchEndpointRemoved(testKey, testKey, testLease.id.toString, false)
@@ -143,7 +151,11 @@ class LeaseKeepAliveServiceTests
     Thread.sleep(500) //wait for the lease to be granted
 
     service.stateName shouldBe Active
-    service.stateData shouldBe newTestLease
+    service.stateData shouldBe a[ActiveStates]
+    service.stateData match {
+      case ActiveStates(_, lease) => lease shouldBe newTestLease
+      case _                      => fail()
+    }
     watcher.expectMsg(WatchEndpoint(newTestKey, newTestLease.id.toString, false, watcherName, Set(DeleteEvent)))
   }
 
@@ -198,14 +210,22 @@ class LeaseKeepAliveServiceTests
     val watcher = TestProbe()
     val service = TestFSMRef(new LeaseKeepAliveService(mockEtcd, testInstanceId, watcher.ref))
     service.stateName shouldBe Active
-    service.stateData shouldBe testLease
+    service.stateData shouldBe a[ActiveStates]
+    service.stateData match {
+      case ActiveStates(_, lease) => lease shouldBe testLease
+      case _                      => fail()
+    }
     watcher.expectMsg(WatchEndpoint(testKey, testLease.id.toString, false, watcherName, Set(DeleteEvent)))
 
     watcher.expectMsg(UnwatchEndpoint(testKey, false, watcherName))
     Thread.sleep(1500) //wait for the lease to be granted
 
     service.stateName shouldBe Active
-    service.stateData shouldBe newTestLease
+    service.stateData shouldBe a[ActiveStates]
+    service.stateData match {
+      case ActiveStates(_, lease) => lease shouldBe newTestLease
+      case _                      => fail()
+    }
     watcher.expectMsg(WatchEndpoint(newTestKey, newTestLease.id.toString, false, watcherName, Set(DeleteEvent)))
   }
 


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
- In invoker and scheduler components, each host has a lease. This service manages lease to not disappear due to timeout.
- Each host writes health data to etcd with this lease. When lease disappears by timeout, each host's health data disappear together, so it can be determined as an unhealthy host by the scheduler.
- Because it is the service that has the greatest influence on the health state of the component, a dedicated dispatcher is allocated.
- https://cwiki.apache.org/confluence/display/OPENWHISK/LeaseKeepAliveService

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Invoker
- [x] Scheduler
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

