### PR TITLE
[Scheduler Enhancement] Consider binding action when creating or recovering queue.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/service/WatcherService.scala
@@ -128,6 +128,7 @@ class WatcherService(etcdClient: EtcdClient)(implicit logging: Logging, actorSys
           deleteWatchers.update(watcherKey, sender())
 
     case request: UnwatchEndpoint =>
+      logging.info(this, s"unwatch endpoint: $request")
       val watcherKey = WatcherKey(request.watchKey, request.watchName)
       if (request.isPrefix) {
         prefixPutWatchers.remove(watcherKey)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -174,7 +174,7 @@ class FPCPoolBalancer(config: WhiskConfig,
     if (retryCount >= 0)
       scheduler
         .getRemoteRef(QueueManager.actorName)
-        .ask(CreateQueue(invocationNamespace, fullyQualifiedEntityName.copy(binding = None), revision, actionMetaData))
+        .ask(CreateQueue(invocationNamespace, fullyQualifiedEntityName, revision, actionMetaData))
         .mapTo[CreateQueueResponse]
         .onComplete {
           case Success(_) =>

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
@@ -680,7 +680,13 @@ class FunctionPullingContainerPool(
       case Some(((proxy, data), containerState)) =>
         // record creationMessage so when container created failed, we can send failed message to scheduler
         creationMessages.getOrElseUpdate(proxy, create)
-        proxy ! Initialize(create.invocationNamespace, executable, create.schedulerHost, create.rpcPort, create.transid)
+        proxy ! Initialize(
+          create.invocationNamespace,
+          create.action,
+          executable,
+          create.schedulerHost,
+          create.rpcPort,
+          create.transid)
         inProgressPool = inProgressPool + (proxy -> data)
         logContainerStart(create, executable.toWhiskAction, containerState)
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -68,6 +68,7 @@ case class InitCodeCompleted(data: WarmData)
 
 // Events received by the actor
 case class Initialize(invocationNamespace: String,
+                      fqn: FullyQualifiedEntityName,
                       action: ExecutableWhiskAction,
                       schedulerHost: String,
                       rpcPort: Int,
@@ -251,7 +252,7 @@ class FunctionPullingContainerProxy(
             clientProxyFactory(
               context,
               job.invocationNamespace,
-              job.action.fullyQualifiedName(true),
+              job.fqn, // include binding field
               job.action.rev,
               job.schedulerHost,
               job.rpcPort,
@@ -292,7 +293,7 @@ class FunctionPullingContainerProxy(
         clientProxyFactory(
           context,
           job.invocationNamespace,
-          job.action.fullyQualifiedName(true),
+          job.fqn, // include binding field
           job.action.rev,
           job.schedulerHost,
           job.rpcPort,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/InvokerHealthManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/InvokerHealthManager.scala
@@ -172,7 +172,8 @@ class InvokerHealthManager(instanceId: InvokerInstanceId,
 
     WhiskAction.get(entityStore, docId).onComplete {
       case Success(action) =>
-        val initialize = Initialize(namespace, action.toExecutableWhiskAction.get, "", 0, transid)
+        val initialize =
+          Initialize(namespace, action.fullyQualifiedName(true), action.toExecutableWhiskAction.get, "", 0, transid)
         startHealthAction(initialize, manager)
       case Failure(t) => logging.error(this, s"get health action error: ${t.getMessage}")
     }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerPoolTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerPoolTests.scala
@@ -227,12 +227,12 @@ class FunctionPullingContainerPoolTests
 
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(1).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -254,7 +254,7 @@ class FunctionPullingContainerPoolTests
     // Start first action
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction) // 1 * stdMemory taken
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // Send second action to the pool
@@ -267,7 +267,7 @@ class FunctionPullingContainerPoolTests
     pool ! CreationContainer(creationMessageLarge.copy(revision = bigDoc.rev), bigWhiskAction)
     // Second container should run now
     containers(1).expectMsgPF() {
-      case Initialize(invocationNamespace, bigExecuteAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, bigExecuteAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -307,7 +307,7 @@ class FunctionPullingContainerPoolTests
     pool ! Enable
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction) // 1 * stdMemory taken
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -328,7 +328,7 @@ class FunctionPullingContainerPoolTests
     (0 to 10).foreach(_ => pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)) // 11 * stdMemory taken)
     (0 to 10).foreach(i => {
       containers(i).expectMsgPF() {
-        case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+        case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
       }
       // create 5 container in busy pool, and 6 in warmed pool
       if (i < 5)
@@ -526,7 +526,7 @@ class FunctionPullingContainerPoolTests
     // the prewarm container with matched memory should be chose
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // prewarm a new container
@@ -537,7 +537,7 @@ class FunctionPullingContainerPoolTests
     // the prewarm container with bigger memory should not be chose
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(3).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -566,7 +566,7 @@ class FunctionPullingContainerPoolTests
     // the prewarm container with smallest memory should be chose
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // prewarm a new container
@@ -577,7 +577,7 @@ class FunctionPullingContainerPoolTests
     // the prewarm container with bigger memory should be chose
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(1).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // prewarm a new container
@@ -589,7 +589,7 @@ class FunctionPullingContainerPoolTests
     // a new container should be created
     pool ! CreationContainer(creationMessageLarge.copy(revision = doc.rev), bigWhiskAction)
     containers(4).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // no new prewarmed container should be created
@@ -616,7 +616,7 @@ class FunctionPullingContainerPoolTests
 
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(1).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -640,7 +640,7 @@ class FunctionPullingContainerPoolTests
 
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(1).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -674,24 +674,24 @@ class FunctionPullingContainerPoolTests
     // the revision doesn't match, create 1 container
     pool ! CreationContainer(creationMessage, whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // the invocation namespace doesn't match, create 1 container
     pool ! CreationContainer(creationMessage.copy(invocationNamespace = "otherNamespace"), whiskAction)
     containers(1).expectMsgPF() {
-      case Initialize("otherNamespace", executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize("otherNamespace", fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     container.expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // warmed container is occupied, create 1 more container
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(2).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -726,7 +726,7 @@ class FunctionPullingContainerPoolTests
     // choose the warmed container
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     container.expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // warmed container is failed to resume
@@ -743,7 +743,7 @@ class FunctionPullingContainerPoolTests
 
     // then a new container will be created
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -806,7 +806,7 @@ class FunctionPullingContainerPoolTests
 
     // a new container will be created
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
   }
 
@@ -850,7 +850,7 @@ class FunctionPullingContainerPoolTests
 
     pool ! CreationContainer(actualCreationMessage, whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     containers(0).send(pool, Initialized(initializedData)) // container is initialized
 
@@ -898,7 +898,7 @@ class FunctionPullingContainerPoolTests
     // choose the warmed container
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     container.expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool.tell(
       Resumed(
@@ -956,7 +956,7 @@ class FunctionPullingContainerPoolTests
 
     pool ! CreationContainer(actualCreationMessage, whiskAction)
     containers(0).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     containers(0).send(pool, ContainerRemoved(true)) // the container0 init failed or create container failed
 
@@ -1127,11 +1127,11 @@ class FunctionPullingContainerPoolTests
     // 2 cold start happened
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(2).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(3).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     // Make sure AdjustPrewarmedContainer is sent by ContainerPool's scheduler after prewarmExpirationCheckIntervel time
     Thread.sleep(prewarmExpirationCheckIntervel.toMillis)
@@ -1165,23 +1165,23 @@ class FunctionPullingContainerPoolTests
     // 5 code start happened(5 > maxCount)
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(6).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(7).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(8).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(9).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
     pool ! CreationContainer(creationMessage.copy(revision = doc.rev), whiskAction)
     containers(10).expectMsgPF() {
-      case Initialize(invocationNamespace, executeAction, schedulerHost, rpcPort, _) => true
+      case Initialize(invocationNamespace, fqn, executeAction, schedulerHost, rpcPort, _) => true
     }
 
     // Make sure AdjustPrewarmedContainer is sent by ContainerPool's scheduler after prewarmExpirationCheckIntervel time

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -425,7 +425,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     preWarm(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, transid)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, transid)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -490,7 +490,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     preWarm(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -554,7 +554,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -623,7 +623,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -696,7 +696,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     preWarm(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     probe.expectMsg(ContainerRemoved(true))
 
@@ -757,7 +757,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     probe.expectMsg(ContainerRemoved(true))
 
@@ -809,7 +809,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientClosed)
@@ -864,7 +864,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -924,7 +924,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -996,7 +996,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1075,7 +1075,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1152,7 +1152,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1233,7 +1233,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1310,7 +1310,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1386,7 +1386,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     probe watch machine
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1429,7 +1429,7 @@ class FunctionPullingContainerProxyTests
           Some(testContainerId))))
     probe.expectMsg(Transition(machine, Pausing, Paused))
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     dataManagementService.expectMsgAllOf(
       UnregisterData(
         ContainerKeys
@@ -1495,7 +1495,7 @@ class FunctionPullingContainerProxyTests
             timeoutConfig))
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, noLogsAction, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, noLogsAction, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1563,7 +1563,7 @@ class FunctionPullingContainerProxyTests
             timeoutConfig))
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsgAllOf(
       Transition(machine, Uninitialized, CreatingClient),
       ContainerCreationFailed(exception),
@@ -1626,7 +1626,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     preWarm(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1700,7 +1700,7 @@ class FunctionPullingContainerProxyTests
             timeoutConfig))
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1777,7 +1777,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1856,7 +1856,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -1946,7 +1946,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2009,7 +2009,7 @@ class FunctionPullingContainerProxyTests
             timeoutConfig))
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2075,7 +2075,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2145,7 +2145,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2228,7 +2228,7 @@ class FunctionPullingContainerProxyTests
 
     registerCallback(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2305,7 +2305,7 @@ class FunctionPullingContainerProxyTests
     mockNamespaceBlacklist.refreshBlacklist()
     //the namespace:invocationSpace will be added to namespaceBlackboxlist
     mockNamespaceBlacklist.refreshBlacklist()
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2372,7 +2372,7 @@ class FunctionPullingContainerProxyTests
 
     //first refresh, the namespace:invocationSpace is not in namespaceBlacklist, so activations are executed successfully
     mockNamespaceBlacklist.refreshBlacklist()
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2458,7 +2458,7 @@ class FunctionPullingContainerProxyTests
     registerCallback(machine, probe)
     preWarm(machine, probe)
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2538,7 +2538,7 @@ class FunctionPullingContainerProxyTests
     tcpProbe.expectMsg(Connect(new InetSocketAddress("0.0.0.0", 12345)))
 
     //pings should repeat till the container goes into Running state
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, transid)
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, transid)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2606,7 +2606,10 @@ class FunctionPullingContainerProxyTests
     // throw health error
     initPromise.failure(ContainerHealthError(messageTransId, "intentional failure"))
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    val fqn = action.fullyQualifiedName(withVersion = true)
+    val rev = action.rev
+
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2617,8 +2620,6 @@ class FunctionPullingContainerProxyTests
     client.send(machine, message)
 
     // message should be rescheduled
-    val fqn = action.fullyQualifiedName(withVersion = true)
-    val rev = action.rev
     client.expectMsg(RescheduleActivation(invocationNamespace.asString, fqn, rev, message))
   }
 
@@ -2667,7 +2668,10 @@ class FunctionPullingContainerProxyTests
     // throw health error
     runPromises.head.failure(ContainerHealthError(messageTransId, "intentional failure"))
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    val fqn = action.fullyQualifiedName(withVersion = true)
+    val rev = action.rev
+
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2678,8 +2682,6 @@ class FunctionPullingContainerProxyTests
     client.send(machine, message)
 
     // message should be rescheduled
-    val fqn = action.fullyQualifiedName(withVersion = true)
-    val rev = action.rev
     client.expectMsg(ContainerWarmed)
     client.expectMsg(RescheduleActivation(invocationNamespace.asString, fqn, rev, message))
   }
@@ -2732,7 +2734,10 @@ class FunctionPullingContainerProxyTests
     // throw health error
     runPromises(1).failure(ContainerHealthError(messageTransId, "intentional failure"))
 
-    machine ! Initialize(invocationNamespace.asString, action, schedulerHost, rpcPort, messageTransId)
+    val fqn = action.fullyQualifiedName(withVersion = true)
+    val rev = action.rev
+
+    machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
     client.send(machine, ClientCreationCompleted())
@@ -2751,8 +2756,6 @@ class FunctionPullingContainerProxyTests
     client.send(machine, message)
 
     // message should be rescheduled
-    val fqn = action.fullyQualifiedName(withVersion = true)
-    val rev = action.rev
     client.expectMsg(RescheduleActivation(invocationNamespace.asString, fqn, rev, message))
   }
 


### PR DESCRIPTION
## Description
Currently, binding action is not properly considered while creating or recovering queues.
It makes throttling for package actions work in an original namespace and actions from different namespaces share the same throttling limit.
This change will address the issue.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

