### PR TITLE
update default python3 image name

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -76,7 +76,7 @@
                 "default": true,
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "python3action",
+                    "name": "actionloop-python-v3.7",
                     "tag": "nightly"
                 },
                 "deprecated": false,


### PR DESCRIPTION
We stopped building the old (non-actionloop) python 3 docker image
about six months ago. Update the default image name so we use/test the
actionloop-based python3 runtime.
