### PR TITLE
[New Scheduler] Add a centralized watcher for etcd data

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
@@ -32,7 +32,7 @@ case class WatchEndpoint(key: String,
                          isPrefix: Boolean,
                          name: String,
                          listenEvents: Set[EtcdEvent] = Set.empty)
-case class UnWatchEndpoint(watchKey: String, isPrefix: Boolean, watchName: String, needFeedback: Boolean = false)
+case class UnwatchEndpoint(watchKey: String, isPrefix: Boolean, watchName: String, needFeedback: Boolean = false)
 
 // the watchKey is the string user want to watch, it can be a prefix, the key is a record's key in Etcd
 // so if `isPrefix = true`, the `watchKey != key`, else the `watchKey == key`
@@ -126,7 +126,7 @@ class WatcherService(etcdClient: EtcdClient)(implicit logging: Logging, actorSys
         else
           deleteWatchers.update(watcherKey, sender())
 
-    case request: UnWatchEndpoint =>
+    case request: UnwatchEndpoint =>
       val watcherKey = WatcherKey(request.watchKey, request.watchName)
       if (request.isPrefix) {
         prefixPutWatchers.remove(watcherKey)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.service
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import com.ibm.etcd.api.Event.EventType
+import com.ibm.etcd.client.kv.WatchUpdate
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.etcd.EtcdClient
+import org.apache.openwhisk.core.etcd.EtcdType._
+import scala.collection.JavaConverters._
+import scala.collection.concurrent.TrieMap
+
+// messages received by this actor
+case class WatchEndpoint(key: String,
+                         value: String,
+                         isPrefix: Boolean,
+                         name: String,
+                         listenEvents: Set[EtcdEvent] = Set.empty)
+case class UnWatchEndpoint(watchKey: String, isPrefix: Boolean, watchName: String, needFeedback: Boolean = false)
+
+// the watchKey is the string user want to watch, it can be a prefix, the key is a record's key in Etcd
+// so if `isPrefix = true`, the `watchKey != key`, else the `watchKey == key`
+sealed abstract class WatchEndpointOperation(val watchKey: String,
+                                             val key: String,
+                                             val value: String,
+                                             val isPrefix: Boolean)
+case class WatchEndpointRemoved(override val watchKey: String,
+                                override val key: String,
+                                override val value: String,
+                                override val isPrefix: Boolean)
+    extends WatchEndpointOperation(watchKey, key, value, isPrefix)
+case class WatchEndpointInserted(override val watchKey: String,
+                                 override val key: String,
+                                 override val value: String,
+                                 override val isPrefix: Boolean)
+    extends WatchEndpointOperation(watchKey, key, value, isPrefix)
+case class WatcherClosed(key: String, isPrefix: Boolean)
+
+sealed trait EtcdEvent
+case object PutEvent extends EtcdEvent
+case object DeleteEvent extends EtcdEvent
+
+// there may be several watchers for a same watcher key, so add a watcherName to distinguish them
+case class WatcherKey(watchKey: String, watchName: String)
+
+class WatcherService(etcdClient: EtcdClient)(implicit logging: Logging, actorSystem: ActorSystem) extends Actor {
+
+  implicit val ec = context.dispatcher
+
+  private[service] val putWatchers = TrieMap[WatcherKey, ActorRef]()
+  private[service] val deleteWatchers = TrieMap[WatcherKey, ActorRef]()
+  private[service] val prefixPutWatchers = TrieMap[WatcherKey, ActorRef]()
+  private[service] val prefixDeleteWatchers = TrieMap[WatcherKey, ActorRef]()
+
+  private val watcher = etcdClient.watchAllKeys { res: WatchUpdate =>
+    res.getEvents.asScala.foreach { event =>
+      event.getType match {
+        case EventType.DELETE =>
+          val key = ByteStringToString(event.getPrevKv.getKey)
+          val value = ByteStringToString(event.getPrevKv.getValue)
+          val watchEvent = WatchEndpointRemoved(key, key, value, false)
+          deleteWatchers
+            .foreach { watcher =>
+              if (watcher._1.watchKey == key) {
+                watcher._2 ! watchEvent
+              }
+            }
+          prefixDeleteWatchers
+            .foreach { watcher =>
+              if (key.startsWith(watcher._1.watchKey)) {
+                watcher._2 ! WatchEndpointRemoved(watcher._1.watchKey, key, value, true)
+              }
+            }
+        case EventType.PUT =>
+          val key = ByteStringToString(event.getKv.getKey)
+          val value = ByteStringToString(event.getKv.getValue)
+          val watchEvent = WatchEndpointInserted(key, key, value, false)
+          putWatchers
+            .foreach { watcher =>
+              if (watcher._1.watchKey == key) {
+                watcher._2 ! watchEvent
+              }
+            }
+          prefixPutWatchers
+            .foreach { watcher =>
+              if (key.startsWith(watcher._1.watchKey)) {
+                watcher._2 ! WatchEndpointInserted(watcher._1.watchKey, key, value, true)
+              }
+            }
+        case msg =>
+          logging.debug(this, s"watch event received: $msg.")
+      }
+    }
+
+  }
+
+  override def receive: Receive = {
+    case request: WatchEndpoint =>
+      logging.info(this, s"watch endpoint: $request")
+      val watcherKey = WatcherKey(request.key, request.name)
+      if (request.listenEvents.contains(PutEvent))
+        if (request.isPrefix)
+          prefixPutWatchers.update(watcherKey, sender())
+        else
+          putWatchers.update(watcherKey, sender())
+
+      if (request.listenEvents.contains(DeleteEvent))
+        if (request.isPrefix)
+          prefixDeleteWatchers.update(watcherKey, sender())
+        else
+          deleteWatchers.update(watcherKey, sender())
+
+    case request: UnWatchEndpoint =>
+      val watcherKey = WatcherKey(request.watchKey, request.watchName)
+      if (request.isPrefix) {
+        prefixPutWatchers.remove(watcherKey)
+        prefixDeleteWatchers.remove(watcherKey)
+      } else {
+        putWatchers.remove(watcherKey)
+        deleteWatchers.remove(watcherKey)
+      }
+
+      // always send WatcherClosed back to sender if it need a feedback
+      if (request.needFeedback)
+        sender ! WatcherClosed(request.watchKey, request.isPrefix)
+  }
+}
+
+object WatcherService {
+  def props(etcdClient: EtcdClient)(implicit logging: Logging, actorSystem: ActorSystem): Props = {
+    Props(new WatcherService(etcdClient))
+  }
+}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -90,6 +90,7 @@ ext.testSets = [
         "includes" : [
             "org/apache/openwhisk/common/etcd/**",
             "org/apache/openwhisk/core/scheduler/**",
+            "org/apache/openwhisk/core/service/**",
         ]
     ],
     "REQUIRE_MULTI_RUNTIME" : [

--- a/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
@@ -299,7 +299,8 @@ class MockWatchClient(client: Client)(ece: ExecutionContextExecutor) extends Etc
           .newBuilder()
           .setKey(ByteString.copyFromUtf8(key))
           .setValue(ByteString.copyFromUtf8(value))
-          .build()) build ()
+          .build())
+      .build()
     onNext(new mockWatchUpdate().addEvents(event))
   }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.core.service
