### PR TITLE
Replace kafka.RecordMetadata with a common ResultMetadata

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -48,6 +48,8 @@ trait Message {
   override def toString = serialize
 }
 
+case class ResultMetadata(topic: String, partition: Int, offset: Long)
+
 case class ActivationMessage(override val transid: TransactionId,
                              action: FullyQualifiedEntityName,
                              revision: DocRevision,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/MessageProducer.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/MessageProducer.scala
@@ -19,15 +19,13 @@ package org.apache.openwhisk.core.connector
 
 import scala.concurrent.Future
 
-import org.apache.kafka.clients.producer.RecordMetadata
-
 trait MessageProducer {
 
   /** Count of messages sent. */
   def sentCount(): Long
 
   /** Sends msg to topic. This is an asynchronous operation. */
-  def send(topic: String, msg: Message, retry: Int = 0): Future[RecordMetadata]
+  def send(topic: String, msg: Message, retry: Int = 0): Future[ResultMetadata]
 
   /** Closes producer. */
   def close(): Unit

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/CommonLoadBalancer.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.LongAdder
 
 import akka.actor.ActorSystem
 import akka.event.Logging.InfoLevel
-import org.apache.kafka.clients.producer.RecordMetadata
 import pureconfig._
 import pureconfig.generic.auto._
 import org.apache.openwhisk.common.LoggingMarkers._
@@ -189,7 +188,7 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
   /** 3. Send the activation to the invoker */
   protected def sendActivationToInvoker(producer: MessageProducer,
                                         msg: ActivationMessage,
-                                        invoker: InvokerInstanceId): Future[RecordMetadata] = {
+                                        invoker: InvokerInstanceId): Future[ResultMetadata] = {
     implicit val transid: TransactionId = msg.transid
 
     val topic = s"${Controller.topicPrefix}invoker${invoker.toInt}"
@@ -206,7 +205,7 @@ abstract class CommonLoadBalancer(config: WhiskConfig,
         transid.finished(
           this,
           start,
-          s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]",
+          s"posted to ${status.topic}[${status.partition}][${status.offset}]",
           logLevel = InfoLevel)
       case Failure(_) => transid.failed(this, start, s"error on posting to topic $topic")
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -8,7 +8,6 @@ import akka.actor.{Actor, ActorRef, ActorRefFactory, ActorSystem, Cancellable, P
 import akka.event.Logging.InfoLevel
 import akka.pattern.ask
 import akka.util.Timeout
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy}
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector._
@@ -250,7 +249,7 @@ class FPCPoolBalancer(config: WhiskConfig,
   /** 3. Send the activation to the kafka */
   private def sendActivationToKafka(producer: MessageProducer,
                                     msg: ActivationMessage,
-                                    topic: String): Future[RecordMetadata] = {
+                                    topic: String): Future[ResultMetadata] = {
     implicit val transid: TransactionId = msg.transid
 
     MetricEmitter.emitCounterMetric(LoggingMarkers.LOADBALANCER_ACTIVATION_START)
@@ -261,7 +260,7 @@ class FPCPoolBalancer(config: WhiskConfig,
         transid.finished(
           this,
           start,
-          s"posted to ${status.topic()}[${status.partition()}][${status.offset()}]",
+          s"posted to ${status.topic}[${status.partition}][${status.offset}]",
           logLevel = InfoLevel)
       case Failure(_) => transid.failed(this, start, s"error on posting to topic $topic")
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerPoolFactory.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/InvokerPoolFactory.scala
@@ -18,11 +18,9 @@
 package org.apache.openwhisk.core.loadBalancer
 import akka.actor.ActorRef
 import akka.actor.ActorRefFactory
-import org.apache.kafka.clients.producer.RecordMetadata
-import org.apache.openwhisk.core.connector.ActivationMessage
-import org.apache.openwhisk.core.connector.MessageProducer
-import org.apache.openwhisk.core.connector.MessagingProvider
+import org.apache.openwhisk.core.connector.{ActivationMessage, MessageProducer, MessagingProvider, ResultMetadata}
 import org.apache.openwhisk.core.entity.InvokerInstanceId
+
 import scala.concurrent.Future
 
 trait InvokerPoolFactory {
@@ -30,6 +28,6 @@ trait InvokerPoolFactory {
     actorRefFactory: ActorRefFactory,
     messagingProvider: MessagingProvider,
     messagingProducer: MessageProducer,
-    sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
+    sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[ResultMetadata],
     monitor: Option[ActorRef]): ActorRef
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/ShardingContainerPoolBalancer.scala
@@ -26,7 +26,6 @@ import akka.cluster.ClusterEvent._
 import akka.cluster.{Cluster, Member, MemberStatus}
 import akka.management.scaladsl.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy, Unresponsive}
 import pureconfig._
 import pureconfig.generic.auto._
@@ -340,7 +339,7 @@ object ShardingContainerPoolBalancer extends LoadBalancerProvider {
         actorRefFactory: ActorRefFactory,
         messagingProvider: MessagingProvider,
         messagingProducer: MessageProducer,
-        sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
+        sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[ResultMetadata],
         monitor: Option[ActorRef]): ActorRef = {
 
         InvokerPool.prepare(instance, WhiskEntityStore.datastore())

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
@@ -18,15 +18,15 @@
 package org.apache.openwhisk.core.containerpool.v2
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Cancellable, Props}
-import org.apache.kafka.clients.producer.RecordMetadata
+
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector.ContainerCreationError._
 import org.apache.openwhisk.core.connector.{
   ContainerCreationAckMessage,
   ContainerCreationMessage,
-  ContainerDeletionMessage
+  ContainerDeletionMessage,
+  ResultMetadata
 }
 import org.apache.openwhisk.core.containerpool.{
   AdjustPrewarmedContainer,
@@ -81,7 +81,7 @@ class FunctionPullingContainerPool(
   poolConfig: ContainerPoolConfig,
   instance: InvokerInstanceId,
   prewarmConfig: List[PrewarmingConfig] = List.empty,
-  sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[RecordMetadata])(
+  sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[ResultMetadata])(
   implicit val logging: Logging)
     extends Actor {
   import ContainerPoolV2.memoryConsumptionOf
@@ -841,7 +841,7 @@ object ContainerPoolV2 {
             poolConfig: ContainerPoolConfig,
             instance: InvokerInstanceId,
             prewarmConfig: List[PrewarmingConfig] = List.empty,
-            sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[RecordMetadata])(
+            sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[ResultMetadata])(
     implicit logging: Logging): Props = {
     Props(
       new FunctionPullingContainerPool(

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/ContainerMessageConsumer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/ContainerMessageConsumer.scala
@@ -20,7 +20,6 @@ package org.apache.openwhisk.core.invoker
 import java.nio.charset.StandardCharsets
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.{GracefulShutdown, Logging, TransactionId}
 import org.apache.openwhisk.core.WarmUp.isWarmUpAction
 import org.apache.openwhisk.core.WhiskConfig
@@ -48,7 +47,7 @@ class ContainerMessageConsumer(
   msgProvider: MessagingProvider,
   longPollDuration: FiniteDuration,
   maxPeek: Int,
-  sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[RecordMetadata])(
+  sendAckToScheduler: (SchedulerInstanceId, ContainerCreationAckMessage) => Future[ResultMetadata])(
   implicit actorSystem: ActorSystem,
   executionContext: ExecutionContext,
   logging: Logging) {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.server.Route
 import com.ibm.etcd.api.Event.EventType
 import com.ibm.etcd.client.kv.KvClient.Watch
 import com.ibm.etcd.client.kv.WatchUpdate
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.ack.{ActiveAck, HealthActionAck, MessagingActiveAck, UserEventSender}
 import org.apache.openwhisk.core.connector._
@@ -267,7 +266,7 @@ class FPCInvokerReactive(config: WhiskConfig,
   }
 
   private def sendAckToScheduler(schedulerInstanceId: SchedulerInstanceId,
-                                 creationAckMessage: ContainerCreationAckMessage): Future[RecordMetadata] = {
+                                 creationAckMessage: ContainerCreationAckMessage): Future[ResultMetadata] = {
     val topic = s"${Invoker.topicPrefix}creationAck${schedulerInstanceId.asString}"
     val reschedulable =
       creationAckMessage.error.map(ContainerCreationError.whiskErrors.contains(_)).getOrElse(false)

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/container/ContainerManager.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/container/ContainerManager.scala
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.ThreadLocalRandom
 import akka.actor.{Actor, ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.event.Logging.InfoLevel
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy}
 import org.apache.openwhisk.common.{GracefulShutdown, InvokerHealth, Logging, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.connector.ContainerCreationError.{
@@ -275,7 +274,7 @@ class ContainerManager(jobManagerFactory: ActorRefFactory => ActorRef,
 
   private def sendCreationContainerToInvoker(producer: MessageProducer,
                                              invoker: Int,
-                                             msg: ContainerCreationMessage): Future[RecordMetadata] = {
+                                             msg: ContainerCreationMessage): Future[ResultMetadata] = {
     implicit val transid: TransactionId = msg.transid
 
     val topic = s"${Scheduler.topicPrefix}invoker$invoker"
@@ -286,8 +285,7 @@ class ContainerManager(jobManagerFactory: ActorRefFactory => ActorRef,
         transid.finished(
           this,
           start,
-          s"posted creationId: ${msg.creationId} for ${msg.invocationNamespace}/${msg.action} to ${status
-            .topic()}[${status.partition()}][${status.offset()}]",
+          s"posted creationId: ${msg.creationId} for ${msg.invocationNamespace}/${msg.action} to ${status.topic}[${status.partition}][${status.offset}]",
           logLevel = InfoLevel)
       case Failure(_) =>
         logging.error(this, s"Failed to create container for ${msg.action}, error: error on posting to topic $topic")
@@ -297,7 +295,7 @@ class ContainerManager(jobManagerFactory: ActorRefFactory => ActorRef,
 
   private def sendDeletionContainerToInvoker(producer: MessageProducer,
                                              invoker: Int,
-                                             msg: ContainerDeletionMessage): Future[RecordMetadata] = {
+                                             msg: ContainerDeletionMessage): Future[ResultMetadata] = {
     implicit val transid: TransactionId = msg.transid
 
     val topic = s"${Scheduler.topicPrefix}invoker$invoker"
@@ -308,8 +306,7 @@ class ContainerManager(jobManagerFactory: ActorRefFactory => ActorRef,
         transid.finished(
           this,
           start,
-          s"posted deletion for ${msg.invocationNamespace}/${msg.action} to ${status
-            .topic()}[${status.partition()}][${status.offset()}]",
+          s"posted deletion for ${msg.invocationNamespace}/${msg.action} to ${status.topic}[${status.partition}][${status.offset}]",
           logLevel = InfoLevel)
       case Failure(_) =>
         logging.error(this, s"Failed to delete container for ${msg.action}, error: error on posting to topic $topic")

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/test/TestConnector.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/test/TestConnector.scala
@@ -19,19 +19,12 @@ package org.apache.openwhisk.core.connector.test
 
 import java.util.ArrayList
 import java.util.concurrent.LinkedBlockingQueue
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
-
-import org.apache.kafka.clients.producer.RecordMetadata
-import org.apache.kafka.common.TopicPartition
 import common.StreamLogging
-
 import org.apache.openwhisk.common.Counter
-import org.apache.openwhisk.core.connector.Message
-import org.apache.openwhisk.core.connector.MessageConsumer
-import org.apache.openwhisk.core.connector.MessageProducer
+import org.apache.openwhisk.core.connector.{Message, MessageConsumer, MessageProducer, ResultMetadata}
 
 class TestConnector(topic: String, override val maxPeek: Int, allowMoreThanMax: Boolean)
     extends MessageConsumer
@@ -58,11 +51,11 @@ class TestConnector(topic: String, override val maxPeek: Int, allowMoreThanMax: 
 
   def occupancy = queue.size
 
-  def send(msg: Message): Future[RecordMetadata] = {
+  def send(msg: Message): Future[ResultMetadata] = {
     producer.send(topic, msg)
   }
 
-  def send(msgs: Seq[Message]): Future[RecordMetadata] = {
+  def send(msgs: Seq[Message]): Future[ResultMetadata] = {
     import scala.language.reflectiveCalls
     producer.sendBulk(topic, msgs)
   }
@@ -75,11 +68,11 @@ class TestConnector(topic: String, override val maxPeek: Int, allowMoreThanMax: 
   def getProducer(): MessageProducer = producer
 
   private val producer = new MessageProducer {
-    def send(topic: String, msg: Message, retry: Int = 0): Future[RecordMetadata] = {
+    def send(topic: String, msg: Message, retry: Int = 0): Future[ResultMetadata] = {
       queue.synchronized {
         if (queue.offer(msg)) {
           logging.info(this, s"put: $msg")
-          Future.successful(new RecordMetadata(new TopicPartition(topic, 0), 0, queue.size, -1, Long.box(-1L), -1, -1))
+          Future.successful(ResultMetadata(topic, 0, queue.size()))
         } else {
           logging.error(this, s"put failed: $msg")
           Future.failed(new IllegalStateException("failed to write msg"))
@@ -87,11 +80,11 @@ class TestConnector(topic: String, override val maxPeek: Int, allowMoreThanMax: 
       }
     }
 
-    def sendBulk(topic: String, msgs: Seq[Message]): Future[RecordMetadata] = {
+    def sendBulk(topic: String, msgs: Seq[Message]): Future[ResultMetadata] = {
       queue.synchronized {
         if (queue.addAll(msgs.asJava)) {
           logging.info(this, s"put: ${msgs.length} messages")
-          Future.successful(new RecordMetadata(new TopicPartition(topic, 0), 0, queue.size, -1, Long.box(-1L), -1, -1))
+          Future.successful(ResultMetadata(topic, 0, queue.size()))
         } else {
           logging.error(this, s"put failed: ${msgs.length} messages")
           Future.failed(new IllegalStateException("failed to write msg"))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerPoolTests.scala
@@ -19,11 +19,9 @@ package org.apache.openwhisk.core.containerpool.v2.test
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
 import common.StreamLogging
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.{Enable, GracefulShutdown, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.connector.ContainerCreationError._
@@ -32,7 +30,8 @@ import org.apache.openwhisk.core.connector.{
   ContainerCreationAckMessage,
   ContainerCreationError,
   ContainerCreationMessage,
-  MessageProducer
+  MessageProducer,
+  ResultMetadata
 }
 import org.apache.openwhisk.core.containerpool.docker.DockerContainer
 import org.apache.openwhisk.core.containerpool.v2._
@@ -196,7 +195,7 @@ class FunctionPullingContainerPoolTests
       prewarmContainerCreationConfig)
 
   def sendAckToScheduler(producer: MessageProducer)(schedulerInstanceId: SchedulerInstanceId,
-                                                    ackMessage: ContainerCreationAckMessage): Future[RecordMetadata] = {
+                                                    ackMessage: ContainerCreationAckMessage): Future[ResultMetadata] = {
     val topic = s"creationAck${schedulerInstanceId.asString}"
     producer.send(topic, ackMessage)
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/ContainerMessageConsumerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/ContainerMessageConsumerTests.scala
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import common.StreamLogging
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.openwhisk.common.{Logging, TransactionId}
 import org.apache.openwhisk.core.{WarmUp, WhiskConfig}
 import org.apache.openwhisk.core.connector.ContainerCreationError._
@@ -115,7 +114,7 @@ class ContainerMessageConsumerTests
   }
 
   def sendAckToScheduler(producer: MessageProducer)(schedulerInstanceId: SchedulerInstanceId,
-                                                    ackMessage: ContainerCreationAckMessage): Future[RecordMetadata] = {
+                                                    ackMessage: ContainerCreationAckMessage): Future[ResultMetadata] = {
     val topic = s"creationAck${schedulerInstanceId.asString}"
     producer.send(topic, ackMessage)
   }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.Future
-import org.apache.kafka.common.TopicPartition
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/InvokerSupervisionTests.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.Future
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory
@@ -46,8 +45,7 @@ import common.{LoggedFunction, StreamLogging}
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy, Unresponsive}
 import org.apache.openwhisk.common.{InvokerHealth, InvokerState, TransactionId}
 import org.apache.openwhisk.core.WhiskConfig
-import org.apache.openwhisk.core.connector.ActivationMessage
-import org.apache.openwhisk.core.connector.PingMessage
+import org.apache.openwhisk.core.connector.{ActivationMessage, PingMessage, ResultMetadata}
 import org.apache.openwhisk.core.entity.ActivationId.ActivationIdGenerator
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
@@ -108,7 +106,7 @@ class InvokerSupervisionTests
     val children = mutable.Queue(invoker5.ref, invoker2.ref)
     val childFactory = (f: ActorRefFactory, instance: InvokerInstanceId) => children.dequeue()
 
-    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[RecordMetadata]]
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[ResultMetadata]]
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
     within(timeout.duration) {
@@ -147,7 +145,7 @@ class InvokerSupervisionTests
     val invokerInstance = InvokerInstanceId(0, userMemory = defaultUserMemory)
     val invokerName = s"invoker${invokerInstance.toInt}"
     val childFactory = (f: ActorRefFactory, instance: InvokerInstanceId) => invoker.ref
-    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[RecordMetadata]]
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[ResultMetadata]]
 
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
@@ -174,7 +172,7 @@ class InvokerSupervisionTests
     val childFactory = (f: ActorRefFactory, instance: InvokerInstanceId) => invoker.ref
 
     val sendActivationToInvoker = LoggedFunction { (a: ActivationMessage, b: InvokerInstanceId) =>
-      Future.successful(new RecordMetadata(new TopicPartition(invokerName, 0), 0L, 0L, 0L, Long.box(0L), 0, 0))
+      Future.successful(ResultMetadata(invokerName, 0, 0))
     }
 
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
@@ -421,7 +419,7 @@ class InvokerSupervisionTests
     val children = mutable.Queue(invoker0.ref)
     val childFactory = (f: ActorRefFactory, instance: InvokerInstanceId) => children.dequeue()
 
-    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[RecordMetadata]]
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[ResultMetadata]]
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
     val invokerInstance = InvokerInstanceId(0, Some("10.x.x.x"), Some("invoker-xyz"), userMemory = defaultUserMemory)
@@ -444,7 +442,7 @@ class InvokerSupervisionTests
     val children = mutable.Queue(invoker0.ref)
     val childFactory = (f: ActorRefFactory, instance: InvokerInstanceId) => children.dequeue()
 
-    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[RecordMetadata]]
+    val sendActivationToInvoker = stubFunction[ActivationMessage, InvokerInstanceId, Future[ResultMetadata]]
     val supervisor = system.actorOf(InvokerPool.props(childFactory, sendActivationToInvoker, pC))
 
     val invokerInstance = InvokerInstanceId(0, Some("10.x.x.x"), Some("invoker-xyz"), userMemory = defaultUserMemory)

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -22,9 +22,8 @@ import akka.actor.ActorRefFactory
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import common.{StreamLogging, WhiskProperties}
-import java.nio.charset.StandardCharsets
 
-import org.apache.kafka.clients.producer.RecordMetadata
+import java.nio.charset.StandardCharsets
 import org.apache.kafka.common.TopicPartition
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy}
 import org.junit.runner.RunWith
@@ -39,12 +38,15 @@ import scala.concurrent.duration._
 import org.apache.openwhisk.common.{InvokerHealth, Logging, NestedSemaphore, TransactionId}
 import org.apache.openwhisk.core.entity.FullyQualifiedEntityName
 import org.apache.openwhisk.core.WhiskConfig
-import org.apache.openwhisk.core.connector.ActivationMessage
-import org.apache.openwhisk.core.connector.CompletionMessage
-import org.apache.openwhisk.core.connector.Message
-import org.apache.openwhisk.core.connector.MessageConsumer
-import org.apache.openwhisk.core.connector.MessageProducer
-import org.apache.openwhisk.core.connector.MessagingProvider
+import org.apache.openwhisk.core.connector.{
+  ActivationMessage,
+  CompletionMessage,
+  Message,
+  MessageConsumer,
+  MessageProducer,
+  MessagingProvider,
+  ResultMetadata
+}
 import org.apache.openwhisk.core.entity.ActivationId
 import org.apache.openwhisk.core.entity.BasicAuthenticationAuthKey
 import org.apache.openwhisk.core.entity.ControllerInstanceId
@@ -455,7 +457,7 @@ class ShardingContainerPoolBalancerTests
     (producer
       .send(_: String, _: Message, _: Int))
       .when(*, *, *)
-      .returns(Future.successful(new RecordMetadata(new TopicPartition("fake", 0), 0, 0, 0l, 0l, 0, 0)))
+      .returns(Future.successful(ResultMetadata("fake", 0, 0)))
 
     messaging
   }
@@ -472,7 +474,7 @@ class ShardingContainerPoolBalancerTests
         actorRefFactory: ActorRefFactory,
         messagingProvider: MessagingProvider,
         messagingProducer: MessageProducer,
-        sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[RecordMetadata],
+        sendActivationToInvoker: (MessageProducer, ActivationMessage, InvokerInstanceId) => Future[ResultMetadata],
         monitor: Option[ActorRef]): ActorRef =
         TestProbe().testActor
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/loadBalancer/test/ShardingContainerPoolBalancerTests.scala
@@ -24,7 +24,6 @@ import akka.testkit.TestProbe
 import common.{StreamLogging, WhiskProperties}
 
 import java.nio.charset.StandardCharsets
-import org.apache.kafka.common.TopicPartition
 import org.apache.openwhisk.common.InvokerState.{Healthy, Offline, Unhealthy}
 import org.junit.runner.RunWith
 import org.scalamock.scalatest.MockFactory

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
@@ -22,7 +22,6 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.ibm.etcd.api.{KeyValue, RangeResponse}
 import common.{StreamLogging, WskActorSystem}
-import org.apache.kafka.common.TopicPartition
 import org.apache.openwhisk.common.InvokerState.{Healthy, Unhealthy}
 import org.apache.openwhisk.common.{GracefulShutdown, InvokerHealth, Logging, TransactionId}
 import org.apache.openwhisk.core.connector.ContainerCreationError.{

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
@@ -22,7 +22,6 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.ibm.etcd.api.{KeyValue, RangeResponse}
 import common.{StreamLogging, WskActorSystem}
-import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.openwhisk.common.InvokerState.{Healthy, Unhealthy}
 import org.apache.openwhisk.common.{GracefulShutdown, InvokerHealth, Logging, TransactionId}
@@ -150,7 +149,7 @@ class ContainerManagerTests
       (producer
         .send(_: String, _: Message, _: Int))
         .when(*, *, *)
-        .returns(Future.successful(new RecordMetadata(new TopicPartition("fake", 0), 0, 0, 0l, 0l, 0, 0)))
+        .returns(Future.successful(ResultMetadata("fake", 0, 0)))
     }
 
     messaging
@@ -162,12 +161,11 @@ class ContainerManagerTests
     override def sentCount(): Long = 0
 
     /** Sends msg to topic. This is an asynchronous operation. */
-    override def send(topic: String, msg: Message, retry: Int): Future[RecordMetadata] = {
+    override def send(topic: String, msg: Message, retry: Int): Future[ResultMetadata] = {
       val message = s"$topic-$msg"
       receiver ! message
 
-      Future.successful(
-        new RecordMetadata(new TopicPartition(topic, 0), -1, -1, System.currentTimeMillis(), null, -1, -1))
+      Future.successful(ResultMetadata(topic, 0, -1))
     }
 
     /** Closes producer. */

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTestsFixture.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTestsFixture.scala
@@ -1,7 +1,6 @@
 package org.apache.openwhisk.core.scheduler.queue.test
 
 import java.time.Instant
-
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import com.sksamuel.elastic4s.http
@@ -10,13 +9,17 @@ import com.sksamuel.elastic4s.http._
 import com.sksamuel.elastic4s.http.search.{SearchHits, SearchResponse}
 import com.sksamuel.elastic4s.searches.SearchRequest
 import common.StreamLogging
-import org.apache.kafka.clients.producer.RecordMetadata
-import org.apache.kafka.common.TopicPartition
 import org.apache.openwhisk.common.TransactionId
 import org.apache.openwhisk.common.WhiskInstants.InstantImplicits
 import org.apache.openwhisk.core.WhiskConfig
 import org.apache.openwhisk.core.ack.ActiveAck
-import org.apache.openwhisk.core.connector.{AcknowledegmentMessage, ActivationMessage, Message, MessageProducer}
+import org.apache.openwhisk.core.connector.{
+  AcknowledegmentMessage,
+  ActivationMessage,
+  Message,
+  MessageProducer,
+  ResultMetadata
+}
 import org.apache.openwhisk.core.database.UserContext
 import org.apache.openwhisk.core.database.elasticsearch.ElasticSearchActivationStore.generateIndex
 import org.apache.openwhisk.core.entity.ExecManifest.{ImageName, RuntimeManifest}
@@ -188,11 +191,10 @@ class MemoryQueueTestsFixture
     override def sentCount(): Long = 0
 
     /** Sends msg to topic. This is an asynchronous operation. */
-    override def send(topic: String, msg: Message, retry: Int): Future[RecordMetadata] = {
+    override def send(topic: String, msg: Message, retry: Int): Future[ResultMetadata] = {
       receiver ! s"$topic-${msg}"
 
-      Future.successful(
-        new RecordMetadata(new TopicPartition(topic, 0), -1, -1, System.currentTimeMillis(), null, -1, -1))
+      Future.successful(ResultMetadata(topic, 0, -1))
     }
 
     /** Closes producer. */


### PR DESCRIPTION
Replace `RecordMetadata` with `ResultMetadata`

## Description
Replace `RecordMetadata` with `ResultMetadata` to make `MessageProducer` independent of kafka
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

