### PR TITLE
Support graceful shutdown of runtime pods.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -18,12 +18,9 @@
 package org.apache.openwhisk.core.entity
 
 import scala.util.Try
-
-import akka.http.scaladsl.model.StatusCodes.OK
-
+import akka.http.scaladsl.model.StatusCodes.{OK, ServiceUnavailable}
 import spray.json._
 import spray.json.DefaultJsonProtocol
-
 import org.apache.openwhisk.common.Logging
 import org.apache.openwhisk.http.Messages._
 
@@ -139,6 +136,10 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
     /** true iff status code is OK (HTTP 200 status code), anything else is considered an error. **/
     val okStatus = statusCode == OK.intValue
     val ok = okStatus && truncated.isEmpty
+
+    /** true iff status code is ServiceUnavailable (HTTP 503 status code) */
+    val shuttingDown = statusCode == ServiceUnavailable.intValue
+
     override def toString = {
       val base = if (okStatus) "ok" else "not ok"
       val rest = truncated.map(e => s", truncated ${e.toString}").getOrElse("")

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/docker/test/DockerContainerTests.scala
@@ -474,6 +474,23 @@ class DockerContainerTests
     end.deltaToMarkerStart shouldBe Some(interval.duration.toMillis)
   }
 
+  it should "throw ContainerHealthError if runtime container returns 503 response" in {
+    implicit val docker = stub[DockerApiWithFileAccess]
+    implicit val runc = stub[RuncApi]
+
+    val interval = intervalOf(1.millisecond)
+    val result = JsObject.empty
+    val container = dockerContainer() {
+      Future.successful(RunResult(interval, Right(ContainerResponse(503, result.compactPrint, None))))
+    }
+
+    val initResult = container.initialize(JsObject.empty, 1.second, 1)
+    an[ContainerHealthError] should be thrownBy await(initResult)
+
+    val runResult = container.run(JsObject.empty, JsObject.empty, 1.second, 1)
+    an[ContainerHealthError] should be thrownBy await(runResult)
+  }
+
   it should "properly deal with a timeout during run" in {
     implicit val docker = stub[DockerApiWithFileAccess]
     implicit val runc = stub[RuncApi]


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
This is to support the graceful shutdown.
When OW is running on K8S and a pod is drained for some reason (server maintenance..)
Our runtime pod also shut down and a time-out error can occur.

In this case, activation's result is an action developer error but it's actually the internal system error.
So this is to handle such a case.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