+
+import java.{lang, util}
+import java.util.concurrent.Executor
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import akka.util.Timeout
+import com.google.protobuf.ByteString
+import com.ibm.etcd.api.{Event, KeyValue, ResponseHeader}
+import com.ibm.etcd.api.Event.EventType
+import com.ibm.etcd.client.kv.KvClient.Watch
+import com.ibm.etcd.client.kv.WatchUpdate
+import com.ibm.etcd.client.{EtcdClient => Client}
+import common.StreamLogging
+import org.apache.openwhisk.core.entity.SchedulerInstanceId
+import org.apache.openwhisk.core.etcd.EtcdClient
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class WatcherServiceTests
+    extends TestKit(ActorSystem("WatcherService"))
+    with ImplicitSender
+    with FlatSpecLike
+    with ScalaFutures
+    with Matchers
+    with MockFactory
+    with BeforeAndAfterAll
+    with StreamLogging {
+
+  implicit val timeout: Timeout = Timeout(5.seconds)
+  implicit val ece: ExecutionContextExecutor = system.dispatcher
+
+  private val watchName = "test-watcher-service"
+
+  val schedulerId = SchedulerInstanceId("scheduler0")
+
+  val client: Client = {
+    val hostAndPorts = "172.17.0.1:2379"
+    Client.forEndpoints(hostAndPorts).withPlainText().build()
+  }
+
+  val watch = new Watch {
+    override def close(): Unit = {}
+
+    override def addListener(listener: Runnable, executor: Executor): Unit = {}
+
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = true
+
+    override def isCancelled: Boolean = true
+
+    override def isDone: Boolean = true
+
+    override def get(): lang.Boolean = true
+
+    override def get(timeout: Long, unit: TimeUnit): lang.Boolean = true
+  }
+
+  private def watchEtcd(etcdClient: EtcdClient): Unit = {
+    (etcdClient
+      .watchAllKeys(_: WatchUpdate => Unit, _: Throwable => Unit, _: () => Unit))
+      .expects(*, *, *)
+      .returning(watch)
+  }
+
+  behavior of "WatcherService"
+
+  it should "watch a endpoint" in {
+    val etcdClient = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+
+    watchEtcd(etcdClient)
+
+    val service = TestActorRef(new WatcherService(etcdClient))
+    service ! WatchEndpoint(key, value, isPrefix = false, watchName, Set(DeleteEvent))
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+
+    service ! WatchEndpoint(key, value, isPrefix = false, watchName, Set(PutEvent))
+    service.underlyingActor.putWatchers.size shouldBe 1
+
+    service ! WatchEndpoint(key, value, isPrefix = false, watchName + 1, Set(DeleteEvent, PutEvent))
+    service.underlyingActor.deleteWatchers.size shouldBe 2
+    service.underlyingActor.putWatchers.size shouldBe 2
+
+    service ! WatchEndpoint(key, value, isPrefix = true, watchName, Set(DeleteEvent))
+    service.underlyingActor.prefixDeleteWatchers.size shouldBe 1
+
+    service ! WatchEndpoint(key, value, isPrefix = true, watchName, Set(PutEvent))
+    service.underlyingActor.prefixPutWatchers.size shouldBe 1
+
+    service ! WatchEndpoint(key, value, isPrefix = true, watchName + 1, Set(DeleteEvent, PutEvent))
+    service.underlyingActor.prefixDeleteWatchers.size shouldBe 2
+    service.underlyingActor.prefixPutWatchers.size shouldBe 2
+  }
+
+  it should "close the watcher upon UnWatchEndpoint event" in {
+    val etcdClient = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+
+    watchEtcd(etcdClient)
+
+    val service = TestActorRef(new WatcherService(etcdClient))
+
+    service ! WatchEndpoint(key, value, isPrefix = false, watchName, Set(DeleteEvent))
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+
+    service ! WatchEndpoint(key, value, isPrefix = false, watchName + "1", Set(DeleteEvent))
+    service.underlyingActor.deleteWatchers.size shouldBe 2
+
+    service ! UnWatchEndpoint(key, isPrefix = false, watchName)
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+
+    service ! UnWatchEndpoint(key, isPrefix = false, watchName + "1")
+    service.underlyingActor.deleteWatchers.size shouldBe 0
+  }
+
+  it should "notify the recipient if a deletion or put event occurs" in {
+    val etcdClient = new MockWatchClient(client)(ece)
+    val key = "testKey"
+    val value = "testValue"
+
+    val probe = TestProbe()
+    val service = TestActorRef(new WatcherService(etcdClient))
+    val request = WatchEndpoint(key, value, isPrefix = false, watchName, Set(DeleteEvent, PutEvent))
+
+    probe.send(service, request)
+
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+    service.underlyingActor.putWatchers.size shouldBe 1
+
+    etcdClient.onNext should not be null
+
+    etcdClient.publishEvents(EventType.DELETE, key, value)
+    probe.expectMsg(WatchEndpointRemoved(request.key, key, value, request.isPrefix))
+
+    etcdClient.publishEvents(EventType.PUT, key, value)
+    probe.expectMsg(WatchEndpointInserted(request.key, key, value, request.isPrefix))
+
+    service ! UnWatchEndpoint(key, false, watchName)
+
+    val request2 = WatchEndpoint("test", "", isPrefix = true, watchName, Set(DeleteEvent, PutEvent))
+    probe.send(service, request2)
+
+    etcdClient.publishEvents(EventType.DELETE, key, value)
+    probe.expectMsg(WatchEndpointRemoved(request2.key, key, value, request2.isPrefix))
+
+    etcdClient.publishEvents(EventType.PUT, key, value)
+    probe.expectMsg(WatchEndpointInserted(request2.key, key, value, request2.isPrefix))
+  }
+
+  it should "not notify the recipient if event type mismatched" in {
+    val etcdClient = new MockWatchClient(client)(ece)
+    val key = "testKey"
+    val value = "testValue"
+
+    val probe = TestProbe()
+    val service = TestActorRef(new WatcherService(etcdClient))
+    val request = WatchEndpoint(key, value, isPrefix = false, watchName, Set(DeleteEvent))
+
+    probe.send(service, request)
+
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+
+    etcdClient.onNext should not be null
+
+    etcdClient.publishEvents(EventType.PUT, key, value)
+    probe.expectNoMessage()
+    service ! UnWatchEndpoint(key, false, watchName) // close the watcher for delete event
+
+    val request2 = WatchEndpoint(key, value, isPrefix = false, watchName, Set(PutEvent))
+
+    probe.send(service, request2)
+
+    service.underlyingActor.putWatchers.size shouldBe 1
+
+    etcdClient.onNext should not be null
+
+    etcdClient.publishEvents(EventType.DELETE, key, value)
+    probe.expectNoMessage()
+  }
+
+  it should "not register a watch request if there is already registered one" in {
+    val etcdClient = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val numOfTries = 3
+
+    watchEtcd(etcdClient)
+
+    val service = TestActorRef(new WatcherService(etcdClient))
+
+    (1 to numOfTries).foreach { _ =>
+      service ! WatchEndpoint(key, value, isPrefix = false, watchName, Set(DeleteEvent))
+    }
+
+    service.underlyingActor.deleteWatchers.size shouldBe 1
+  }
+
+  it should "register a watch request if there is already registered one but with different watch name" in {
+    val etcdClient = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val numOfTries = 3
+
+    watchEtcd(etcdClient)
+
+    val service = TestActorRef(new WatcherService(etcdClient))
+
+    (1 to numOfTries).foreach { index =>
+      service ! WatchEndpoint(key, value, isPrefix = false, watchName + index, Set(DeleteEvent))
+    }
+
+    service.underlyingActor.deleteWatchers.size shouldBe 3
+  }
+
+}
+
+class mockWatchUpdate extends WatchUpdate {
+  private val eventLists: util.List[Event] = new util.ArrayList[Event]()
+  override def getHeader: ResponseHeader = ???
+
+  def addEvents(event: Event): WatchUpdate = {
+    eventLists.add(event)
+    this
+  }
+
+  override def getEvents: util.List[Event] = eventLists
+}
+
+class MockWatchClient(client: Client)(ece: ExecutionContextExecutor) extends EtcdClient(client)(ece) {
+  var onNext: WatchUpdate => Unit = null
+
+  override def watchAllKeys(next: WatchUpdate => Unit, error: Throwable => Unit, completed: () => Unit): Watch = {
+    onNext = next
+    new Watch {
+      override def close(): Unit = {}
+
+      override def addListener(listener: Runnable, executor: Executor): Unit = {}
+
+      override def cancel(mayInterruptIfRunning: Boolean): Boolean = true
+
+      override def isCancelled: Boolean = true
+
+      override def isDone: Boolean = true
+
+      override def get(): lang.Boolean = true
+
+      override def get(timeout: Long, unit: TimeUnit): lang.Boolean = true
+    }
+  }
+
+  def publishEvents(eventType: EventType, key: String, value: String): Unit = {
+    val eType = eventType match {
+      case EventType.PUT          => EventType.PUT
+      case EventType.DELETE       => EventType.DELETE
+      case EventType.UNRECOGNIZED => EventType.UNRECOGNIZED
+    }
+    val event = Event
+      .newBuilder()
+      .setType(eType)
+      .setPrevKv(
+        KeyValue
+          .newBuilder()
+          .setKey(ByteString.copyFromUtf8(key))
+          .setValue(ByteString.copyFromUtf8(value))
+          .build())
+      .setKv(
+        KeyValue
+          .newBuilder()
+          .setKey(ByteString.copyFromUtf8(key))
+          .setValue(ByteString.copyFromUtf8(value))
+          .build()) build ()
+    onNext(new mockWatchUpdate().addEvents(event))
+  }
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/service/WatcherServiceTests.scala
@@ -135,10 +135,10 @@ class WatcherServiceTests
     service ! WatchEndpoint(key, value, isPrefix = false, watchName + "1", Set(DeleteEvent))
     service.underlyingActor.deleteWatchers.size shouldBe 2
 
-    service ! UnWatchEndpoint(key, isPrefix = false, watchName)
+    service ! UnwatchEndpoint(key, isPrefix = false, watchName)
     service.underlyingActor.deleteWatchers.size shouldBe 1
 
-    service ! UnWatchEndpoint(key, isPrefix = false, watchName + "1")
+    service ! UnwatchEndpoint(key, isPrefix = false, watchName + "1")
     service.underlyingActor.deleteWatchers.size shouldBe 0
   }
 
