### PR TITLE
deprecate nodejs:10 kind

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -22,7 +22,7 @@
                     "name": "action-nodejs-v10",
                     "tag": "nightly"
                 },
-                "deprecated": false,
+                "deprecated": true,
                 "attached": {
                     "attachmentName": "codefile",
                     "attachmentType": "text/plain"

--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -243,7 +243,7 @@ trait WskTestHelpers extends Matchers {
     run: RunResult,
     initialWait: Duration = 1.second,
     pollPeriod: Duration = 1.second,
-    totalWait: Duration = 60.seconds)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
+    totalWait: Duration = 120.seconds)(check: ActivationResult => Unit)(implicit wskprops: WskProps): Unit = {
     val activationId = wsk.extractActivationId(run)
 
     withClue(s"did not find an activation id in '$run'") {
@@ -275,7 +275,7 @@ trait WskTestHelpers extends Matchers {
   }
   def withActivation(wsk: ActivationOperations, activationId: String)(check: ActivationResult => Unit)(
     implicit wskprops: WskProps): Unit = {
-    withActivation(wsk, activationId, 1.second, 1.second, 60.seconds)(check)
+    withActivation(wsk, activationId, 1.second, 1.second, 120.seconds)(check)
   }
 
   /**

--- a/tools/travis/runStandaloneTests.sh
+++ b/tools/travis/runStandaloneTests.sh
@@ -47,6 +47,7 @@ kubectl config set-context --current --namespace=default
 # This is required because it is timed out to pull the image during the test.
 docker pull openwhisk/action-nodejs-v14:nightly
 docker pull openwhisk/dockerskeleton:nightly
+docker pull openwhisk/example:nightly
 docker pull openwhisk/apigateway:0.11.0
 
 cd $ROOTDIR


### PR DESCRIPTION
Node.js v10 hit end of life on April 30, 2021.  Mark nodejs:10 as deprecated; the next step towards removing nodejs:10 support.
