### PR TITLE
minor version bump of azure-storage-blob to fix builds

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     }
     compile "com.amazonaws:aws-java-sdk-cloudfront:1.11.517"
 
-    compile ("com.azure:azure-storage-blob:12.6.0") {
+    compile ("com.azure:azure-storage-blob:12.7.0") {
         exclude group: "com.azure", module: "azure-core-test"
     }
 }


### PR DESCRIPTION
It appears the version 12.6.0 of com.azure:azure-storage-blob has
been removed from the maven central repo.  Our builds have been failing
for about 3 days trying to download it.  Version 12.7.0 is available,
so hack around the build problems by upgrading one minor version.

A typical failing build is: https://app.travis-ci.com/github/apache/openwhisk-runtime-rust/jobs/531822834#L279