@@ -164,7 +164,7 @@ class WatcherServiceTests
     etcdClient.publishEvents(EventType.PUT, key, value)
     probe.expectMsg(WatchEndpointInserted(request.key, key, value, request.isPrefix))
 
-    service ! UnWatchEndpoint(key, false, watchName)
+    service ! UnwatchEndpoint(key, false, watchName)
 
     val request2 = WatchEndpoint("test", "", isPrefix = true, watchName, Set(DeleteEvent, PutEvent))
     probe.send(service, request2)
@@ -193,7 +193,7 @@ class WatcherServiceTests
 
     etcdClient.publishEvents(EventType.PUT, key, value)
     probe.expectNoMessage()
-    service ! UnWatchEndpoint(key, false, watchName) // close the watcher for delete event
+    service ! UnwatchEndpoint(key, false, watchName) // close the watcher for delete event
 
     val request2 = WatchEndpoint(key, value, isPrefix = false, watchName, Set(PutEvent))
 


### PR DESCRIPTION
## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
The FPC scheduler will use etcd to store and share some data, and some components need to get noticed for some data when they are changed(inserted, updated or removed), this PR implements a centralized watcher for them, which will watch all changes on etcd and distribute them to subscribers

design document: https://cwiki.apache.org/confluence/display/OPENWHISK/WatcherService

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

