### PR TITLE
Update ansible with new scheduler instructions

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -182,27 +182,8 @@ Add a new dispatcher entry as follows.
 **common/scala/src/main/resources/reference.conf**
 ```
   lease-service-dispatcher {
-    type = Dispatcher
     executor = "thread-pool-executor"
-
-    # Underlying thread pool implementation is java.util.concurrent.ThreadPoolExecutor
-    thread-pool-executor {
-      # Min number of threads to cap factor-based corePoolSize number to
-      core-pool-size-min = 2
-
-      # The core-pool-size-factor is used to determine corePoolSize of the
-      # ThreadPoolExecutor using the following formula:
-      # ceil(available processors * factor).
-      # Resulting size is then bounded by the core-pool-size-min and
-      # core-pool-size-max values.
-      core-pool-size-factor = 2.0
-
-      # Max number of threads to cap factor-based corePoolSize number to
-      core-pool-size-max = 32
-    }
-    # Throughput defines the number of messages that are processed in a batch
-    # before the thread is returned to the pool. Set to 1 for as fair as possible.
-    throughput = 5
+    type = PinnedDispatcher
   }
 .
 .

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -156,7 +156,7 @@ It will run one more component called "scheduler" and ETCD.
 #### Configure service providers for the scheduler
 You can update service providers for the scheduler as follows. 
 
-**common/scala/src/main/resources**
+**common/scala/src/main/resources/reference.conf**
 ```
 whisk.spi {
   ArtifactStoreProvider = org.apache.openwhisk.core.database.CouchDbStoreProvider
@@ -176,10 +176,43 @@ whisk.spi {
 .
 ```
 
+#### Configure akka dispatcher for the scheduler
+Add a new dispatcher entry as follows.
+
+**common/scala/src/main/resources/reference.conf**
+```
+  lease-service-dispatcher {
+    type = Dispatcher
+    executor = "thread-pool-executor"
+
+    # Underlying thread pool implementation is java.util.concurrent.ThreadPoolExecutor
+    thread-pool-executor {
+      # Min number of threads to cap factor-based corePoolSize number to
+      core-pool-size-min = 2
+
+      # The core-pool-size-factor is used to determine corePoolSize of the
+      # ThreadPoolExecutor using the following formula:
+      # ceil(available processors * factor).
+      # Resulting size is then bounded by the core-pool-size-min and
+      # core-pool-size-max values.
+      core-pool-size-factor = 2.0
+
+      # Max number of threads to cap factor-based corePoolSize number to
+      core-pool-size-max = 32
+    }
+    # Throughput defines the number of messages that are processed in a batch
+    # before the thread is returned to the pool. Set to 1 for as fair as possible.
+    throughput = 5
+  }
+.
+.
+.
+```
+
 #### Enable the scheduler
 - Make sure you enable the scheduler by configuring `scheduler_enable`.
 
-**ansible/environments/local/group_vars**
+**ansible/environments/local/group_vars/all**
 ```yaml
 scheduler_enable: true
 ```


### PR DESCRIPTION
Add instructions to add configuration for akka dispatcher, add complete file paths in two places

## Description
When trying to deploy the new scheduler with ansible, I kept getting this error in the scheduler:
```
Exception in thread "main" akka.ConfigurationException: Dispatcher [dispatchers.lease-service-dispatcher] not configured for path akka://scheduler-actor-system/user/$b
```
Adding the dispatcher to the references.conf file fixed the error, and now I can deploy the scheduler via ansible.
I've just tested this locally by invoking a few functions after deployment.

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [X] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [N/A] I added tests to cover my changes.
- [N/A] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

