### PR TITLE
update action container metrics subactions to action instead of names…

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -377,14 +377,14 @@ object LoggingMarkers {
       scheduler,
       "actionContainer",
       counter,
-      Some(namespace),
+      Some(action),
       Map("namespace" -> namespace, "action" -> action))(MeasurementUnit.none)
   def SCHEDULER_ACTION_INPROGRESS_CONTAINER(namespace: String, action: String) =
     LogMarkerToken(
       scheduler,
       "actionInProgressContainer",
       counter,
-      Some(namespace),
+      Some(action),
       Map("namespace" -> namespace, "action" -> action))(MeasurementUnit.none)
 
   /*


### PR DESCRIPTION
## Description
I believe that the subaction for these two metrics should be the action instead of the namespace since there is a separate container metric for namespaces called `namespaceContainer` where the namespace is the subaction. This is needed for statsd agent that doesn't support kamon tagging to track action container counts.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

