### PR TITLE
Support array result for common action and sequence action

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -380,17 +380,12 @@ object Activation extends DefaultJsonProtocol {
 
   /** Get "StatusCode" from result response set by action developer * */
   def userDefinedStatusCode(result: Option[JsValue]): Option[Int] = {
-    var statusCode: Option[JsValue] = None
-    result match {
-      case Some(value) =>
-        value match {
-          case JsArray(_) =>
-          case _ =>
-            statusCode = JsHelpers
-              .getFieldPath(result.get.asJsObject, ERROR_FIELD, "statusCode")
-              .orElse(JsHelpers.getFieldPath(result.get.asJsObject, "statusCode"))
-        }
-      case None =>
+    val statusCode: Option[JsValue] = result match {
+      case Some(JsObject(fields)) =>
+        JsHelpers
+          .getFieldPath(JsObject(fields), ERROR_FIELD, "statusCode")
+          .orElse(JsHelpers.getFieldPath(JsObject(fields), "statusCode"))
+      case _ => None
     }
     statusCode.map {
       case value => Try(value.convertTo[BigInt].intValue).toOption.getOrElse(BadRequest.intValue)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/Container.scala
@@ -26,7 +26,7 @@ import akka.util.ByteString
 import pureconfig._
 import pureconfig.generic.auto._
 import spray.json.DefaultJsonProtocol._
-import spray.json.JsObject
+import spray.json.{JsObject, JsValue}
 import org.apache.openwhisk.common.{Logging, LoggingMarkers, TransactionId}
 import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.entity.ActivationResponse.{ContainerConnectionError, ContainerResponse}
@@ -159,7 +159,7 @@ trait Container {
   }
 
   /** Runs code in the container. Thread-safe - caller may invoke concurrently for concurrent activation processing. */
-  def run(parameters: JsObject,
+  def run(parameters: JsValue,
           environment: JsObject,
           timeout: FiniteDuration,
           maxConcurrent: Int,

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -203,7 +203,7 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
         truncated match {
           case None =>
             val sizeOpt = Option(str).map(_.length)
-            Try { str.parseJson.asJsObject } match {
+            Try { str.parseJson } match {
               case scala.util.Success(result @ JsObject(fields)) =>
                 // If the response is a JSON object container an error field, accept it as the response error.
                 val errorOpt = fields.get(ERROR_FIELD)
@@ -220,6 +220,16 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
                   // there was a useful error message in there.
                   val errorContent = errorOpt getOrElse invalidRunResponse(str).toJson
                   developerError(errorContent, sizeOpt)
+                }
+
+              case scala.util.Success(result @ JsArray(_)) =>
+                if (res.okStatus) {
+                  success(Some(result), sizeOpt)
+                } else {
+                  // Any non-200 code is treated as a container failure. We still need to check whether
+                  // there was a useful error message in there.
+                  val errorContent = invalidRunResponse(str).toJson
+                  developerErrorWithLog(errorContent, sizeOpt, None)
                 }
 
               case scala.util.Success(notAnObj) =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -111,7 +111,7 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
    * NOTE: the code is application error (since this response could be used as a response for the sequence
    * if the payload contains an error)
    */
-  protected[core] def payloadPlaceholder(payload: Option[JsObject]) = ActivationResponse(ApplicationError, payload)
+  protected[core] def payloadPlaceholder(payload: Option[JsValue]) = ActivationResponse(ApplicationError, payload)
 
   /**
    * Class of errors for invoker-container communication.

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/entity/ActivationResult.scala
@@ -229,7 +229,8 @@ protected[core] object ActivationResponse extends DefaultJsonProtocol {
                   // Any non-200 code is treated as a container failure. We still need to check whether
                   // there was a useful error message in there.
                   val errorContent = invalidRunResponse(str).toJson
-                  developerErrorWithLog(errorContent, sizeOpt, None)
+                  //developerErrorWithLog(errorContent, sizeOpt, None)
+                  developerError(errorContent, sizeOpt)
                 }
 
               case scala.util.Success(notAnObj) =>

--- a/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/http/ErrorResponse.scala
@@ -204,7 +204,7 @@ object Messages {
   }
 
   def invalidRunResponse(actualResponse: String) = {
-    "The action did not produce a valid JSON response" + {
+    "The action did not produce a valid JSON or JSON Array response" + {
       Option(actualResponse) filter { _.nonEmpty } map { s =>
         s": $s"
       } getOrElse "."

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -289,8 +289,12 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
           complete(Accepted, activationId.toJsObject)
         }
       case Success(Right(activation)) =>
-        val response = if (result) activation.resultAsJson else activation.toExtendedJson()
-
+        val response = activation.response.result match {
+          case Some(JsArray(elements)) =>
+            JsArray(elements)
+          case _ =>
+            if (result) activation.resultAsJson else activation.toExtendedJson()
+        }
         respondWithActivationIdHeader(activation.activationId) {
           if (activation.response.isSuccess) {
             complete(OK, response)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PostActionActivation.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PostActionActivation.scala
@@ -47,7 +47,7 @@ protected[core] trait PostActionActivation extends PrimitiveActions with Sequenc
   protected[controller] def invokeAction(
     user: Identity,
     action: WhiskActionMetaData,
-    payload: Option[JsObject],
+    payload: Option[JsValue],
     waitForResponse: Option[FiniteDuration],
     cause: Option[ActivationId])(implicit transid: TransactionId): Future[Either[ActivationId, WhiskActivation]] = {
     action.toExecutableWhiskAction match {

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/actions/PrimitiveActions.scala
@@ -173,6 +173,10 @@ protected[actions] trait PrimitiveActions {
     val startLoadbalancer =
       transid.started(this, LoggingMarkers.CONTROLLER_LOADBALANCER, s"action activation id: ${activationId}")
 
+    val keySet = payload match {
+      case Some(JsObject(fields)) => Some(fields.keySet)
+      case _                      => None
+    }
     val message = ActivationMessage(
       transid,
       FullyQualifiedEntityName(action.namespace, action.name, Some(action.version), action.binding),
@@ -183,7 +187,7 @@ protected[actions] trait PrimitiveActions {
       waitForResponse.isDefined,
       args,
       action.parameters.initParameters,
-      action.parameters.lockedParameters(payload.map(_.fields.keySet).getOrElse(Set.empty)),
+      action.parameters.lockedParameters(keySet.getOrElse(Set.empty)),
       cause = cause,
       WhiskTracerProvider.tracer.getTraceContext(transid))
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -1085,11 +1085,11 @@ object ContainerProxy {
   def partitionArguments(content: Option[JsValue], initArgs: Set[String]): (Map[String, JsValue], JsValue) = {
     content match {
       case None                                       => (Map.empty, JsObject.empty)
+      case Some(JsArray(elements))                    => (Map.empty, JsArray(elements))
       case Some(JsObject(fields)) if initArgs.isEmpty => (Map.empty, JsObject(fields))
       case Some(JsObject(fields)) =>
-        val (env, args) = JsObject(fields).fields.partition(k => initArgs.contains(k._1))
+        val (env, args) = fields.partition(k => initArgs.contains(k._1))
         (env, JsObject(args))
-      case Some(JsArray(elements)) => (Map.empty, JsArray(elements))
     }
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -1082,13 +1082,14 @@ object ContainerProxy {
    * @param initArgs set of parameters to treat as initialization arguments
    * @return A partition of the arguments into an environment variables map and the JsObject argument to the action
    */
-  def partitionArguments(content: Option[JsObject], initArgs: Set[String]): (Map[String, JsValue], JsObject) = {
+  def partitionArguments(content: Option[JsValue], initArgs: Set[String]): (Map[String, JsValue], JsValue) = {
     content match {
-      case None                         => (Map.empty, JsObject.empty)
-      case Some(js) if initArgs.isEmpty => (Map.empty, js)
-      case Some(js) =>
-        val (env, args) = js.fields.partition(k => initArgs.contains(k._1))
+      case None                                       => (Map.empty, JsObject.empty)
+      case Some(JsObject(fields)) if initArgs.isEmpty => (Map.empty, JsObject(fields))
+      case Some(JsObject(fields)) =>
+        val (env, args) = JsObject(fields).fields.partition(k => initArgs.contains(k._1))
         (env, JsObject(args))
+      case Some(JsArray(elements)) => (Map.empty, JsArray(elements))
     }
   }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/ContainerProxy.scala
@@ -1093,15 +1093,17 @@ object ContainerProxy {
     }
   }
 
-  def unlockArguments(content: Option[JsObject],
+  def unlockArguments(content: Option[JsValue],
                       lockedArgs: Map[String, String],
-                      decoder: ParameterEncryption): Option[JsObject] = {
-    content.map {
-      case JsObject(fields) =>
-        JsObject(fields.map {
+                      decoder: ParameterEncryption): Option[JsValue] = {
+    content match {
+      case Some(JsObject(fields)) =>
+        Some(JsObject(fields.map {
           case (k, v: JsString) if lockedArgs.contains(k) => (k -> decoder.encryptor(lockedArgs(k)).decrypt(v))
           case p                                          => p
-        })
+        }))
+      // keep the original for other type(e.g. JsArray)
+      case contentValue => contentValue
     }
   }
 }

--- a/tests/dat/actions/helloArray.js
+++ b/tests/dat/actions/helloArray.js
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * helloArray action
+ */
+
+function main(params) {
+    return [{"key1":"value1"},{"key2":"value2"}];
+}

--- a/tests/dat/actions/sort-array.js
+++ b/tests/dat/actions/sort-array.js
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Sort a set of lines.
+ * @param lines An array of strings to sort.
+ */
+function main(msg) {
+    var lines = msg || [];
+    console.log('sort before: ' + lines);
+    lines.sort();
+    console.log('sort after: ' + lines);
+    return lines;
+}

--- a/tests/dat/actions/split-array.js
+++ b/tests/dat/actions/split-array.js
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Splits a string into an array of strings
+ * Return lines in an array.
+ * @param payload A string.
+ * @param separator The character, or the regular expression, to use for splitting the string
+ */
+function main(msg) {
+    var separator = msg.separator || /\r?\n/;
+    var payload = msg.payload.toString();
+    var lines = payload.split(separator);
+    // return array as next action's input
+    return lines;
+}
+

--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -173,7 +173,7 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
         initCode should be(200)
         val (runCode, out) = c.run(JsObject.empty)
         runCode should not be (200)
-        out should be(Some(JsObject("error" -> JsString("The action did not return a dictionary."))))
+        out should be(Some(JsObject("error" -> JsString("The action did not return a dictionary or array."))))
       }
 
       checkStreams(out, err, {

--- a/tests/src/test/scala/common/WskTestHelpers.scala
+++ b/tests/src/test/scala/common/WskTestHelpers.scala
@@ -76,7 +76,7 @@ object FullyQualifiedNames {
  * @param status a string used to indicate the status of the action
  * @param success a boolean value used to indicate whether the action is executed successfully or not
  */
-case class ActivationResponse(result: Option[JsObject], status: String, success: Boolean)
+case class ActivationResponse(result: Option[JsValue], status: String, success: Boolean)
 
 object ActivationResponse extends DefaultJsonProtocol {
   implicit val serdes = jsonFormat3(ActivationResponse.apply)

--- a/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
+++ b/tests/src/test/scala/invokerShoot/ShootInvokerTests.scala
@@ -307,7 +307,7 @@ class ShootInvokerTests extends TestHelpers with WskTestHelpers with JsHelpers w
     val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
     withActivation(wsk.activation, run) { activation =>
       val result = activation.response.result.get
-      result.getFields("stdout", "code") match {
+      result.asJsObject.getFields("stdout", "code") match {
         case Seq(JsString(stdout), JsNumber(code)) =>
           stdout should not include "bytes from"
           code.intValue should not be 0

--- a/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/cli/test/WskRestBasicUsageTests.scala
@@ -224,7 +224,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
 
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
         val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.abnormalInitialization.toJson
+        response.result.get.asJsObject.fields("error") shouldBe Messages.abnormalInitialization.toJson
         response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
       }
   }
@@ -238,7 +238,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
 
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
         val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
+        response.result.get.asJsObject.fields("error") shouldBe Messages.timedoutActivation(3 seconds, true).toJson
         response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
       }
   }
@@ -252,7 +252,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
 
       withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
         val response = activation.response
-        response.result.get.fields("error") shouldBe Messages.abnormalRun.toJson
+        response.result.get.asJsObject.fields("error") shouldBe Messages.abnormalRun.toJson
         response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
       }
   }
@@ -326,7 +326,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
       val run = wsk.action.invoke(name)
       withActivation(wsk.activation, run) { activation =>
         activation.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-        activation.response.result.get
+        activation.response.result.get.asJsObject
           .fields("error") shouldBe s"Failed to pull container image '$containerName'.".toJson
         activation.annotations shouldBe defined
         val limits = activation.annotations.get.filter(_.fields("key").convertTo[String] == "limits")
@@ -775,7 +775,7 @@ class WskRestBasicUsageTests extends TestHelpers with WskTestHelpers with WskAct
         withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
           actionActivation.response.result match {
             case Some(result) =>
-              result.fields.get("args") map { headers =>
+              result.asJsObject.fields.get("args") map { headers =>
                 headers.asJsObject.fields.get("__ow_headers") map { params =>
                   params.asJsObject.fields.get("foo") map { foo =>
                     foo shouldBe JsString("Bar")

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/test/ContainerProxyTests.scala
@@ -1338,7 +1338,7 @@ class ContainerProxyTests
     timeout) {
     val container = new TestContainer {
       override def run(
-        parameters: JsObject,
+        parameters: JsValue,
         environment: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
@@ -1519,7 +1519,7 @@ class ContainerProxyTests
     timeout) {
     val container = new TestContainer {
       override def run(
-        parameters: JsObject,
+        parameters: JsValue,
         environment: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
@@ -1688,7 +1688,7 @@ class ContainerProxyTests
   it should "resend the job to the parent if /run fails connection after Paused -> Running" in within(timeout) {
     val container = new TestContainer {
       override def run(
-        parameters: JsObject,
+        parameters: JsValue,
         environment: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
@@ -1740,7 +1740,7 @@ class ContainerProxyTests
   it should "resend the job to the parent if /run fails connection after Ready -> Running" in within(timeout) {
     val container = new TestContainer {
       override def run(
-        parameters: JsObject,
+        parameters: JsValue,
         environment: JsObject,
         timeout: FiniteDuration,
         concurrent: Int,
@@ -2160,7 +2160,7 @@ class ContainerProxyTests
       initPromise.map(_.future).getOrElse(Future.successful(initInterval))
     }
     override def run(
-      parameters: JsObject,
+      parameters: JsValue,
       environment: JsObject,
       timeout: FiniteDuration,
       concurrent: Int,

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -1737,7 +1737,7 @@ class FunctionPullingContainerProxyTests
     val dataManagementService = TestProbe()
 
     val container = new TestContainer {
-      override def run(parameters: JsObject,
+      override def run(parameters: JsValue,
                        environment: JsObject,
                        timeout: FiniteDuration,
                        concurrent: Int,
@@ -1810,7 +1810,7 @@ class FunctionPullingContainerProxyTests
     val dataManagementService = TestProbe()
 
     val container = new TestContainer {
-      override def run(parameters: JsObject,
+      override def run(parameters: JsValue,
                        environment: JsObject,
                        timeout: FiniteDuration,
                        concurrent: Int,
@@ -2418,7 +2418,7 @@ class FunctionPullingContainerProxyTests
     val dataManagementService = TestProbe()
 
     val container = new TestContainer {
-      override def run(parameters: JsObject,
+      override def run(parameters: JsValue,
                        environment: JsObject,
                        timeout: FiniteDuration,
                        concurrent: Int,
@@ -2816,7 +2816,7 @@ class FunctionPullingContainerProxyTests
     }
 
     override def run(
-      parameters: JsObject,
+      parameters: JsValue,
       environment: JsObject,
       timeout: FiniteDuration,
       concurrent: Int,

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ConductorsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ConductorsApiTests.scala
@@ -322,10 +322,16 @@ class ConductorsApiTests extends ControllerTestCommon with WhiskActionsApi {
   class FakeLoadBalancerService(config: WhiskConfig)(implicit ec: ExecutionContext)
       extends DegenerateLoadBalancerService(config) {
 
-    private def respond(action: ExecutableWhiskActionMetaData, msg: ActivationMessage, result: JsObject) = {
-      val response =
-        if (result.fields.get("error") isDefined) ActivationResponse(ActivationResponse.ApplicationError, Some(result))
-        else ActivationResponse.success(Some(result))
+    private def respond(action: ExecutableWhiskActionMetaData, msg: ActivationMessage, result: JsValue) = {
+      val response = {
+        result match {
+          case JsObject(fields) =>
+            if (fields.get("error") isDefined)
+              ActivationResponse(ActivationResponse.ApplicationError, Some(result))
+            else ActivationResponse.success(Some(result))
+          case _ => ActivationResponse.success(Some(result))
+        }
+      }
       val start = Instant.now
       WhiskActivation(
         action.namespace,
@@ -345,26 +351,39 @@ class ConductorsApiTests extends ControllerTestCommon with WhiskActionsApi {
             case `echo` => // echo action
               Future(Right(respond(action, msg, args)))
             case `conductor` => // see tests/dat/actions/conductor.js
-              val result =
-                if (args.fields.get("error") isDefined) args
-                else {
-                  val action = args.fields.get("action") map { action =>
-                    Map("action" -> action)
-                  } getOrElse Map.empty
-                  val state = args.fields.get("state") map { state =>
-                    Map("state" -> state)
-                  } getOrElse Map.empty
-                  val wrappedParams = args.fields.getOrElse("params", JsObject.empty).asJsObject.fields
-                  val escapedParams = args.fields - "action" - "state" - "params"
-                  val params = Map("params" -> JsObject(wrappedParams ++ escapedParams))
-                  JsObject(params ++ action ++ state)
+              val result = {
+                args match {
+                  case JsObject(fields) =>
+                    if (fields.get("error") isDefined) args
+                    else {
+                      val action = fields.get("action") map { action =>
+                        Map("action" -> action)
+                      } getOrElse Map.empty
+                      val state = fields.get("state") map { state =>
+                        Map("state" -> state)
+                      } getOrElse Map.empty
+                      val wrappedParams = fields.getOrElse("params", JsObject.empty).asJsObject.fields
+                      val escapedParams = fields - "action" - "state" - "params"
+                      val params = Map("params" -> JsObject(wrappedParams ++ escapedParams))
+                      JsObject(params ++ action ++ state)
+                    }
+                  case _ => JsObject.empty
                 }
+
+              }
               Future(Right(respond(action, msg, result)))
             case `step` => // see tests/dat/actions/step.js
-              val result = args.fields.get("n") map { n =>
-                JsObject("n" -> (n.convertTo[BigDecimal] + 1).toJson)
-              } getOrElse {
-                JsObject("error" -> "missing parameter".toJson)
+              val result = {
+                args match {
+                  case JsObject(fields) =>
+                    fields.get("n") map { n =>
+                      JsObject("n" -> (n.convertTo[BigDecimal] + 1).toJson)
+                    } getOrElse {
+                      JsObject("error" -> "missing parameter".toJson)
+                    }
+                  case _ => JsObject.empty
+                }
+
               }
               Future(Right(respond(action, msg, result)))
             case _ =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -225,7 +225,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       withActivation(wsk.activation, run) { result =>
         withClue("Activation result not as expected:") {
           result.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-          result.response.result.get.fields("error") shouldBe {
+          result.response.result.get.asJsObject.fields("error") shouldBe {
             Messages.timedoutActivation(allowedActionDuration, init = false).toJson
           }
           result.duration.toInt should be >= allowedActionDuration.toMillis.toInt
@@ -314,7 +314,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
         val response = activation.response
         response.success shouldBe false
         response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.ApplicationError)
-        val msg = response.result.get.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
+        val msg = response.result.get.asJsObject.fields(ActivationResponse.ERROR_FIELD).convertTo[String]
         val expected = Messages.truncatedResponse((allowedSize + 10).B, allowedSize.B)
         withClue(s"is: ${msg.take(expected.length)}\nexpected: $expected") {
           msg.startsWith(expected) shouldBe true
@@ -404,7 +404,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
     withActivation(wsk.activation, run) { activation =>
       activation.response.success shouldBe false
 
-      val error = activation.response.result.get.fields("error").asJsObject
+      val error = activation.response.result.get.asJsObject.fields("error").asJsObject
       error.fields("filesToOpen") shouldBe (openFileLimit + 1).toJson
 
       error.fields("message") shouldBe {
@@ -471,7 +471,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
     val payload = MemoryLimit.MIN_MEMORY.toMB * 2
     val run = wsk.action.invoke(name, Map("payload" -> payload.toJson))
     withActivation(wsk.activation, run) {
-      _.response.result.get.fields("error") shouldBe Messages.memoryExhausted.toJson
+      _.response.result.get.asJsObject.fields("error") shouldBe Messages.memoryExhausted.toJson
     }
   }
 
@@ -494,7 +494,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
       withActivation(wsk.activation, run) { result =>
         withClue("Activation result not as expected:") {
           result.response.status shouldBe ActivationResponse.messageForCode(ActivationResponse.DeveloperError)
-          result.response.result.get
+          result.response.result.get.asJsObject
             .fields("error") shouldBe Messages.timedoutActivation(allowedActionDuration, init = false).toJson
           val logs = result.logs.get
           logs.last should include(Messages.logWarningDeveloperError)

--- a/tests/src/test/scala/system/basic/WskActionTests.scala
+++ b/tests/src/test/scala/system/basic/WskActionTests.scala
@@ -313,7 +313,7 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
     val run = wsk.action.invoke(name, Map("payload" -> "google.com".toJson))
     withActivation(wsk.activation, run) { activation =>
       val result = activation.response.result.get
-      result.getFields("stdout", "code") match {
+      result.asJsObject.getFields("stdout", "code") match {
         case Seq(JsString(stdout), JsNumber(code)) =>
           stdout should not include "bytes from"
           code.intValue should not be 0
@@ -390,6 +390,20 @@ class WskActionTests extends TestHelpers with WskTestHelpers with JsHelpers with
 
         action.create(name, Some(TestUtils.getTestActionFilename("hello.js")), update = true)
       }
+  }
+
+  it should "invoke an action with a array result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+    val name = "helloArray"
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, Some(TestUtils.getTestActionFilename("helloArray.js")))
+    }
+
+    val run = wsk.action.invoke(name)
+    withActivation(wsk.activation, run) { activation =>
+      activation.response.status shouldBe "success"
+      activation.response.result shouldBe Some(
+        JsArray(JsObject("key1" -> JsString("value1")), JsObject("key2" -> JsString("value2"))))
+    }
   }
 
 }

--- a/tests/src/test/scala/system/basic/WskConductorTests.scala
+++ b/tests/src/test/scala/system/basic/WskConductorTests.scala
@@ -102,7 +102,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
         wsk.action.invoke(echo, Map("payload" -> testString.toJson, "action" -> invalid.toJson))
       withActivation(wsk.activation, invalidrun) { activation =>
         activation.response.status shouldBe "application error"
-        activation.response.result.get.fields.get("error") shouldBe Some(
+        activation.response.result.get.asJsObject.fields.get("error") shouldBe Some(
           JsString(compositionComponentInvalid(JsString(invalid))))
         checkConductorLogsAndAnnotations(activation, 2) // echo
       }
@@ -113,7 +113,7 @@ class WskConductorTests extends TestHelpers with WskTestHelpers with JsHelpers w
 
       withActivation(wsk.activation, undefinedrun) { activation =>
         activation.response.status shouldBe "application error"
-        activation.response.result.get.fields.get("error") shouldBe Some(
+        activation.response.result.get.asJsObject.fields.get("error") shouldBe Some(
           JsString(compositionComponentNotFound(s"$namespace/$missing")))
         checkConductorLogsAndAnnotations(activation, 2) // echo
       }

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -73,9 +73,9 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
         checkSequenceLogsAndAnnotations(activation, 4) // 4 activations in this sequence
         activation.cause shouldBe None // topmost sequence
         val result = activation.response.result.get
-        result.fields.get("payload") shouldBe defined
-        result.fields.get("length") should not be defined
-        result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
+        result.asJsObject.fields.get("payload") shouldBe defined
+        result.asJsObject.fields.get("length") should not be defined
+        result.asJsObject.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
       }
 
       // update action sequence and run it with normal payload
@@ -90,8 +90,8 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       withActivation(wsk.activation, secondrun, totalWait = 2 * allowedActionDuration) { activation =>
         checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
         val result = activation.response.result.get
-        result.fields.get("length") shouldBe Some(2.toJson)
-        result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
+        result.asJsObject.fields.get("length") shouldBe Some(2.toJson)
+        result.asJsObject.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
       }
 
       // run sequence with error in the payload
@@ -102,8 +102,8 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       withActivation(wsk.activation, thirdrun, totalWait = 2 * allowedActionDuration) { activation =>
         checkSequenceLogsAndAnnotations(activation, 2) // 2 activations in this sequence
         val result = activation.response.result.get
-        result.fields.get("length") shouldBe Some(2.toJson)
-        result.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
+        result.asJsObject.fields.get("length") shouldBe Some(2.toJson)
+        result.asJsObject.fields.get("lines") shouldBe Some(args.sortWith(_.compareTo(_) < 0).toArray.toJson)
       }
   }
 
@@ -141,9 +141,9 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
       activation.cause shouldBe None // topmost sequence
       val result = activation.response.result.get
-      result.fields.get("payload") shouldBe defined
-      result.fields.get("length") should not be defined
-      result.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
+      result.asJsObject.fields.get("payload") shouldBe defined
+      result.asJsObject.fields.get("length") should not be defined
+      result.asJsObject.fields.get("lines") shouldBe Some(JsArray(Vector(now.toJson)))
     }
   }
 
@@ -186,7 +186,7 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
     withActivation(wsk.activation, run, totalWait = 2 * allowedActionDuration) { activation =>
       checkSequenceLogsAndAnnotations(activation, 3) // 3 activations in this sequence
       val result = activation.response.result.get
-      result.fields.get("payload") shouldBe Some(argsJson)
+      result.asJsObject.fields.get("payload") shouldBe Some(argsJson)
     }
     // update x with limit echo
     val limit: Int = {
@@ -203,7 +203,7 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       activation.response.status shouldBe ("application error")
       checkSequenceLogsAndAnnotations(activation, 2)
       val result = activation.response.result.get
-      result.fields.get("error") shouldBe Some(JsString(sequenceIsTooLong))
+      result.asJsObject.fields.get("error") shouldBe Some(JsString(sequenceIsTooLong))
       // check that inner sequence had only (limit - 1) activations
       val innerSeq = activation.logs.get(1) // the id of the inner sequence activation
       val getInnerSeq = wsk.activation.get(Some(innerSeq))
@@ -553,7 +553,7 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       withActivation(wsk.activation, ruleActivation.activationId) { actionActivation =>
         actionActivation.response.result match {
           case Some(result) =>
-            val (_, part2) = result.fields partition (p => p._1 == "__ow_headers") // excluding headers
+            val (_, part2) = result.asJsObject.fields partition (p => p._1 == "__ow_headers") // excluding headers
             JsObject(part2) shouldBe triggerPayload
           case others =>
             fail(s"no result found: $others")

--- a/tests/src/test/scala/system/basic/WskSequenceTests.scala
+++ b/tests/src/test/scala/system/basic/WskSequenceTests.scala
@@ -541,7 +541,7 @@ class WskSequenceTests extends TestHelpers with WskTestHelpers with StreamLoggin
       }
   }
 
-  it should "invoke a sequence which support array result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
+  it should "invoke a sequence which supports array result" in withAssetCleaner(wskprops) { (wp, assetHelper) =>
     val name = "sequence-array"
     val actions = Seq("split-array", "sort-array")
     for (actionName <- actions) {

--- a/tests/src/test/scala/system/basic/WskUnicodeTests.scala
+++ b/tests/src/test/scala/system/basic/WskUnicodeTests.scala
@@ -88,8 +88,8 @@ class WskUnicodeTests extends TestHelpers with WskTestHelpers with JsHelpers wit
           wsk.action.invoke(name, parameters = Map("delimiter" -> JsString("❄"))),
           totalWait = activationPollDuration) { activation =>
           val response = activation.response
-          response.result.get.fields.get("error") shouldBe empty
-          response.result.get.fields.get("winter") should be(Some(JsString("❄ ☃ ❄")))
+          response.result.get.asJsObject.fields.get("error") shouldBe empty
+          response.result.get.asJsObject.fields.get("winter") should be(Some(JsString("❄ ☃ ❄")))
 
           activation.logs.toList.flatten.mkString(" ") should include("❄ ☃ ❄")
         }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->
POEM document pr: https://github.com/apache/openwhisk/pull/5244

This feature is:  provide support array result feature for common action and sequence action. e.g.
* Support array result for common action (support nodejs by default, so let's use nodejs as example)
```
# cat ~/hello-array.js 
function main(params) {
    console.log("-------------log test---------")
    return [{"key1":"value1"},{"key2":"value2"}];
}

# wsk -i action create hello-array-nodejs --kind nodejs:10 ~/hello-array.js 
# wsk -i action invoke hello-array-nodejs -r -v
REQUEST:
[POST]	http://xxx.xxx.xxx.xxx:10001/api/v1/namespaces/_/actions/hello-array-nodejs?blocking=true&result=true
...
...
Response body size is 37 bytes
Response body received:
[{"key1":"value1"},{"key2":"value2"}]
```
* Support array result for sequence action
```
# cat ~/split.js
function main(msg) {
    var separator = msg.separator || /\r?\n/;
    var lines = payload.split(separator);
    // below lines result is array, it will be used as next action's input param
    return lines;
}

# cat ~/sort.js
function main(msg) {
    var lines = msg || [];
    lines.sort();
    return lines;
}

# wsk -i action create /whisk.system/utils/split --kind nodejs:10 ~/split.js
# wsk -i action create /whisk.system/utils/sort --kind nodejs:10 ~/sort.js
# wsk -i action create mySequence --sequence /whisk.system/utils/split,/whisk.system/utils/sort
# wsk -i action invoke --result mySequence --param payload "bbb\ncccc\naaaa"  -r -v
REQUEST:
[POST]	http://xxx.xxx.xxx.xxx:10001/api/v1/namespaces/_/actions/mySequence?blocking=true&result=true
...
Response body size is 22 bytes
Response body received:
["aaaa","bbbb","cccc"]
```
* Activation check in elasticsearch
```
# curl -u xxx:xxx -H "Content-Type: application/json" '[http://xxx.xxx.xxx.xxx:9200/lambda-exp_whisk.system/_search?pretty=true' -d  '{
  "query" : { "match" : { "activationId" : "9cc4dad8d81342fc84dad8d81302fc54" }},
  "from":0,
  "size":1
}'
{
  "took" : 3,
  ...
  "hits" : {
    "total" : 1,
    "max_score" : 5.1628795,
    "hits" : [
      {
        "_index" : "lambda-exp_whisk.system",
          ...
          "logs" : [
            "2022-07-21T06:53:16.543515915Z stdout: -------------log test---------"
          ],
          "name" : "hello-array-nodejs",
          ...
          "response" : {
            "result" : "[{\"key1\":\"value1\"},{\"key2\":\"value2\"}]",
            "size" : 37,
            "statusCode" : 0
          },
          ...
        }
      }
    ]
  }
}

# curl -u xxx:xxx -H "Content-Type: application/json" '[http://10.168.240.79:9200/lambda-exp_whisk.system/_search?pretty=true' -d  '{
  "query" : { "match" : { "activationId" : "9c774fe852de44cdb74fe852de94cd54" }},
  "from":0,
  "size":1
}'
...
          "response" : {
            "result" : "[\"aaaa\",\"bbb\",\"cccc\"]",
            "size" : 21,
            "statusCode" : 0
          }
...
```
The `response.result` must use `text` to store, because different activation's same filed may use different type, e.g.
one activation's result's name filed value is string , e.g. {"name": "jack"}
another activation's result's name filed value is int, e.g. {"name": 12}
Elasticsearch doesn't support this, it store like this, it would report error.

* Other works

As above example, we already know, `nodejs` runtime supports this feature by default.
But other runtimes(e.g. go, java, php, etc) don't support,
1. After this pr merged, there still has other works for runtime images, need to support subsequent prs for other images.
2. And in CLI side, still has small mount works to parse the JSON array string to user.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [x] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

