### PR TITLE
[Scheduler Enhancement] Add test cases to make sure an invoker properly boots up in terms of ETCD keys.

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -72,6 +72,7 @@ ext.testSets = [
             "org/apache/openwhisk/core/cli/test/**",
             "org/apache/openwhisk/core/limits/**",
             "org/apache/openwhisk/core/scheduler/**",
+            "org/apache/openwhisk/core/invoker/test/*InvokerBootUpTests*",
             "org/apache/openwhisk/core/loadBalancer/test/*FPCPoolBalancerTests*",
             "org/apache/openwhisk/common/etcd/**",
             "**/*CacheConcurrencyTests*",
@@ -92,6 +93,7 @@ ext.testSets = [
             "org/apache/openwhisk/common/etcd/**",
             "org/apache/openwhisk/core/containerpool/v2/test/**",
             "org/apache/openwhisk/core/scheduler/**",
+            "org/apache/openwhisk/core/invoker/test/*InvokerBootUpTests*",
             "org/apache/openwhisk/core/loadBalancer/test/*FPCPoolBalancerTests*",
             "org/apache/openwhisk/core/service/**",
         ]

--- a/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/InvokerBootUpTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/invoker/test/InvokerBootUpTests.scala
@@ -1,0 +1,92 @@
+package org.apache.openwhisk.core.invoker.test
+
+import java.nio.charset.StandardCharsets
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import common.WskTestHelpers
+import org.apache.openwhisk.common.InvokerState.Healthy
+import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.connector.InvokerResourceMessage
+import org.apache.openwhisk.core.containerpool.v2.InvokerHealthManager.healthActionNamePrefix
+import org.apache.openwhisk.core.entity.InvokerInstanceId
+import org.apache.openwhisk.core.etcd.EtcdKV.ContainerKeys.namespacePrefix
+import org.apache.openwhisk.core.etcd.EtcdKV.{InstanceKeys, InvokerKeys}
+import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig}
+import org.junit.runner.RunWith
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
+import pureconfig.loadConfigOrThrow
+import org.apache.openwhisk.core.entity.size._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+import pureconfig.generic.auto._
+
+@RunWith(classOf[JUnitRunner])
+class InvokerBootUpTests
+    extends TestKit(ActorSystem("SchedulerFlow"))
+    with FlatSpecLike
+    with BeforeAndAfterAll
+    with WskTestHelpers
+    with ScalaFutures {
+  private implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  private val systemNamespace = "whisk.system"
+  private val etcd = EtcdClient.apply(loadConfigOrThrow[EtcdConfig](ConfigKeys.etcd))
+
+  override def afterAll(): Unit = {
+    etcd.close()
+    super.afterAll()
+  }
+
+  behavior of "Invoker Etcd Key"
+  it should "haven't health action key" in {
+    val healthActionPrefix = s"$namespacePrefix/namespace/$systemNamespace/$systemNamespace/$healthActionNamePrefix"
+    awaitAssert({
+      etcd.getPrefix(healthActionPrefix).futureValue.getKvsList.size() shouldBe 0
+    }, 10.seconds)
+  }
+
+  it should "have lease key" in {
+    val leasePrefix = s"$namespacePrefix/instance"
+    awaitAssert({
+      val leases = etcd.getPrefix(leasePrefix).futureValue.getKvsList.asScala.toArray
+
+      // validate size
+      leases.length > 0
+
+      // validate key
+      for (i <- leases.indices) {
+        val invokerId = InvokerInstanceId(i, userMemory = 256.MB)
+        leases(i).getKey.toString(StandardCharsets.UTF_8) shouldBe InstanceKeys.instanceLease(invokerId)
+      }
+    }, 10.seconds)
+  }
+
+  it should "have invoker key" in {
+    val invokerPrefix = InvokerKeys.prefix
+    awaitAssert(
+      {
+        val invokers = etcd.getPrefix(invokerPrefix).futureValue.getKvsList.asScala.toArray
+
+        // validate size
+        invokers.length > 0
+
+        for (i <- invokers.indices) {
+          val invokerId = InvokerInstanceId(i, uniqueName = Some(s"$i"), userMemory = 256.MB)
+          // validate key
+          invokers(i).getKey.toString(StandardCharsets.UTF_8) shouldBe InvokerKeys.health(invokerId)
+
+          // validate if all invoker is healthy
+          InvokerResourceMessage
+            .parse(invokers(i).getValue.toString(StandardCharsets.UTF_8))
+            .map { resource =>
+              resource.status shouldBe Healthy.asString
+            }
+        }
+      },
+      10.seconds)
+  }
+}


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
These test cases would make sure invokers properly remove ETCD keys for health actions after becoming healthy.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

