### PR TITLE
update name for Python 3 image

### DIFF
--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -62,7 +62,7 @@
                 "default": true,
                 "image": {
                     "prefix": "openwhisk",
-                    "name": "actionloop-python-v3.7",
+                    "name": "action-python-v3.7",
                     "tag": "nightly"
                 },
                 "deprecated": false,


### PR DESCRIPTION
We changed the image name we use to publish on dockerhub
from actionloop-python-v3.7 to action-python-v3.7 and
forgot to update runtime.json to match.
