### PR TITLE
Make cache expiration time configurable

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/MultipleReadersSingleWriterCache.scala
@@ -94,6 +94,8 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
   /** Subclasses: Toggle this to enable/disable caching for your entity type. */
   protected val cacheEnabled = true
   protected val evictionPolicy: EvictionPolicy = AccessTime
+  protected val cacheExpirationTime: Long = 5
+  protected val cacheExpirationTimeUnit: TimeUnit = TimeUnit.MINUTES
   protected val fixedCacheSize = 0
 
   private object Entry {
@@ -452,8 +454,8 @@ trait MultipleReadersSingleWriterCache[W, Winfo] {
       .softValues()
 
     evictionPolicy match {
-      case AccessTime => b.expireAfterAccess(5, TimeUnit.MINUTES)
-      case _          => b.expireAfterWrite(5, TimeUnit.MINUTES)
+      case AccessTime => b.expireAfterAccess(cacheExpirationTime, cacheExpirationTimeUnit)
+      case _          => b.expireAfterWrite(cacheExpirationTime, cacheExpirationTimeUnit)
     }
 
     if (fixedCacheSize > 0) b.maximumSize(fixedCacheSize)


### PR DESCRIPTION
Making the cache expiration time configurable.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
When extending the code locally, we need a way to be able to gain greater control of the cache expiration time, just like we currently do with the eviction policy.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [x] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

