### PR TITLE
add per min throttling support to fpc

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -203,6 +203,7 @@ object WhiskConfig {
 object ConfigKeys {
   val cluster = "whisk.cluster"
   val loadbalancer = "whisk.loadbalancer"
+  val fpcLoadBalancer = "whisk.loadbalancer.fpc"
   val fraction = "whisk.fraction"
   val buildInformation = "whisk.info"
 

--- a/core/controller/src/main/resources/reference.conf
+++ b/core/controller/src/main/resources/reference.conf
@@ -29,6 +29,10 @@ whisk {
     # extra time to increase the timeout for forced active acks
     # default is 1.minute
     timeout-addon = 1m
+
+    fpc {
+      use-perMin-throttles = false
+    }
   }
   controller {
     protocol: http

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/Entitlement.scala
@@ -360,7 +360,7 @@ protected[core] abstract class EntitlementProvider(
    * @param resources the set of resources must contain at least one resource that can be activated else return None
    * @return future completing successfully if user is below limits else failing with a rejection
    */
-  private def checkUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
+  protected[core] def checkUserThrottle(user: Identity, right: Privilege, resources: Set[Resource])(
     implicit transid: TransactionId): Future[Unit] = {
     if (right == ACTIVATE) {
       if (resources.exists(_.collection.path == Collection.ACTIONS)) {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -34,6 +34,8 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Pro
 import scala.language.postfixOps
 import scala.util.{Failure, Random, Success, Try}
 
+case class FPCPoolBalancerConfig(usePerMinThrottle: Boolean)
+
 class FPCPoolBalancer(config: WhiskConfig,
                       controllerInstance: ControllerInstanceId,
                       etcdClient: EtcdClient,


### PR DESCRIPTION
## Description
Could use some help verifying this actually works as I'm not totally familiar with the entitlement code path, but I'm pretty sure I have what is needed here since the `FPCEntitlementProvider` just extends from the original overriding the `checkThrottles`.

So FPC currently doesn't support per minute throttling of namespaces. While the system no longer needs these throttles to protect itself with the new fpc scheduler enhancement, it is still a valuable feature to allow for user functions to protect their downstream by having reasonable per minute limits. And it's just a feature that I think is unnecessarily lost if still needed for certain use cases. Ideally people can slowly move away from using this feature, but having the option at least available makes it easier for people to more quickly migrate to fpc from their existing cluster that might be dependent on it.

Since the contributors of FPC to the open source repository do not use the feature, I've set the default config value to not include the per minute throttling. I personally think the default should probably be to have it still turned on right now, but I will let them decide on that. 
## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

