### PR TITLE
add zookeeper storage prefixing to support multi-cluster

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -128,6 +128,10 @@ whisk {
         logs-enabled       = ${?METRICS_LOG}
     }
 
+    zookeeper {
+        prefix = ""
+    }
+
     # kafka related configuration, the complete list of parameters is here:
     # https://kafka.apache.org/documentation/#brokerconfigs
     kafka {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -216,6 +216,7 @@ object ConfigKeys {
   val kafkaTopics = s"$kafka.topics"
   val kafkaTopicsPrefix = s"$kafkaTopics.prefix"
   val kafkaTopicsUserEventPrefix = s"$kafkaTopics.user-event.prefix"
+  val zookeeperStoragePrefix = s"zookeeper.prefix"
 
   val memory = "whisk.memory"
   val timeLimit = "whisk.time-limit"


### PR DESCRIPTION
## Description
Similar to the recent kafka topic prefixing addition, we would like to be able to use the same zookeeper cluster for multiple openwhisk clusters without having the potential for invoker id clashes.

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

