### PR TITLE
change default nodejs kind from nodejs:10 to nodejs:14

### DIFF
--- a/ansible/files/runtimes-nodeonly.json
+++ b/ansible/files/runtimes-nodeonly.json
@@ -3,7 +3,7 @@
         "This file describes the different languages (aka. managed action runtimes) supported by the system",
         "as well as blackbox images that support the runtime specification.",
         "Only actions with runtime families / kinds defined here can be created / read / updated / deleted / invoked.",
-        "Define a list of runtime families (example: 'nodejs') with at least one kind per family (example: 'nodejs:10').",
+        "Define a list of runtime families (example: 'nodejs') with at least one kind per family (example: 'nodejs:14').",
         "Each runtime family needs a default kind (default: true).",
         "When removing or renaming runtime families or runtime kinds from this file, preexisting actions",
         "with the affected kinds can no longer be read / updated / deleted / invoked. In order to remove or rename",
@@ -16,11 +16,11 @@
     "runtimes": {
         "nodejs": [
             {
-                "kind": "nodejs:10",
+                "kind": "nodejs:14",
                 "default": true,
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "action-nodejs-v10",
+                    "name": "action-nodejs-v14",
                     "tag": "nightly"
                 },
                 "deprecated": false,

--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -16,10 +16,38 @@
         "nodejs": [
             {
                 "kind": "nodejs:10",
-                "default": true,
+                "default": false,
                 "image": {
                     "prefix": "openwhisk",
                     "name": "action-nodejs-v10",
+                    "tag": "nightly"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
+            },
+            {
+                "kind": "nodejs:12",
+                "default": false,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-nodejs-v12",
+                    "tag": "nightly"
+                },
+                "deprecated": false,
+                "attached": {
+                    "attachmentName": "codefile",
+                    "attachmentType": "text/plain"
+                }
+            },
+            {
+                "kind": "nodejs:14",
+                "default": true,
+                "image": {
+                    "prefix": "openwhisk",
+                    "name": "action-nodejs-v14",
                     "tag": "nightly"
                 },
                 "deprecated": false,
@@ -40,34 +68,6 @@
                         }
                     }
                 ]
-            },
-            {
-                "kind": "nodejs:12",
-                "default": false,
-                "image": {
-                    "prefix": "openwhisk",
-                    "name": "action-nodejs-v12",
-                    "tag": "nightly"
-                },
-                "deprecated": false,
-                "attached": {
-                    "attachmentName": "codefile",
-                    "attachmentType": "text/plain"
-                }
-            },
-            {
-                "kind": "nodejs:14",
-                "default": false,
-                "image": {
-                    "prefix": "openwhisk",
-                    "name": "action-nodejs-v14",
-                    "tag": "nightly"
-                },
-                "deprecated": false,
-                "attached": {
-                    "attachmentName": "codefile",
-                    "attachmentType": "text/plain"
-                }
             }
         ],
         "python": [

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/KamonRecorderTests.scala
@@ -62,7 +62,7 @@ class KamonRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with Kamo
   val namespaceGuest = "guest"
   val actionWithCustomPackage = "apimgmt/createApi"
   val actionWithDefaultPackage = "createApi"
-  val kind = "nodejs:10"
+  val kind = "nodejs:14"
   val memory = 256
 
   it should "push user events to kamon" in {

--- a/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
+++ b/core/monitoring/user-events/src/test/scala/org/apache/openwhisk/core/monitoring/metrics/PrometheusRecorderTests.scala
@@ -38,7 +38,7 @@ class PrometheusRecorderTests extends KafkaSpecBase with BeforeAndAfterEach with
   val namespaceGuest = "guest"
   val actionWithCustomPackage = "apimgmt/createApiOne"
   val actionWithDefaultPackage = "createApi"
-  val kind = "nodejs:10"
+  val kind = "nodejs:14"
   val memory = "256"
   createCustomTopic(EventConsumer.userEventTopic)
 

--- a/core/standalone/bin/waitready
+++ b/core/standalone/bin/waitready
@@ -20,7 +20,7 @@ wsk property set --apihost "http://$(hostname):3233" --auth "$AUTH"
 until wsk action list 2>/dev/null >/dev/null
 do sleep 1 ; echo server still not ready - retrying
 done
-wsk action update testme <(echo 'function main(){return {"ready":true}}') --kind nodejs:10
+wsk action update testme <(echo 'function main(){return {"ready":true}}') --kind nodejs:14
 until wsk action invoke testme -r 2>/dev/null | grep 'ready'
 do sleep 1 ; echo server initializing... 
 done

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -148,9 +148,9 @@ object StandaloneDockerSupport {
   }
 
   def prePullImage(imageName: String)(implicit logging: Logging): Unit = {
-    //docker images openwhisk/action-nodejs-v10:nightly
+    //docker images openwhisk/action-nodejs-v14:nightly
     //REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
-    //openwhisk/action-nodejs-v10   nightly             dbb0f8e1a050        5 days ago          967MB
+    //openwhisk/action-nodejs-v14   nightly             dbb0f8e1a050        5 days ago          967MB
     val imageResult = s"$dockerCmd images $imageName".!!
     val imageExist = imageResult.linesIterator.toList.size > 1
     if (!imageExist || imageName.contains(":nightly")) {

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneOpenWhisk.scala
@@ -176,11 +176,11 @@ object StandaloneOpenWhisk extends SLF4JLogging {
      |  "runtimes": {
      |    "nodejs": [
      |      {
-     |        "kind": "nodejs:10",
+     |        "kind": "nodejs:14",
      |        "default": true,
      |        "image": {
      |          "prefix": "openwhisk",
-     |          "name": "action-nodejs-v10",
+     |          "name": "action-nodejs-v14",
      |          "tag": "latest"
      |        },
      |        "deprecated": false,

--- a/docs/actions-new.md
+++ b/docs/actions-new.md
@@ -61,21 +61,21 @@ Further, you should automate and pass the following test suites:
 Actions when created specify the desired runtime for the function via a property called "kind".
 When using the `wsk` CLI, this is specified as `--kind <runtime-kind>`. The value is typically
 a string describing the language (e.g., `nodejs`) followed by a colon and the version for the runtime
-as in `nodejs:10` or `php:7.4`.
+as in `nodejs:14` or `php:7.4`.
 
 The manifest is a map of runtime family names to an array of specific kinds. The details of the
 schema are found in the [Exec Manifest](../common/scala/src/main/scala/org/apache/openwhisk/core/entity/ExecManifest.scala).
 As an example, the following entry add a new runtime family called `nodejs` with a single kind
-`nodejs:10`.
+`nodejs:14`.
 
 ```json
 {
   "nodejs": [{
-    "kind": "nodejs:10",
+    "kind": "nodejs:14",
     "default": true,
     "image": {
       "prefix": "openwhisk",
-      "name": "nodejs10action",
+      "name": "action-nodejs-v10",
       "tag": "latest"
     }
   }]
@@ -113,7 +113,7 @@ new language and added to the [test artifacts directory](../tests/dat/actions/un
 with the name `<runtime-kind>.txt` for plain text file or `<runtime-kind>.bin` for a
 a binary file. The `<runtime-kind>` must match the value used for `kind` in the corresponding
 runtime manifest entry, replacing `:` in the kind with a `-`.
-For example, a plain text function for `nodejs:10` becomes `nodejs-10.txt`.
+For example, a plain text function for `nodejs:14` becomes `nodejs-14.txt`.
 
 ```js
 function main(args) {

--- a/docs/actions-nodejs.md
+++ b/docs/actions-nodejs.md
@@ -219,10 +219,10 @@ zip -r action.zip *
 - Create the action from the zip file.
 
 ```
-wsk action create packageAction --kind nodejs:10 action.zip
+wsk action create packageAction --kind nodejs:14 action.zip
 ```
 
-When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:12`, or `nodejs:10`.
+When creating an action from a `.zip` archive with the CLI tool, you must explicitly provide a value for the `--kind` flag by using `nodejs:14`, or `nodejs:12`.
 
 - Invoke the action as normal.
 
@@ -268,7 +268,7 @@ zip -r action.zip *
 - Create new action with action archive.
 
 ```
-wsk action create my-action --kind nodejs:10 action.zip
+wsk action create my-action --kind nodejs:14 action.zip
 ```
 
 #### Building custom runtime image
@@ -353,7 +353,7 @@ npx rollup --config
 - Create an action using the bundle source file.
 
 ```
-wsk action create my-action bundle.js --kind nodejs:10
+wsk action create my-action bundle.js --kind nodejs:14
 ```
 
 - Invoke the action as normal. Results should be the same as the example above.
@@ -406,7 +406,7 @@ npx webpack --config webpack.config.js
 - Create an action using the bundle source file.
 
 ```
-wsk action create my-action dist/bundle.js --kind nodejs:10
+wsk action create my-action dist/bundle.js --kind nodejs:14
 ```
 
 - Invoke the action as normal. Results should be the same as the example above.
@@ -447,7 +447,7 @@ npm install parcel-bundler --save-dev
 - Create an action using the bundle source file.
 
 ```
-wsk action create my-action dist/index.js --kind nodejs:10
+wsk action create my-action dist/index.js --kind nodejs:14
 ```
 
 - Invoke the action as normal. Results should be the same as the example above.
@@ -459,8 +459,8 @@ wsk action invoke my-action --result --param lines "[\"and now\", \"for somethin
 
 ## Reference
 
-JavaScript actions can be executed in Node.js version 8, 10, 12 or 14.
-Currently actions are executed by default in a Node.js version 10 environment.
+JavaScript actions can be executed in Node.js version 10, 12 or 14.
+Currently actions are executed by default in a Node.js version 14 environment.
 
 ### Node.js version 10 environment
 The Node.js version 10 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:10' when creating or updating an Action.
@@ -479,6 +479,6 @@ The following packages are pre-installed in the Node.js version 12 environment:
 ### Node.js version 14 environment
 The Node.js version 14 environment is used if the `--kind` flag is explicitly specified with a value of 'nodejs:14' when creating or updating an Action.
 
-The following packages are pre-installed in the Node.js version 12 environment:
+The following packages are pre-installed in the Node.js version 14 environment:
 
 - [openwhisk](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.

--- a/tests/dat/actions/echo.json
+++ b/tests/dat/actions/echo.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "publish": false,
     "exec": {
-        "kind": "nodejs:10",
+        "kind": "nodejs:14",
         "code": "/**\n * Returns params, or an empty string if no parameter values are provided\n */\nfunction main(params) {\n    return params || {};\n}\n\n"
     },
     "annotations": [],

--- a/tests/dat/actions/word_count.json
+++ b/tests/dat/actions/word_count.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "publish": false,
     "exec": {
-        "kind": "nodejs:10",
+        "kind": "nodejs:14",
         "code": "/**\n *  word count utility\n */\nfunction main(params) {\n    var str = params.payload.toString();\n    var words = str.split(\" \");\n    var count = words.length;\n    console.log(\"The message '\"+str+\"' has\", count, 'words');\n    return { count: count };\n}\n"
     },
     "annotations": [],

--- a/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/admin/WskAdminTests.scala
@@ -248,12 +248,12 @@ class WskAdminTests extends TestHelpers with WskActorSystem with Matchers with B
     val subject = Subject().asString
     try {
       // set some limits
-      wskadmin.cli(Seq("limits", "set", subject, "--allowedKinds", "nodejs:10", "blackbox"))
+      wskadmin.cli(Seq("limits", "set", subject, "--allowedKinds", "nodejs:14", "blackbox"))
       // check correctly set
       val lines = wskadmin.cli(Seq("limits", "get", subject)).stdout.linesIterator.toSeq
       lines should have size 1
-      lines(0) should (be("allowedKinds = [u'nodejs:10', u'blackbox']") or be(
-        "allowedKinds = ['nodejs:10', 'blackbox']"))
+      lines(0) should (be("allowedKinds = [u'nodejs:14', u'blackbox']") or be(
+        "allowedKinds = ['nodejs:14', 'blackbox']"))
     } finally {
       wskadmin.cli(Seq("limits", "delete", subject)).stdout should include("Limits deleted")
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerFactoryTests.scala
@@ -68,7 +68,7 @@ class DockerContainerFactoryTests
 
   it should "set the docker run args based on ContainerArgsConfig" in {
 
-    val image = ExecManifest.runtimesManifest.manifests("nodejs:10").image
+    val image = ExecManifest.runtimesManifest.manifests("nodejs:14").image
 
     implicit val tid = TransactionId.testing
     val dockerApiStub = mock[DockerApiWithFileAccess]

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -279,23 +279,23 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     // String: binary: true, main: jsMain
     val jsAction1 = WhiskAction(namespace, aname(), jsDefault("RHViZWU=", Some("jsMain")))
     val jsAction1Content =
-      Map("exec" -> Map("kind" -> NODEJS10, "code" -> "RHViZWU=", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction1ExecMetaData = js10MetaData(Some("jsMain"), true)
+      Map("exec" -> Map("kind" -> NODEJS, "code" -> "RHViZWU=", "main" -> "jsMain")).toJson.asJsObject
+    val jsAction1ExecMetaData = jsMetaData(Some("jsMain"), true)
 
     // String: binary: false, main: jsMain
     val jsAction2 = WhiskAction(namespace, aname(), jsDefault("", Some("jsMain")))
-    val jsAction2Content = Map("exec" -> Map("kind" -> NODEJS10, "code" -> "", "main" -> "jsMain")).toJson.asJsObject
-    val jsAction2ExecMetaData = js10MetaData(Some("jsMain"), false)
+    val jsAction2Content = Map("exec" -> Map("kind" -> NODEJS, "code" -> "", "main" -> "jsMain")).toJson.asJsObject
+    val jsAction2ExecMetaData = jsMetaData(Some("jsMain"), false)
 
     // String: binary: true, no main
     val jsAction3 = WhiskAction(namespace, aname(), jsDefault("RHViZWU="))
-    val jsAction3Content = Map("exec" -> Map("kind" -> NODEJS10, "code" -> "RHViZWU=")).toJson.asJsObject
-    val jsAction3ExecMetaData = js10MetaData(None, true)
+    val jsAction3Content = Map("exec" -> Map("kind" -> NODEJS, "code" -> "RHViZWU=")).toJson.asJsObject
+    val jsAction3ExecMetaData = jsMetaData(None, true)
 
     // String: binary: false, no main
     val jsAction4 = WhiskAction(namespace, aname(), jsDefault(""))
-    val jsAction4Content = Map("exec" -> Map("kind" -> NODEJS10, "code" -> "")).toJson.asJsObject
-    val jsAction4ExecMetaData = js10MetaData(None, false)
+    val jsAction4Content = Map("exec" -> Map("kind" -> NODEJS, "code" -> "")).toJson.asJsObject
+    val jsAction4ExecMetaData = jsMetaData(None, false)
 
     // Sequence
     val component = WhiskAction(namespace, aname(), jsDefault("??"))
@@ -578,7 +578,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.limits,
           action.version,
           action.publish,
-          action.annotations ++ systemAnnotations(NODEJS10)))
+          action.annotations ++ systemAnnotations(NODEJS)))
     }
   }
 
@@ -695,7 +695,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
+      response.exec.kind should be(NODEJS)
       response.parameters shouldBe Parameters()
     }
   }
@@ -714,7 +714,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
+      response.exec.kind should be(NODEJS)
       response.parameters should be(Parameters("a", "A"))
     }
   }
@@ -744,7 +744,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.limits,
           action.version,
           action.publish,
-          action.annotations ++ systemAnnotations(NODEJS10)))
+          action.annotations ++ systemAnnotations(NODEJS)))
     }
   }
 
@@ -785,7 +785,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.limits,
           action.version,
           action.publish,
-          action.annotations ++ systemAnnotations(NODEJS10)))
+          action.annotations ++ systemAnnotations(NODEJS)))
     }
   }
 
@@ -794,7 +794,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val javaAction =
       WhiskAction(namespace, aname(), javaDefault("ZHViZWU=", Some("hello")), annotations = Parameters("exec", "java"))
     val nodeAction = WhiskAction(namespace, aname(), jsDefault("??"), Parameters("x", "b"))
-    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS10))
+    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS))
 
     actions.foreach {
       case (action, kind) =>
@@ -899,7 +899,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val swiftAction = WhiskAction(namespace, aname(), swift(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
-    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS10), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
+    val actions = Seq((javaAction, JAVA_DEFAULT), (nodeAction, NODEJS), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
 
     actions.foreach {
       case (action, kind) =>
@@ -1076,7 +1076,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val swiftAction = WhiskAction(namespace, aname(), swift(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
-    val actions = Seq((nodeAction, NODEJS10), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
+    val actions = Seq((nodeAction, NODEJS), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
 
     actions.foreach {
       case (action, kind) =>
@@ -1126,7 +1126,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "concurrently get an action with attachment that is not cached" in {
     implicit val tid = transid()
     val action = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
-    val kind = NODEJS10
+    val kind = NODEJS
 
     val content = WhiskActionPut(
       Some(action.exec),
@@ -1183,7 +1183,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val nodeAction = WhiskAction(namespace, aname(), jsDefault(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val swiftAction = WhiskAction(namespace, aname(), swift(nonInlinedCode(entityStore)), Parameters("x", "b"))
     val bbAction = WhiskAction(namespace, aname(), bb("bb", nonInlinedCode(entityStore), Some("bbMain")))
-    val actions = Seq((nodeAction, NODEJS10), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
+    val actions = Seq((nodeAction, NODEJS), (swiftAction, SWIFT4), (bbAction, BLACKBOX))
 
     actions.foreach {
       case (action, kind) =>
@@ -1252,7 +1252,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
   it should "ensure old and new action schemas are supported" in {
     implicit val tid = transid()
     val code = nonInlinedCode(entityStore)
-    val actionOldSchema = WhiskAction(namespace, aname(), js10Old(code))
+    val actionOldSchema = WhiskAction(namespace, aname(), jsOld(code))
     val actionNewSchema = WhiskAction(namespace, aname(), jsDefault(code))
     val content = WhiskActionPut(
       Some(actionOldSchema.exec),
@@ -1290,7 +1290,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           actionOldSchema.limits,
           actionOldSchema.version.upPatch,
           actionOldSchema.publish,
-          actionOldSchema.annotations ++ systemAnnotations(NODEJS10, create = false)))
+          actionOldSchema.annotations ++ systemAnnotations(NODEJS, create = false)))
     }
 
     stream.toString should include regex (expectedPutLog)
@@ -1315,7 +1315,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           actionOldSchema.limits,
           actionOldSchema.version.upPatch,
           actionOldSchema.publish,
-          actionOldSchema.annotations ++ systemAnnotations(NODEJS10, create = false)))
+          actionOldSchema.annotations ++ systemAnnotations(NODEJS, create = false)))
     }
   }
 
@@ -1361,7 +1361,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
             content.limits.get.logs.get,
             content.limits.get.concurrency.get),
           version = action.version.upPatch,
-          annotations = action.annotations ++ systemAnnotations(NODEJS10, create = false)))
+          annotations = action.annotations ++ systemAnnotations(NODEJS, create = false)))
     }
   }
 
@@ -1382,7 +1382,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.exec,
           content.parameters.get,
           version = action.version.upPatch,
-          annotations = action.annotations ++ systemAnnotations(NODEJS10, false)))
+          annotations = action.annotations ++ systemAnnotations(NODEJS, false)))
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/EntitlementProviderTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/EntitlementProviderTests.scala
@@ -53,7 +53,7 @@ class EntitlementProviderTests extends ControllerTestCommon with ScalaFutures {
   val adminUser = WhiskAuthHelpers.newIdentity(Subject("admin"))
   val guestUser = WhiskAuthHelpers.newIdentity(Subject("anonym"))
 
-  val allowedKinds = Set("nodejs:10", "python")
+  val allowedKinds = Set("nodejs:14", "python")
   val disallowedKinds = Set("golang", "blackbox")
 
   def getExec(kind: String): Exec = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/KindRestrictorTests.scala
@@ -39,7 +39,7 @@ class KindRestrictorTests extends FlatSpec with Matchers with StreamLogging {
 
   behavior of "Kind Restrictor"
 
-  val allowedKinds = Set("nodejs:10", "python")
+  val allowedKinds = Set("nodejs:14", "python")
   val disallowedKinds = Set("golang", "blackbox")
   val allKinds = allowedKinds ++ disallowedKinds
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackageActionsApiTests.scala
@@ -162,7 +162,7 @@ class PackageActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
           action.limits,
           action.version,
           action.publish,
-          action.annotations ++ systemAnnotations(NODEJS10),
+          action.annotations ++ systemAnnotations(NODEJS),
           updated = response.updated))
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/migration/SequenceActionApiMigrationTests.scala
@@ -98,7 +98,7 @@ class SequenceActionApiMigrationTests
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
+      response.exec.kind should be(NODEJS)
       response.parameters should be(Parameters("a", "A"))
     }
   }
@@ -117,7 +117,7 @@ class SequenceActionApiMigrationTests
       deleteAction(action.docid)
       status should be(OK)
       val response = responseAs[WhiskAction]
-      response.exec.kind should be(NODEJS10)
+      response.exec.kind should be(NODEJS)
       response.parameters shouldBe Parameters()
     }
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/ArtifactWithFileStorageActivationStoreTests.scala
@@ -154,7 +154,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             response = response,
             logs = logs,
             duration = Some(101L),
-            annotations = Parameters("kind", "nodejs:10") ++ Parameters(
+            annotations = Parameters("kind", "nodejs:14") ++ Parameters(
               "limits",
               ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
@@ -205,7 +205,7 @@ class ArtifactWithFileStorageActivationStoreTests()
             response = response,
             logs = logs,
             duration = Some(101L),
-            annotations = Parameters("kind", "nodejs:10") ++ Parameters(
+            annotations = Parameters("kind", "nodejs:14") ++ Parameters(
               "limits",
               ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
               Parameters("waitTime", 16.toJson) ++
@@ -317,7 +317,7 @@ class ArtifactWithFileStorageActivationStoreTests()
               response = response,
               logs = logs,
               duration = Some(101L),
-              annotations = Parameters("kind", "nodejs:10") ++ Parameters(
+              annotations = Parameters("kind", "nodejs:14") ++ Parameters(
                 "limits",
                 ActionLimits(TimeLimit(60.second), MemoryLimit(256.MB), LogLimit(10.MB)).toJson) ++
                 Parameters("waitTime", 16.toJson) ++

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/LimitsCommandTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/LimitsCommandTests.scala
@@ -50,7 +50,7 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       "--concurrentInvocations",
       "11",
       "--allowedKinds",
-      "nodejs:10",
+      "nodejs:14",
       "blackbox",
       "--storeActivations",
       "false",
@@ -61,7 +61,7 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
       invocationsPerMinute = Some(3),
       firesPerMinute = Some(7),
       concurrentInvocations = Some(11),
-      allowedKinds = Some(Set("nodejs:10", "blackbox")),
+      allowedKinds = Some(Set("nodejs:14", "blackbox")),
       storeActivations = Some(false))
 
     resultOk("limits", "set", "--invocationsPerMinute", "13", ns) shouldBe CommandMessages.limitsSuccessfullyUpdated(ns)
@@ -97,10 +97,10 @@ class LimitsCommandTests extends FlatSpec with WhiskAdminCliTestBase {
 
   it should "update existing allowedKind limit" in {
     val ns = newNamespace()
-    resultOk("limits", "set", "--allowedKinds", "nodejs:10", ns)
-    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:10"
-    resultOk("limits", "set", "--allowedKinds", "nodejs:10", "blackbox", "python", ns)
-    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:10, blackbox, python"
+    resultOk("limits", "set", "--allowedKinds", "nodejs:14", ns)
+    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:14"
+    resultOk("limits", "set", "--allowedKinds", "nodejs:14", "blackbox", "python", ns)
+    resultOk("limits", "get", ns) shouldBe "allowedKinds = nodejs:14, blackbox, python"
 
     //Delete
     resultOk("limits", "delete", ns) shouldBe CommandMessages.limitsDeleted

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/AttachmentCompatibilityTests.scala
@@ -116,7 +116,7 @@ class AttachmentCompatibilityTests
   it should "read existing base64 encoded code string" in {
     implicit val tid: TransactionId = transid()
     val exec = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "code": "SGVsbG8gT3BlbldoaXNr"
                |}""".stripMargin.parseJson.asJsObject
     val (id, action) = makeActionJson(namespace, aname(), exec)
@@ -129,7 +129,7 @@ class AttachmentCompatibilityTests
   it should "read existing simple code string" in {
     implicit val tid: TransactionId = transid()
     val exec = """{
-                 |  "kind": "nodejs:10",
+                 |  "kind": "nodejs:14",
                  |  "code": "while (true)"
                  |}""".stripMargin.parseJson.asJsObject
     val (id, action) = makeActionJson(namespace, aname(), exec)

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecHelpers.scala
@@ -35,7 +35,7 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   private val config = new WhiskConfig(ExecManifest.requiredProperties)
   ExecManifest.initialize(config) should be a 'success
 
-  protected val NODEJS10 = "nodejs:10"
+  protected val NODEJS = "nodejs:14"
   protected val SWIFT4 = "swift:4.2"
   protected val BLACKBOX = "blackbox"
   protected val JAVA_DEFAULT = "java:8"
@@ -45,11 +45,11 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
   protected def imageName(name: String) =
     ExecManifest.runtimesManifest.runtimes.flatMap(_.versions).find(_.kind == name).get.image
 
-  protected def js10Old(code: String, main: Option[String] = None) = {
+  protected def jsOld(code: String, main: Option[String] = None) = {
     CodeExecAsString(
       RuntimeManifest(
-        NODEJS10,
-        imageName(NODEJS10),
+        NODEJS,
+        imageName(NODEJS),
         default = Some(true),
         deprecated = Some(false),
         stemCells = Some(List(StemCell(2, 256.MB)))),
@@ -57,22 +57,22 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
       main.map(_.trim))
   }
 
-  protected def js10(code: String, main: Option[String] = None) = {
+  protected def js(code: String, main: Option[String] = None) = {
     val attachment = attFmt[String].read(code.trim.toJson)
-    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS10).get
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS).get
 
     CodeExecAsAttachment(manifest, attachment, main.map(_.trim), Exec.isBinaryCode(code))
   }
 
   protected def jsDefault(code: String, main: Option[String] = None) = {
-    js10(code, main)
+    js(code, main)
   }
 
-  protected def js10MetaDataOld(main: Option[String] = None, binary: Boolean) = {
+  protected def jsMetaDataOld(main: Option[String] = None, binary: Boolean) = {
     CodeExecMetaDataAsString(
       RuntimeManifest(
-        NODEJS10,
-        imageName(NODEJS10),
+        NODEJS,
+        imageName(NODEJS),
         default = Some(true),
         deprecated = Some(false),
         stemCells = Some(List(StemCell(2, 256.MB)))),
@@ -80,8 +80,8 @@ trait ExecHelpers extends Matchers with WskActorSystem with StreamLogging {
       main.map(_.trim))
   }
 
-  protected def js10MetaData(main: Option[String] = None, binary: Boolean) = {
-    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS10).get
+  protected def jsMetaData(main: Option[String] = None, binary: Boolean) = {
+    val manifest = ExecManifest.runtimesManifest.resolveDefaultRuntime(NODEJS).get
 
     CodeExecMetaDataAsAttachment(manifest, binary, main.map(_.trim))
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecManifestTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecManifestTests.scala
@@ -270,7 +270,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |{ "runtimes": {
                  |    "nodef": [
                  |      {
-                 |        "kind": "nodejs:10",
+                 |        "kind": "nodejs:14",
                  |        "default": true,
                  |        "image": {
                  |          "name": "nodejsaction"
@@ -321,8 +321,8 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |}
                  |""".stripMargin.parseJson.asJsObject
 
-    val js10 = RuntimeManifest(
-      "nodejs:10",
+    val js14 = RuntimeManifest(
+      "nodejs:14",
       ImageName("nodejsaction"),
       default = Some(true),
       stemCells = Some(List(StemCell(1, 128.MB), StemCell(1, 256.MB))))
@@ -339,7 +339,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
     mf shouldBe {
       Runtimes(
         Set(
-          RuntimeFamily("nodef", Set(js10, js12)),
+          RuntimeFamily("nodef", Set(js14, js12)),
           RuntimeFamily("pythonf", Set(py)),
           RuntimeFamily("swiftf", Set(sw)),
           RuntimeFamily("phpf", Set(ph))),
@@ -353,8 +353,8 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
           (m.kind, m.image, c.initialCount, c.memory)
         }
     }.toList should contain theSameElementsAs List(
-      (js10.kind, js10.image, 1, 128.MB),
-      (js10.kind, js10.image, 1, 256.MB),
+      (js14.kind, js14.image, 1, 128.MB),
+      (js14.kind, js14.image, 1, 256.MB),
       (js12.kind, js12.image, 1, 128.MB),
       (py.kind, py.image, 2, 256.MB))
   }
@@ -364,7 +364,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |{ "runtimes": {
                  |    "nodef": [
                  |      {
-                 |        "kind": "nodejs:10",
+                 |        "kind": "nodejs:14",
                  |        "default": true,
                  |        "image": {
                  |          "name": "nodejsaction"
@@ -444,8 +444,8 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
                  |""".stripMargin.parseJson.asJsObject
 
     val reactive = Some(ReactivePrewarmingConfig(1, 4, FiniteDuration(2, TimeUnit.MINUTES), 1, 1))
-    val js10 = RuntimeManifest(
-      "nodejs:10",
+    val js14 = RuntimeManifest(
+      "nodejs:14",
       ImageName("nodejsaction"),
       default = Some(true),
       stemCells = Some(List(StemCell(1, 128.MB, reactive), StemCell(1, 256.MB, reactive))))
@@ -462,7 +462,7 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
     mf shouldBe {
       Runtimes(
         Set(
-          RuntimeFamily("nodef", Set(js10, js12)),
+          RuntimeFamily("nodef", Set(js14, js12)),
           RuntimeFamily("pythonf", Set(py)),
           RuntimeFamily("swiftf", Set(sw)),
           RuntimeFamily("phpf", Set(ph))),
@@ -476,8 +476,8 @@ class ExecManifestTests extends FlatSpec with WskActorSystem with StreamLogging 
           (m.kind, m.image, c.initialCount, c.memory)
         }
     }.toList should contain theSameElementsAs List(
-      (js10.kind, js10.image, 1, 128.MB),
-      (js10.kind, js10.image, 1, 256.MB),
+      (js14.kind, js14.image, 1, 128.MB),
+      (js14.kind, js14.image, 1, 256.MB),
       (js12.kind, js12.image, 1, 128.MB),
       (py.kind, py.image, 2, 256.MB))
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/ExecTests.scala
@@ -59,7 +59,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
                  |  "updated": 1533623651650,
                  |  "entityType": "action",
                  |  "exec": {
-                 |    "kind": "nodejs:10",
+                 |    "kind": "nodejs:14",
                  |    "code": "foo",
                  |    "binary": false
                  |  },
@@ -82,7 +82,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
   it should "properly determine binary property" in {
     val j1 = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "code": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -91,7 +91,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
     }
 
     val j2 = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "code": "while (true)",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -101,7 +101,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
     //Defaults to binary
     val j3 = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "code": "while (true)"
                |}""".stripMargin.parseJson.asJsObject
     Exec.serdes.read(j3) should matchPattern {
@@ -128,7 +128,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
 
   it should "read code stored as jar property" in {
     val j1 = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "jar": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
                |}""".stripMargin.parseJson.asJsObject
@@ -143,7 +143,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
         |  "runtimes": {
         |    "nodejs": [
         |      {
-        |        "kind": "nodejs:10",
+        |        "kind": "nodejs:14",
         |        "default": true,
         |        "image": {
         |          "prefix": "openwhisk",
@@ -164,7 +164,7 @@ class ExecTests extends FlatSpec with Matchers with StreamLogging with BeforeAnd
       new TestConfig(Map(WhiskConfig.runtimesManifest -> oldManifestJson), ExecManifest.requiredProperties)
     ExecManifest.initialize(oldConfig)
     val j1 = """{
-               |  "kind": "nodejs:10",
+               |  "kind": "nodejs:14",
                |  "code": "SGVsbG8gT3BlbldoaXNr",
                |  "binary": false
              |}""".stripMargin.parseJson.asJsObject

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/SchemaTests.scala
@@ -493,18 +493,18 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
   it should "initialize exec manifest" in {
     val runtimes = ExecManifest.runtimesManifest
     val kind = runtimes.resolveDefaultRuntime("nodejs:default").get.kind
-    Some(kind) should contain oneOf ("nodejs:10", "nodejs:12")
+    Some(kind) should contain oneOf ("nodejs:10", "nodejs:12", "nodejs:14")
   }
 
   it should "properly deserialize and reserialize JSON" in {
     val b64Body = """ZnVuY3Rpb24gbWFpbihhcmdzKSB7IHJldHVybiBhcmdzOyB9Cg=="""
 
     val json = Seq[JsObject](
-      JsObject("kind" -> "nodejs:10".toJson, "code" -> "js1".toJson, "binary" -> false.toJson),
-      JsObject("kind" -> "nodejs:10".toJson, "code" -> "js2".toJson, "binary" -> false.toJson, "foo" -> "bar".toJson),
+      JsObject("kind" -> "nodejs:14".toJson, "code" -> "js1".toJson, "binary" -> false.toJson),
+      JsObject("kind" -> "nodejs:14".toJson, "code" -> "js2".toJson, "binary" -> false.toJson, "foo" -> "bar".toJson),
       JsObject("kind" -> "swift:4.2".toJson, "code" -> "swift1".toJson, "binary" -> false.toJson),
       JsObject("kind" -> "swift:4.2".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson),
-      JsObject("kind" -> "nodejs:10".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson))
+      JsObject("kind" -> "nodejs:14".toJson, "code" -> b64Body.toJson, "binary" -> true.toJson))
 
     val execs = json.map { e =>
       Exec.serdes.read(e)
@@ -637,8 +637,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
       JsObject.empty,
       JsNull,
       JsObject("init" -> "zipfile".toJson),
-      JsObject("kind" -> "nodejs:10".toJson, "code" -> JsNumber(42)),
-      JsObject("kind" -> "nodejs:10".toJson, "init" -> "zipfile".toJson),
+      JsObject("kind" -> "nodejs:14".toJson, "code" -> JsNumber(42)),
+      JsObject("kind" -> "nodejs:14".toJson, "init" -> "zipfile".toJson),
       JsObject("kind" -> "turbopascal".toJson, "code" -> "BEGIN1".toJson),
       JsObject("kind" -> "blackbox".toJson, "code" -> "js".toJson),
       JsObject("kind" -> "swift".toJson, "swiftcode" -> "swift".toJson))
@@ -666,8 +666,8 @@ class SchemaTests extends FlatSpec with BeforeAndAfter with ExecHelpers with Mat
   it should "serialize to json" in {
     val execs = Seq(bb("container"), jsDefault("js"), jsDefault("js"), swift("swift")).map { _.asJson }
     assert(execs(0) == JsObject("kind" -> "blackbox".toJson, "image" -> "container".toJson, "binary" -> false.toJson))
-    assert(execs(1) == JsObject("kind" -> "nodejs:10".toJson, "code" -> "js".toJson, "binary" -> false.toJson))
-    assert(execs(2) == JsObject("kind" -> "nodejs:10".toJson, "code" -> "js".toJson, "binary" -> false.toJson))
+    assert(execs(1) == JsObject("kind" -> "nodejs:14".toJson, "code" -> "js".toJson, "binary" -> false.toJson))
+    assert(execs(2) == JsObject("kind" -> "nodejs:14".toJson, "code" -> "js".toJson, "binary" -> false.toJson))
     assert(execs(3) == JsObject("kind" -> "swift:4.2".toJson, "code" -> "swift".toJson, "binary" -> false.toJson))
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/entity/test/WhiskEntityTests.scala
@@ -177,7 +177,7 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
         |	"version": "0.0.2",
         |	"entityType": "action",
         |	"exec": {
-        |		"kind": "nodejs:10",
+        |		"kind": "nodejs:14",
         |		"code": "foo",
         |		"binary": false
         |	},
@@ -205,7 +205,7 @@ class WhiskEntityTests extends FlatSpec with ExecHelpers with Matchers {
         |  "annotations": [],
         |  "version": "0.0.1",
         |  "exec": {
-        |	   "kind": "nodejs:10",
+        |	   "kind": "nodejs:14",
         |    "code": "foo",
         |    "binary": false
         |  },

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -421,7 +421,7 @@ class ShardingContainerPoolBalancerTests
     WhiskActionMetaData(
       namespace,
       name,
-      js10MetaData(Some("jsMain"), false),
+      jsMetaData(Some("jsMain"), false),
       limits = actionLimits(actionMem, concurrency))
   val maxContainers = invokerMem.toMB.toInt / actionMetaData.limits.memory.megabytes
   val numInvokers = 3

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/grpc/test/CommonVariable.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/grpc/test/CommonVariable.scala
@@ -32,7 +32,7 @@ trait CommonVariable {
   val semVer = SemVer(0, 1, 1)
   val testVersion = Some(semVer)
   val testFQN = FullyQualifiedEntityName(testEntityPath, testEntityName, testVersion)
-  val testExec = CodeExecAsString(RuntimeManifest("nodejs:10", ImageName("testImage")), "testCode", None)
+  val testExec = CodeExecAsString(RuntimeManifest("nodejs:14", ImageName("testImage")), "testCode", None)
   val testExecMetadata =
     CodeExecMetaDataAsString(testExec.manifest, entryPoint = testExec.entryPoint)
   val testActionMetaData =

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/ElasticSearchDurationCheckerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/ElasticSearchDurationCheckerTests.scala
@@ -139,7 +139,7 @@ class ElasticSearchDurationCheckerTests
       WhiskActionMetaData(
         EntityPath(namespace),
         EntityName(actionName),
-        js10MetaData(Some("jsMain"), binary = false),
+        jsMetaData(Some("jsMain"), binary = false),
         limits = actionLimits(actionMem, concurrency))
 
     val run1 = wsk.action.invoke(actionName, Map())
@@ -210,7 +210,7 @@ class ElasticSearchDurationCheckerTests
       WhiskActionMetaData(
         EntityPath(s"$namespace/$packageName"),
         EntityName(actionName),
-        js10MetaData(Some("jsMain"), binary = false),
+        jsMetaData(Some("jsMain"), binary = false),
         limits = actionLimits(actionMem, concurrency))
 
     var totalDuration = 0L
@@ -288,7 +288,7 @@ class ElasticSearchDurationCheckerTests
       WhiskActionMetaData(
         EntityPath(s"$namespace/$boundPackageName"),
         EntityName(actionName),
-        js10MetaData(Some("jsMain"), binary = false),
+        jsMetaData(Some("jsMain"), binary = false),
         limits = actionLimits(actionMem, concurrency),
         binding = Some(EntityPath(s"$namespace/$packageName")))
 
@@ -365,7 +365,7 @@ class ElasticSearchDurationCheckerTests
       WhiskActionMetaData(
         EntityPath(s"$namespace"),
         EntityName(actionName),
-        js10MetaData(Some("jsMain"), binary = false),
+        jsMetaData(Some("jsMain"), binary = false),
         limits = actionLimits(actionMem, concurrency))
 
     val durationCheckResult: DurationCheckResult =
@@ -385,7 +385,7 @@ class ElasticSearchDurationCheckerTests
         WhiskActionMetaData(
           EntityPath(s"$namespace/$boundPackageName"),
           EntityName(actionName),
-          js10MetaData(Some("jsMain"), false),
+          jsMetaData(Some("jsMain"), false),
           limits = actionLimits(actionMem, concurrency),
           binding = Some(EntityPath(s"${namespace}/${packageName}")))
 

--- a/tests/src/test/scala/system/rest/JsonSchemaTests.scala
+++ b/tests/src/test/scala/system/rest/JsonSchemaTests.scala
@@ -51,7 +51,7 @@ class JsonSchemaTests extends FlatSpec with Matchers with JsonSchema with RestUt
                        | "name":"foo",
                        | "version":"1.1.1",
                        | "publish":false,
-                       | "exec":{ "code": "foo", "kind": "nodejs:10" },
+                       | "exec":{ "code": "foo", "kind": "nodejs:14" },
                        | "parameters":["key1","value1"],
                        | "limits":{ "timeout":1000, "memory":200 } }""".stripMargin
     assert(check(ACTION, schema))

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -45,7 +45,7 @@ export KUBECONFIG="$(kind get kubeconfig-path)"
 kubectl config set-context --current --namespace=default
 
 # This is required because it is timed out to pull the image during the test.
-docker pull openwhisk/action-nodejs-v10:nightly
+docker pull openwhisk/action-nodejs-v14:nightly
 docker pull openwhisk/dockerskeleton:nightly
 docker pull openwhisk/apigateway:0.11.0
 

--- a/tools/travis/runUnitTests.sh
+++ b/tools/travis/runUnitTests.sh
@@ -32,4 +32,7 @@ cat "$ROOTDIR/tests/src/test/resources/application.conf"
 
 ./distDocker.sh
 
+# yet another hack to hit docker rate limits early...
+docker pull alpine:3.5
+
 ./runTests.sh


### PR DESCRIPTION
Node.js 10 hits its end of life on April 30, 2021.  (https://nodejs.org/en/about/releases/)

Prepare for deprecation and eventual removal of the nodejs:10 kind by rolling the default for nodejs forward to nodejs:14 (most recent LTS release).

I propose to skip over nodejs:12 (similar to how we jumped from nodejs:6 to nodejs:10) since the change of a default kind (and associated stemcell change) is marginally disruptive.
