### PR TITLE
Fail all activations when it fails to pull a blackbox image.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Logging.scala
@@ -594,7 +594,8 @@ object LoggingMarkers {
   val SCHEDULER_KAFKA_WAIT_TIME =
     LogMarkerToken(scheduler, "kafkaWaitTime", counter)(MeasurementUnit.time.milliseconds)
   def SCHEDULER_WAIT_TIME(action: String) =
-    LogMarkerToken(scheduler, "waitTime", counter, Some(action), Map("action" -> action))(MeasurementUnit.time.milliseconds)
+    LogMarkerToken(scheduler, "waitTime", counter, Some(action), Map("action" -> action))(
+      MeasurementUnit.time.milliseconds)
 
   def SCHEDULER_KEEP_ALIVE(leaseId: Long) =
     LogMarkerToken(scheduler, "keepAlive", counter, None, Map("leaseId" -> leaseId.toString))(MeasurementUnit.none)

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -235,6 +235,8 @@ object Messages {
   /** Indicates that the image could not be pulled. */
   def imagePullError(image: String) = s"Failed to pull container image '$image'."
 
+  def commandNotFoundError = "executable file not found"
+
   /** Indicates that the container for the action could not be started. */
   val resourceProvisionError = "Failed to provision resources to run the action."
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesClient.scala
@@ -22,7 +22,6 @@ import java.net.SocketTimeoutException
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 import java.time.{Instant, ZoneId}
-
 import akka.actor.ActorSystem
 import akka.event.Logging.ErrorLevel
 import akka.event.Logging.InfoLevel
@@ -48,6 +47,7 @@ import org.apache.openwhisk.core.containerpool.docker.ProcessRunner
 import org.apache.openwhisk.core.containerpool.{ContainerAddress, ContainerId}
 import org.apache.openwhisk.core.entity.ByteSize
 import org.apache.openwhisk.core.entity.size._
+import org.apache.openwhisk.http.Messages
 import pureconfig._
 import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
@@ -81,6 +81,16 @@ case class KubernetesEphemeralStorageConfig(limit: ByteSize)
  */
 case class KubernetesPodReadyTimeoutException(timeout: FiniteDuration)
     extends Exception(s"Pod readiness timed out after ${timeout.toSeconds}s")
+
+/**
+ * Exception to indicate it failed to pull an image for blackbox actions.
+ */
+case class KubernetesImagePullFailedException(msg: String) extends Exception(msg)
+
+/**
+ * Exception to indicate the command for an image is not found.
+ */
+case class KubernetesImageCommandNotFoundException(msg: String) extends Exception(msg)
 
 /**
  * Exception to indicate a pod could not be created at the apiserver.
@@ -131,6 +141,8 @@ class KubernetesClient(
     config.actionNamespace.foreach(configBuilder.withNamespace)
     new DefaultKubernetesClient(configBuilder.build())
   }
+
+  private val imagePullFailedMsgs = Set("ImagePullBackOff", "ErrImagePull")
 
   private val podBuilder = new WhiskPodBuilder(kubeRestClient, config)
 
@@ -321,7 +333,23 @@ class KubernetesClient(
       .withName(pod.getMetadata.getName)
     val deadline = deadlineOpt.getOrElse((timeout - (System.currentTimeMillis() - start.toEpochMilli).millis).fromNow)
     if (!readyPod.isReady) {
-      if (deadline.isOverdue()) {
+      // when action pod is failed while pulling images, we need to let users know that
+      val imagePullErr = Try {
+        readyPod.get.getStatus.getContainerStatuses.asScala.exists { status =>
+          imagePullFailedMsgs.contains(status.getState.getWaiting.getReason)
+        }
+      } getOrElse false
+      // when command not found in image, we need to let users know that as well
+      val commandNotFoundErr = Try {
+        readyPod.get.getStatus.getContainerStatuses.asScala.exists { status =>
+          status.getState.getWaiting.getMessage.contains(Messages.commandNotFoundError)
+        }
+      } getOrElse false
+      if (imagePullErr) {
+        Future.failed(KubernetesImagePullFailedException(s"Failed to pull image for pod ${pod.getMetadata.getName}"))
+      } else if (commandNotFoundErr) {
+        Future.failed(KubernetesImageCommandNotFoundException(Messages.commandNotFoundError))
+      } else if (deadline.isOverdue()) {
         Future.failed(KubernetesPodReadyTimeoutException(timeout))
       } else {
         after(1.seconds, scheduler) {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/kubernetes/KubernetesContainer.scala
@@ -74,6 +74,10 @@ object KubernetesContainer {
         case e: KubernetesPodApiException =>
           //apiserver call failed - this will expose a different error to users
           cleanupFailedPod(e, podName, WhiskContainerStartupError(Messages.resourceProvisionError))
+        case e: KubernetesImagePullFailedException =>
+          cleanupFailedPod(e, podName, BlackboxStartupError(Messages.imagePullError(image)))
+        case e: KubernetesImageCommandNotFoundException =>
+          cleanupFailedPod(e, podName, BlackboxStartupError(s"${Messages.commandNotFoundError} in image ${image}"))
         case e: Throwable =>
           cleanupFailedPod(e, podName, WhiskContainerStartupError(s"Failed to run container with image '${image}'."))
       }

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -221,7 +221,7 @@ class StandaloneDockerClient(pullDisabled: Boolean)(implicit log: Logging, as: A
     for {
       _ <- if (shouldPull) pull(image) else Future.successful(())
       id <- run(image, args).recoverWith {
-        case t @ BrokenDockerContainer(brokenId, _) =>
+        case t @ BrokenDockerContainer(brokenId, _, _) =>
           // Remove the broken container - but don't wait or check for the result.
           // If the removal fails, there is nothing we could do to recover from the recovery.
           rm(brokenId)

--- a/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdConfigTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdConfigTests.scala
@@ -7,13 +7,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.ExecutionContextExecutor
-
-
 @RunWith(classOf[JUnitRunner])
-class EtcdConfigTests
-  extends FlatSpec
-    with Matchers
-    with WskActorSystem {
+class EtcdConfigTests extends FlatSpec with Matchers with WskActorSystem {
   behavior of "EtcdConfig"
 
   implicit val ece: ExecutionContextExecutor = actorSystem.dispatcher

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -358,7 +358,6 @@ class DockerClientTests
     }
 
     Seq[(ProcessRunningException, String)](
-      (ProcessUnsuccessfulException(ExitStatus(127), id.asString, "Unknown command"), "Exit code not 125"),
       (ProcessUnsuccessfulException(ExitStatus(125), "", "Unknown flag: --foo"), "No container ID"),
       (ProcessUnsuccessfulException(ExitStatus(1), "", ""), "Exit code not 125 and no container ID"),
       (ProcessTimeoutException(1.second, ExitStatus(125), id.asString, ""), "Timeout instead of unsuccessful command"))

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerClientTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerClientTests.scala
@@ -367,6 +367,18 @@ class DockerClientTests
       }
   }
 
+  it should "fail with BrokenDockerContainer when run returns with exit status 127 and a container ID" in {
+    val dc = dockerClient {
+      Future.failed(
+        ProcessUnsuccessfulException(
+          exitStatus = ExitStatus(127),
+          stdout = id.asString,
+          stderr = """Error response from daemon: OCI runtime create failed: executable file not found"""))
+    }
+    val bdc = the[BrokenDockerContainer] thrownBy await(dc.run("image", Seq.empty))
+    bdc.id shouldBe id
+  }
+
   it should "fail with ProcessTimeoutException when command times out" in {
     val expectedPTE =
       ProcessTimeoutException(timeout = 10.seconds, exitStatus = ExitStatus(143), stdout = "stdout", stderr = "stderr")


### PR DESCRIPTION
## Description
Currently, if the system fails to pull a black-box image, it keeps waiting for the runtime pod to be running.

```
$ kubectl get pods
...
wsk-blue-test-invoker-38-47-style95-dockeraction     0/1     ImagePullBackOff   0          41h
wsk-blue-test-invoker-38-48-style95-dockeraction     0/1     ImagePullBackOff   0          41h
...
```

If the pod creation is failed due to image pulling, we can complete activations with an error.
Another case is a black-box pod is failed to run because a command is not found.
In such cases, the system can let users know about the issues in their images.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

