### PR TITLE
Adjust the keeping duration.

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -155,7 +155,7 @@ whisk {
       #aka 'How long should a container sit idle until we kill it?'
       idle-container = 10 minutes
       pause-grace = 50 milliseconds
-      keeping-duration = 60 minutes
+      keeping-duration = 1 second
     }
     action-health-check {
       enabled = false # if true, prewarm containers will be pinged periodically and warm containers will be pinged once after resumed


### PR DESCRIPTION
## Description
This is to reduce the keeping duration.
In FPCScheduler, this value is used to decide how much time do we keep the warmed container.
Currently, it is 60 minutes and it means after a timeout of paused container(10mins), it will keep the last container for another 60 minutes.
I think this is not a good value for the default.
In many cases that people develop or test OpenWhisk, there would be fewer resources in their dev environment and this would cause out of resources easily.


## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

