### PR TITLE
add enable/disable invoker support to old scheduler

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -278,14 +278,16 @@ object AcknowledegmentMessage extends DefaultJsonProtocol {
   }
 }
 
-case class PingMessage(instance: InvokerInstanceId) extends Message {
+case class PingMessage(instance: InvokerInstanceId, isEnabled: Option[Boolean] = None) extends Message {
   override def serialize = PingMessage.serdes.write(this).compactPrint
+
+  def invokerEnabled: Boolean = isEnabled.getOrElse(true)
 }
 
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
 
-  implicit val serdes = jsonFormat(PingMessage.apply _, "name")
+  implicit val serdes = jsonFormat(PingMessage.apply _, "name", "isEnabled")
 }
 
 trait EventMessageBody extends Message {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -287,7 +287,7 @@ case class PingMessage(instance: InvokerInstanceId, isEnabled: Option[Boolean] =
 object PingMessage extends DefaultJsonProtocol {
   def parse(msg: String) = Try(serdes.read(msg.parseJson))
 
-  implicit val serdes = jsonFormat(PingMessage.apply _, "name", "isEnabled")
+  implicit val serdes = jsonFormat(PingMessage.apply, "name", "isEnabled")
 }
 
 trait EventMessageBody extends Message {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerSupervision.scala
@@ -280,8 +280,8 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
 
   // To be used for all states that should send test actions to reverify the invoker
   val healthPingingState: StateFunction = {
-    case Event(_: PingMessage, _) => stay
-    case Event(StateTimeout, _)   => goto(Offline)
+    case Event(ping: PingMessage, _) => goOfflineIfDisabled(ping)
+    case Event(StateTimeout, _)      => goto(Offline)
     case Event(Tick, _) =>
       invokeTestAction()
       stay
@@ -300,7 +300,7 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
 
   /** An Offline invoker represents an existing but broken invoker. This means, that it does not send pings anymore. */
   when(Offline) {
-    case Event(_: PingMessage, _) => goto(Unhealthy)
+    case Event(ping: PingMessage, _) => if (ping.invokerEnabled) goto(Unhealthy) else stay
   }
 
   /** An Unhealthy invoker represents an invoker that was not able to handle actions successfully. */
@@ -314,8 +314,8 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
    * It will go offline if that state is not confirmed for 20 seconds.
    */
   when(Healthy, stateTimeout = healthyTimeout) {
-    case Event(_: PingMessage, _) => stay
-    case Event(StateTimeout, _)   => goto(Offline)
+    case Event(ping: PingMessage, _) => goOfflineIfDisabled(ping)
+    case Event(StateTimeout, _)      => goto(Offline)
   }
 
   /** Handles the completion of an Activation in every state. */
@@ -338,6 +338,16 @@ class InvokerActor(invokerInstance: InvokerInstanceId, controllerInstance: Contr
   onTransition(healthPingingTransitionHandler(Unresponsive))
 
   initialize()
+
+  /**
+   * Handling for if a ping message from an invoker signals that it has been disabled to immediately transition to Offline.
+   *
+   * @param ping
+   * @return
+   */
+  private def goOfflineIfDisabled(ping: PingMessage) = {
+    if (ping.invokerEnabled) stay else goto(Offline)
+  }
 
   /**
    * Handling for active acks. This method saves the result (successful or unsuccessful)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/DefaultInvokerServer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/DefaultInvokerServer.scala
@@ -47,6 +47,8 @@ class DefaultInvokerServer(val invoker: InvokerCore, systemUsername: String, sys
           invoker.enable()
         } ~ (path("disable") & post) {
           invoker.disable()
+        } ~ (path("isEnabled") & get) {
+          invoker.isEnabled()
         }
       case _ => terminate(StatusCodes.Unauthorized)
     }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -404,7 +404,7 @@ class FPCInvokerReactive(config: WhiskConfig,
   }
 
   override def isEnabled(): Route = {
-    complete(InvokerEnabled(consumer.nonEmpty && warmUpWatcher.nonEmpty).toJson().compactPrint)
+    complete(InvokerEnabled(consumer.nonEmpty && warmUpWatcher.nonEmpty).serialize())
   }
 
   override def backfillPrewarm(): Route = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -34,11 +34,12 @@ import org.apache.openwhisk.core.containerpool.logging.LogStoreProvider
 import org.apache.openwhisk.core.containerpool.v2._
 import org.apache.openwhisk.core.database.{UserContext, _}
 import org.apache.openwhisk.core.entity._
-import org.apache.openwhisk.core.etcd.EtcdKV.ContainerKeys.{containerPrefix}
+import org.apache.openwhisk.core.etcd.EtcdKV.ContainerKeys.containerPrefix
 import org.apache.openwhisk.core.etcd.EtcdKV.QueueKeys.queue
 import org.apache.openwhisk.core.etcd.EtcdKV.{ContainerKeys, SchedulerKeys}
 import org.apache.openwhisk.core.etcd.EtcdType._
 import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig}
+import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
 import org.apache.openwhisk.core.scheduler.{SchedulerEndpoints, SchedulerStates}
 import org.apache.openwhisk.core.service.{DataManagementService, EtcdWorker, LeaseKeepAliveService, WatcherService}
 import org.apache.openwhisk.core.{ConfigKeys, WarmUp, WhiskConfig}
@@ -400,6 +401,10 @@ class FPCInvokerReactive(config: WhiskConfig,
     warmUpWatcher.foreach(_.close())
     warmUpWatcher = None
     complete("Successfully disabled invoker")
+  }
+
+  override def isEnabled(): Route = {
+    complete(InvokerEnabled(consumer.nonEmpty && warmUpWatcher.nonEmpty).toJson().compactPrint)
   }
 
   override def backfillPrewarm(): Route = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerServer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerServer.scala
@@ -47,6 +47,8 @@ class FPCInvokerServer(val invoker: InvokerCore, systemUsername: String, systemP
           invoker.enable()
         } ~ (path("disable") & post) {
           invoker.disable()
+        } ~ (path("isEnabled") & get) {
+          invoker.isEnabled()
         }
       case _ => terminate(StatusCodes.Unauthorized)
     }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -35,6 +35,7 @@ import org.apache.openwhisk.spi.{Spi, SpiLoader}
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig._
 import pureconfig.generic.auto._
+import spray.json.{JsBoolean, JsObject}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -73,6 +74,10 @@ object Invoker {
   protected val protocol = loadConfigOrThrow[String]("whisk.invoker.protocol")
 
   val topicPrefix = loadConfigOrThrow[String](ConfigKeys.kafkaTopicsPrefix)
+
+  case class InvokerEnabled(isEnabled: Boolean) {
+    def toJson(): JsObject = JsObject("enabled" -> JsBoolean(isEnabled))
+  }
 
   /**
    * An object which records the environment variables required for this component to run.
@@ -220,6 +225,7 @@ trait InvokerProvider extends Spi {
 trait InvokerCore {
   def enable(): Route
   def disable(): Route
+  def isEnabled(): Route
   def backfillPrewarm(): Route
 }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -35,7 +35,7 @@ import org.apache.openwhisk.spi.{Spi, SpiLoader}
 import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig._
 import pureconfig.generic.auto._
-import spray.json.{JsBoolean, JsObject}
+import spray.json._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -75,8 +75,13 @@ object Invoker {
 
   val topicPrefix = loadConfigOrThrow[String](ConfigKeys.kafkaTopicsPrefix)
 
+  object InvokerEnabled extends DefaultJsonProtocol {
+    def parseJson(string: String) = Try(serdes.read(string.parseJson))
+    implicit val serdes = jsonFormat(InvokerEnabled.apply _, "enabled")
+  }
+
   case class InvokerEnabled(isEnabled: Boolean) {
-    def toJson(): JsObject = JsObject("enabled" -> JsBoolean(isEnabled))
+    def serialize(): String = InvokerEnabled.serdes.write(this).compactPrint
   }
 
   /**

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -309,7 +309,6 @@ class InvokerReactive(
     } else {
       complete(s"${instance.toString} is already enabled.")
     }
-    complete("not supported")
   }
 
   override def disable(): Route = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -300,7 +300,7 @@ class InvokerReactive(
       }
     })
 
-  var healthScheduler: Option[ActorRef] = Some(getHealthScheduler)
+  private var healthScheduler: Option[ActorRef] = Some(getHealthScheduler)
 
   override def enable(): Route = {
     if (healthScheduler.isEmpty) {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -325,7 +325,7 @@ class InvokerReactive(
   }
 
   override def isEnabled(): Route = {
-    complete(InvokerEnabled(healthScheduler.nonEmpty).toJson().compactPrint)
+    complete(InvokerEnabled(healthScheduler.nonEmpty).serialize())
   }
 
   override def backfillPrewarm(): Route = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -19,9 +19,8 @@ package org.apache.openwhisk.core.invoker
 
 import java.nio.charset.StandardCharsets
 import java.time.Instant
-
 import akka.Done
-import akka.actor.{ActorRefFactory, ActorSystem, CoordinatedShutdown, Props}
+import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, CoordinatedShutdown, Props}
 import akka.event.Logging.InfoLevel
 import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.Route
@@ -34,6 +33,7 @@ import org.apache.openwhisk.core.containerpool.logging.LogStoreProvider
 import org.apache.openwhisk.core.database.{UserContext, _}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
+import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.http.Messages
 import org.apache.openwhisk.spi.SpiLoader
@@ -46,7 +46,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 object InvokerReactive extends InvokerProvider {
-
   override def instance(
     config: WhiskConfig,
     instance: InvokerInstanceId,
@@ -293,18 +292,38 @@ class InvokerReactive(
   }
 
   private val healthProducer = msgProvider.getProducer(config)
-  Scheduler.scheduleWaitAtMost(1.seconds)(() => {
-    healthProducer.send(s"${Invoker.topicPrefix}health", PingMessage(instance)).andThen {
-      case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
-    }
-  })
+
+  def getHealthScheduler: ActorRef =
+    Scheduler.scheduleWaitAtMost(1.seconds)(() => {
+      healthProducer.send(s"${Invoker.topicPrefix}health", PingMessage(instance)).andThen {
+        case Failure(t) => logging.error(this, s"failed to ping the controller: $t")
+      }
+    })
+
+  var healthScheduler: Option[ActorRef] = Some(getHealthScheduler)
 
   override def enable(): Route = {
+    if (healthScheduler.isEmpty) {
+      healthScheduler = Some(getHealthScheduler)
+      complete(s"${instance.toString} is now enabled.")
+    } else {
+      complete(s"${instance.toString} is already enabled.")
+    }
     complete("not supported")
   }
 
   override def disable(): Route = {
-    complete("not supported")
+    if (healthScheduler.nonEmpty) {
+      actorSystem.stop(healthScheduler.get)
+      healthScheduler = None
+      complete(s"${instance.toString} is now disabled.")
+    } else {
+      complete(s"${instance.toString} is already disabled.")
+    }
+  }
+
+  override def isEnabled(): Route = {
+    complete(InvokerEnabled(healthScheduler.nonEmpty).toJson().compactPrint)
   }
 
   override def backfillPrewarm(): Route = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.StatusCodes.{OK, Unauthorized}
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import common.StreamLogging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
@@ -82,7 +83,9 @@ class DefaultInvokerServerTests
     val validCredentials = BasicHttpCredentials(systemUsername, systemPassword)
     Get(s"/isEnabled") ~> addCredentials(validCredentials) ~> Route.seal(server.routes(tid)) ~> check {
       status should be(OK)
-      InvokerEnabled.parseJson(responseEntity.toString) shouldEqual InvokerEnabled(true)
+      Unmarshal(responseEntity).to[String].map(response => {
+        InvokerEnabled.parseJson(response) shouldEqual InvokerEnabled(true)
+      })
     }
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import common.StreamLogging
 import org.apache.openwhisk.common.TransactionId
+import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
 import org.apache.openwhisk.core.invoker.{DefaultInvokerServer, InvokerCore}
 import org.apache.openwhisk.http.BasicHttpService
 import org.junit.runner.RunWith
@@ -73,6 +74,15 @@ class DefaultInvokerServerTests
       status should be(OK)
       reactive.enableCount shouldBe 0
       reactive.disableCount shouldBe 1
+    }
+  }
+
+  it should "check if invoker is enabled" in {
+    implicit val tid = transid()
+    val validCredentials = BasicHttpCredentials(systemUsername, systemPassword)
+    Get(s"/isEnabled") ~> addCredentials(validCredentials) ~> Route.seal(server.routes(tid)) ~> check {
+      status should be(OK)
+      InvokerEnabled.parseJson(responseEntity.toString) shouldEqual InvokerEnabled(true)
     }
   }
 
@@ -131,7 +141,7 @@ class TestInvokerReactive extends InvokerCore with BasicHttpService {
   }
 
   override def isEnabled(): Route = {
-    complete("")
+    complete(InvokerEnabled(true).serialize())
   }
 
   override def backfillPrewarm(): Route = {

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/DefaultInvokerServerTests.scala
@@ -130,6 +130,10 @@ class TestInvokerReactive extends InvokerCore with BasicHttpService {
     complete("")
   }
 
+  override def isEnabled(): Route = {
+    complete("")
+  }
+
   override def backfillPrewarm(): Route = {
     complete("")
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/FPCInvokerServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/FPCInvokerServerTests.scala
@@ -129,6 +129,10 @@ class TestFPCInvokerReactive extends InvokerCore with BasicHttpService {
     complete("")
   }
 
+  override def isEnabled(): Route = {
+    complete("")
+  }
+
   override def backfillPrewarm(): Route = {
     complete("")
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/FPCInvokerServerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/FPCInvokerServerTests.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.StatusCodes.{OK, Unauthorized}
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import common.StreamLogging
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
@@ -82,7 +83,9 @@ class FPCInvokerServerTests
     val validCredentials = BasicHttpCredentials(systemUsername, systemPassword)
     Get(s"/isEnabled") ~> addCredentials(validCredentials) ~> Route.seal(server.routes(tid)) ~> check {
       status should be(OK)
-      InvokerEnabled.parseJson(responseEntity.toString) shouldEqual InvokerEnabled(true)
+      Unmarshal(responseEntity).to[String].map(response => {
+        InvokerEnabled.parseJson(response) shouldEqual InvokerEnabled(true)
+      })
     }
   }
 


### PR DESCRIPTION
add enable/disable invoker support to old scheduler

## Description
Adds enable / disabling of original invoker implementation. Disabling will turn off the scheduler of health pings so the controller will view the invoker as offline. Enabling will reschedule the health pings if it was disabled. Also added a route for both invoker types to check if an invoker is disabled so that the state of a running invoker does not get lost.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components

- [ ] API
- [x] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [X] My changes require further changes to the documentation.
- [X] I updated the documentation where necessary.

