### PR TITLE
Change the value of pause-grace for new scheduler

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -177,6 +177,23 @@ whisk.spi {
 .
 .
 ```
+#### Configure pause grace for the scheduler
+Set the value of pause-grace to 10s by default
+
+**core/invoker/src/main/resources/application.conf**
+```
+  container-proxy {
+    timeouts {
+      # The "unusedTimeout" in the ContainerProxy,
+      #aka 'How long should a container sit idle until we kill it?'
+      idle-container = 10 minutes
+      pause-grace = 10 seconds
+      keeping-duration = 10 minutes
+    }
+  .
+  .
+  .
+```
 
 #### Enable the scheduler
 - Make sure you enable the scheduler by configuring `scheduler_enable`.

--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -155,7 +155,7 @@ whisk {
       # The "unusedTimeout" in the ContainerProxy,
       #aka 'How long should a container sit idle until we kill it?'
       idle-container = 10 minutes
-      pause-grace = 50 milliseconds
+      pause-grace = 10 seconds
       keeping-duration = 10 minutes
     }
     action-health-check {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
The default value of pause-grace, which is 50 milliseconds by default, is too short for FPCScheduler. If requests' time intervals are longer than 50ms, the container will be paused and can't pull requests from MemoryQueue, doesn't take advantage of the ActivationProxy-ActivationService path, which is the core of FPCScheduler design. So we need to set the pause-grace to a longer value, 10s by default now.
## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
To prove this, I did a test for FPCScheduler. I sent 5 concurrent requests every 5 seconds, the second 5 requests would be successfully picked up by GetActivaion in MemoryQueue. But for subsequent concurrent requests, the SchedulingDecisionMaker would keep matching an exceptional case:
```
  // this is an exceptional case, create a container immediately
  case (Running, _) if totalContainers == 0 && availableMsg > 0 =>
    logging.info(
      this,
      s"add one container if totalContainers($totalContainers) == 0 && availableMsg($availableMsg) > 0 [$invocationNamespace:$action]")
    Future.successful(DecisionResults(AddContainer, 1))
```
It was because MemoryQueue told him that there were no warm containers, but actually, there were some containers already spawned for previous requests, just in paused state, and couldn't pull requests temporarily. And then SchedulingDecisonMaker tried to send container creation message to the invoker, invoker didn't create any container because there are already some warm containers, causing some latencies.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [x] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [x] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [N/A] I added tests to cover my changes.
- [N/A] My changes require further changes to the documentation.
- [x] I updated the documentation where necessary.

