### PR TITLE
Add retry logic of save activation

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -331,7 +331,7 @@ whisk {
 
     # ActivationStore related configuration
     # For example:
-    # activationStore {
+    # activation-store {
     #   elasticsearch {
     #      protocol         =       # "http" or "https"
     #      hosts            =       # the hosts address of ES, can be multi hosts combined with commas, like "172.17.0.1:9200,172.17.0.2:9200,172.17.0.3:9200"
@@ -343,6 +343,15 @@ whisk {
     #      password         =       # password of the provide ES
     #   }
     # }
+
+    activation-store {
+        retry-config {
+            max-tries = 3
+        }
+        elasticsearch {
+            keep-alive = 13 minutes
+        }
+    }
 
     azure-blob {
         # Config property when using AzureBlobAttachmentStore

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/Batcher.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/Batcher.scala
@@ -49,9 +49,10 @@ import akka.stream.scaladsl.{Sink, Source}
  * @tparam T the type to be batched
  * @tparam R return type of a single element after operation
  */
-class Batcher[T, R](batchSize: Int, concurrency: Int)(operation: Seq[T] => Future[Seq[R]])(implicit
-                                                                                           system: ActorSystem,
-                                                                                           ec: ExecutionContext) {
+class Batcher[T, R](batchSize: Int, concurrency: Int, retry: Int)(operation: (Seq[T], Int) => Future[Seq[R]])(
+  implicit
+  system: ActorSystem,
+  ec: ExecutionContext) {
 
   val cm: PartialFunction[Any, CompletionStrategy] = {
     case Done =>
@@ -69,7 +70,7 @@ class Batcher[T, R](batchSize: Int, concurrency: Int)(operation: Seq[T] => Futur
       val elements = els.map(_._1)
       val promises = els.map(_._2)
 
-      val f = operation(elements)
+      val f = operation(elements, retry)
       f.onComplete {
         case Success(results) => results.zip(promises).foreach { case (result, p) => p.success(result) }
         case Failure(e)       => promises.foreach(_.failure(e))

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/CouchDbRestStore.scala
@@ -30,6 +30,7 @@ import org.apache.openwhisk.core.database.StoreUtils._
 import org.apache.openwhisk.core.entity.Attachments.Attached
 import org.apache.openwhisk.core.entity.{BulkEntityResult, DocInfo, DocumentReader, UUID}
 import org.apache.openwhisk.http.Messages
+import pureconfig.loadConfigOrThrow
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -74,8 +75,9 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
   // and more documents need to be stored, then all arriving documents will be put into batches (if enabled) to avoid a long queue.
   private val maxOpenDbRequests = system.settings.config.getInt("akka.http.host-connection-pool.max-connections") / 2
 
+  private val maxRetry = loadConfigOrThrow[Int]("whisk.activation-store.retry-config.max-tries")
   private val batcher: Batcher[JsObject, Either[ArtifactStoreException, DocInfo]] =
-    new Batcher(500, maxOpenDbRequests)(put(_)(TransactionId.dbBatcher))
+    new Batcher(500, maxOpenDbRequests, maxRetry)(put(_, _)(TransactionId.dbBatcher))
 
   override protected[database] def put(d: DocumentAbstraction)(implicit transid: TransactionId): Future[DocInfo] = {
     val asJson = d.toDocumentRecord
@@ -131,13 +133,10 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       }
     }
 
-    reportFailure(
-      f,
-      failure =>
-        transid.failed(this, start, s"[PUT] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
+    f
   }
 
-  private def put(ds: Seq[JsObject])(
+  private def put(ds: Seq[JsObject], retry: Int)(
     implicit transid: TransactionId): Future[Seq[Either[ArtifactStoreException, DocInfo]]] = {
     val count = ds.size
     val start = transid.started(this, LoggingMarkers.DATABASE_BULK_SAVE, s"'$dbName' saving $count documents")
@@ -166,10 +165,16 @@ class CouchDbRestStore[DocumentAbstraction <: DocumentSerializer](dbProtocol: St
       }
     }
 
-    reportFailure(
-      f,
-      failure =>
-        transid.failed(this, start, s"[PUT] '$dbName' internal error, failure: '${failure.getMessage}'", ErrorLevel))
+    f.recoverWith {
+      case t: ArtifactStoreException => Future.failed(t)
+      case _ if retry > 0 =>
+        transid.failed(this, start, s"store activation to CouchDB failed")
+        put(ds, retry - 1)
+      case t =>
+        transid
+          .failed(this, start, s"[PUT] '$dbName' internal error, failure: '${t.getMessage}'", ErrorLevel)
+        Future.failed(t)
+    }
   }
 
   override protected[database] def del(doc: DocInfo)(implicit transid: TransactionId): Future[Boolean] = {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/elasticsearch/ElasticSearchActivationStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/elasticsearch/ElasticSearchActivationStore.scala
@@ -20,11 +20,13 @@ package org.apache.openwhisk.core.database.elasticsearch
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.duration._
 import scala.language.postfixOps
 import akka.actor.ActorSystem
 import akka.event.Logging.ErrorLevel
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.Flow
+import com.google.common.base.Throwables
 import com.sksamuel.elastic4s.http.search.SearchHit
 import com.sksamuel.elastic4s.http.{ElasticClient, ElasticProperties, NoOpRequestConfigCallback}
 import com.sksamuel.elastic4s.indexes.IndexRequest
@@ -44,6 +46,9 @@ import org.apache.openwhisk.core.database.StoreUtils._
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.http.Messages
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
+import org.apache.http
+import org.apache.http.conn.ConnectionKeepAliveStrategy
+import org.apache.http.protocol.HttpContext
 
 import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
 import scala.util.Try
@@ -74,8 +79,9 @@ class ElasticSearchActivationStore(
   private val esType = "_doc"
   private val maxOpenDbRequests = actorSystem.settings.config
     .getInt("akka.http.host-connection-pool.max-connections") / 2
+  private val maxRetry = loadConfigOrThrow[Int]("whisk.activation-store.retry-config.max-tries")
   private val batcher: Batcher[IndexRequest, Either[ArtifactStoreException, DocInfo]] =
-    new Batcher(500, maxOpenDbRequests)(doStore(_)(TransactionId.dbBatcher))
+    new Batcher(500, maxOpenDbRequests, maxRetry)(doStore(_, _)(TransactionId.dbBatcher))
 
   private val minStart = 0L
   private val maxStart = Instant.now.toEpochMilli + TimeUnit.DAYS.toMillis(365 * 100) //100 years from now
@@ -128,10 +134,10 @@ class ElasticSearchActivationStore(
         throw PutException("error on 'put'")
     }
 
-    reportFailure(res, start, failure => s"[PUT] 'activations' internal error, failure: '${failure.getMessage}'")
+    res
   }
 
-  private def doStore(ops: Seq[IndexRequest])(
+  private def doStore(ops: Seq[IndexRequest], retry: Int)(
     implicit transid: TransactionId): Future[Seq[Either[ArtifactStoreException, DocInfo]]] = {
     val count = ops.size
     val start = transid.started(this, LoggingMarkers.DATABASE_BULK_SAVE, s"'activations' saving $count documents")
@@ -158,7 +164,20 @@ class ElasticSearchActivationStore(
         }
       }
 
-    reportFailure(res, start, failure => s"[PUT] 'activations' internal error, failure: '${failure.getMessage}'")
+    res.recoverWith {
+      case t: ArtifactStoreException => Future.failed(t)
+      case _ if retry > 0 =>
+        transid.failed(this, start, s"store activation to ElasticSearch failed")
+        doStore(ops, retry - 1)
+      case t =>
+        transid.failed(
+          this,
+          start,
+          s"[PUT] 'activations' internal error, failure: '${t.getMessage}' [${t.getClass.getSimpleName}]\n" + Throwables
+            .getStackTraceAsString(t),
+          ErrorLevel)
+        Future.failed(t)
+    }
   }
 
   override def get(activationId: ActivationId, context: UserContext)(
@@ -412,6 +431,7 @@ object ElasticSearchActivationStore {
         AuthScope.ANY,
         new UsernamePasswordCredentials(elasticSearchConfig.username, elasticSearchConfig.password))
       httpClientBuilder.setDefaultCredentialsProvider(provider)
+      httpClientBuilder.setKeepAliveStrategy(new CustomKeepAliveStrategy())
     }
   }
 
@@ -427,4 +447,10 @@ object ElasticSearchActivationStoreProvider extends ActivationStoreProvider {
     new ElasticSearchActivationStore(elasticSearchConfig = elasticSearchConfig, useBatching = true)(
       actorSystem,
       logging)
+}
+
+class CustomKeepAliveStrategy extends ConnectionKeepAliveStrategy {
+  override def getKeepAliveDuration(response: http.HttpResponse, context: HttpContext): Long = {
+    loadConfigOrThrow[FiniteDuration]("whisk.activation-store.elasticsearch.keep-alive").toMillis
+  }
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/test/BatcherTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/test/BatcherTests.scala
@@ -54,32 +54,33 @@ class BatcherTests extends FlatSpec with Matchers with WskActorSystem {
 
     val transform = (i: Int) => i + 1
 
-    val batchOperation = LoggedFunction((els: Seq[Int]) => {
+    val batchOperation = LoggedFunction((els: Seq[Int], retry: Int) => {
       batchPromises.dequeue().future.map(_ => els.map(transform))
     })
 
-    val batcher = new Batcher[Int, Int](2, 1)(batchOperation)
+    val batcher = new Batcher[Int, Int](2, 1, 1)(batchOperation)
 
     val values = 1 to 5
     val results = values.map(batcher.put)
 
     // First "batch"
     retry(batchOperation.calls should have size 1, (promiseDelay.toMillis * 2).toInt)
-    batchOperation.calls(0) should have size 1
+
+    batchOperation.calls(0)._1 should have size 1
 
     // Allow batch to build up
     resolveDelayed(ps(0))
 
     // Second batch
     retry(batchOperation.calls should have size 2, (promiseDelay.toMillis * 2).toInt)
-    batchOperation.calls(1) should have size 2
+    batchOperation.calls(1)._1 should have size 2
 
     // Allow batch to build up
     resolveDelayed(ps(1))
 
     // Third batch
     retry(batchOperation.calls should have size 3, (promiseDelay.toMillis * 2).toInt)
-    batchOperation.calls(2) should have size 2
+    batchOperation.calls(2)._1 should have size 2
     ps(2).success(())
 
     await(Future.sequence(results)) shouldBe values.map(transform)
@@ -90,7 +91,7 @@ class BatcherTests extends FlatSpec with Matchers with WskActorSystem {
     val parallel = new AtomicInteger(0)
     val concurrency = 2
 
-    val batcher = new Batcher[Int, Int](1, concurrency)(els => {
+    val batcher = new Batcher[Int, Int](1, concurrency, 1)((els, _) => {
       parallel.incrementAndGet()
       p.future.map(_ => els)
     })
@@ -108,7 +109,7 @@ class BatcherTests extends FlatSpec with Matchers with WskActorSystem {
   }
 
   it should "complete batched values with the thrown exception" in {
-    val batcher = new Batcher[Int, Int](2, 1)(_ => Future.failed(new Exception))
+    val batcher = new Batcher[Int, Int](2, 1, 1)((_, _) => Future.failed(new Exception))
 
     val r1 = batcher.put(1)
     val r2 = batcher.put(2)
@@ -122,5 +123,72 @@ class BatcherTests extends FlatSpec with Matchers with WskActorSystem {
 
     an[Exception] should be thrownBy await(r3)
     an[Exception] should be thrownBy await(r4)
+  }
+
+  it should "complete batched values with max retry limit" in {
+    val p = Promise[Unit]()
+
+    val maxRetry = 3
+    val batchSize = 1
+    val concurrency = 1
+
+    var retryCount = new AtomicInteger(0)
+
+    def doStore(els: Seq[Int], retry: Int): Future[Seq[Int]] = {
+      val result = if (retry > 0) {
+        Future.failed(new Exception)
+      } else {
+        p.future.map(_ => els)
+      }
+
+      result.recoverWith {
+        case _ if retry > 0 =>
+          retryCount.incrementAndGet()
+          doStore(els, retry - 1)
+        case e =>
+          Future.failed(e)
+      }
+
+    }
+    val batcher = new Batcher[Int, Int](batchSize, concurrency, maxRetry)(doStore)
+
+    val values = List(1)
+    val results = values.map(batcher.put)
+
+    p.success(())
+
+    await(Future.sequence(results)) shouldBe values
+
+    retryCount.get() shouldBe maxRetry
+  }
+
+  it should "complete batched values with the thrown exception with max retry limit" in {
+    val p = Promise[Unit]()
+
+    val maxRetry = 3
+    val batchSize = 1
+    val concurrency = 1
+
+    var retryCount = new AtomicInteger(0)
+
+    def doStore(els: Seq[Int], retry: Int): Future[Seq[Int]] = {
+      val result = Future.failed(new Exception)
+
+      result.recoverWith {
+        case _ if retry > 0 =>
+          retryCount.incrementAndGet()
+          doStore(els, retry - 1)
+        case e =>
+          Future.failed(e)
+      }
+
+    }
+    val batcher = new Batcher[Int, Int](batchSize, concurrency, maxRetry)(doStore)
+
+    val r1 = batcher.put(1)
+
+    an[Exception] should be thrownBy await(r1)
+
+    retryCount.get() shouldBe maxRetry
   }
 }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
Sometimes, due to `network work issue or other issue`, it is failed to save the activation to db,  .e.g.
![image](https://user-images.githubusercontent.com/11749867/123745009-38acf680-d8e2-11eb-8ef4-940fb1a15644.png)

So add retry logic of save activation.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB、ElasticSearch)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/wiki/Contributing:-Git-guidelines#code-readiness) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

