### PR TITLE
rework scheduler wait time metric to include total time in scheduler

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -591,8 +591,9 @@ object LoggingMarkers {
 
   // Time that is needed to produce message in kafka
   val SCHEDULER_KAFKA = LogMarkerToken(scheduler, kafka, start)(MeasurementUnit.time.milliseconds)
-  val SCHEDULER_WAIT_TIME =
-    LogMarkerToken(scheduler, "waitTime", counter)(MeasurementUnit.none)
+  val SCHEDULER_KAFKA_WAIT_TIME =
+    LogMarkerToken(scheduler, "kafkaWaitTime", counter)(MeasurementUnit.none)
+  def SCHEDULER_WAIT_TIME(action: String) = LogMarkerToken(scheduler, "waitTime", counter, Some(action), Map("action" -> action))(MeasurementUnit.none)
 
   def SCHEDULER_KEEP_ALIVE(leaseId: Long) =
     LogMarkerToken(scheduler, "keepAlive", counter, None, Map("leaseId" -> leaseId.toString))(MeasurementUnit.none)
@@ -603,6 +604,7 @@ object LoggingMarkers {
     LogMarkerToken(scheduler, "queueUpdate", counter, None, Map("reason" -> reason))(MeasurementUnit.none)
   def SCHEDULER_QUEUE_WAITING_ACTIVATION(action: String) =
     LogMarkerToken(scheduler, "queueActivation", counter, Some(action), Map("action" -> action))(MeasurementUnit.none)
+
   /*
    * General markers
    */

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/QueueManager.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/QueueManager.scala
@@ -391,7 +391,7 @@ class QueueManager(
 
     // Drop the message that has not been scheduled for a long time
     val schedulingWaitTime = Interval(msg.transid.meta.start, Instant.now()).duration
-    MetricEmitter.emitHistogramMetric(LoggingMarkers.SCHEDULER_WAIT_TIME, schedulingWaitTime.toMillis)
+    MetricEmitter.emitHistogramMetric(LoggingMarkers.SCHEDULER_KAFKA_WAIT_TIME, schedulingWaitTime.toMillis)
 
     if (schedulingWaitTime > queueManagerConfig.maxSchedulingTime) {
       logging.warn(


### PR DESCRIPTION
## Description
The current scheduler wait time metric emits as soon as the queue manager receives an activation. From this point it's then put on to the respective action queue in which it may wait for variable amounts of time until the activation is retrieved by an action container from the queue. The existing wait time metric still exists but is renamed to `kafkaWaitTime` since it's essentially the wait time from when the transaction starts to when it gets to the scheduler. The new version of `waitTime` metric emits for an action whenever the action either is force error completed within the memory queue or when the activation is forwarded to an action container and removed from the scheduler queue.

## Related issue and scope
N/A

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

