### PR TITLE
Do not put data to ETCD when no date is changed.

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -470,6 +470,33 @@ case class InvokerResourceMessage(status: String,
    * Serializes message to string. Must be idempotent.
    */
   override def serialize: String = InvokerResourceMessage.serdes.write(this).compactPrint
+
+  def canEqual(a: Any) = a.isInstanceOf[InvokerResourceMessage]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: InvokerResourceMessage => {
+        that.canEqual(this) &&
+        this.status == that.status &&
+        this.freeMemory == that.freeMemory &&
+        this.busyMemory == that.busyMemory &&
+        this.inProgressMemory == that.inProgressMemory &&
+        this.tags.toSet == that.tags.toSet &&
+        this.dedicatedNamespaces.toSet == that.dedicatedNamespaces.toSet
+      }
+      case _ => false
+    }
+
+  override def hashCode: Int = {
+    var result = 1
+    val prime = 31
+    result = prime * 31 + status.hashCode()
+    result = prime * 31 + freeMemory.hashCode()
+    result = prime * 31 + busyMemory.hashCode()
+    result = prime * 31 + inProgressMemory.hashCode()
+    result = prime * 31 + tags.hashCode()
+    result
+  }
 }
 
 object InvokerResourceMessage extends DefaultJsonProtocol {

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -490,11 +490,11 @@ case class InvokerResourceMessage(status: String,
   override def hashCode: Int = {
     var result = 1
     val prime = 31
-    result = prime * 31 + status.hashCode()
-    result = prime * 31 + freeMemory.hashCode()
-    result = prime * 31 + busyMemory.hashCode()
-    result = prime * 31 + inProgressMemory.hashCode()
-    result = prime * 31 + tags.hashCode()
+    result = prime * result + status.hashCode()
+    result = prime * result + freeMemory.hashCode()
+    result = prime * result + busyMemory.hashCode()
+    result = prime * result + inProgressMemory.hashCode()
+    result = prime * result + tags.hashCode()
     result
   }
 }

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -471,19 +471,16 @@ case class InvokerResourceMessage(status: String,
    */
   override def serialize: String = InvokerResourceMessage.serdes.write(this).compactPrint
 
-  def canEqual(a: Any) = a.isInstanceOf[InvokerResourceMessage]
-
   override def equals(that: Any): Boolean =
     that match {
-      case that: InvokerResourceMessage => {
-        that.canEqual(this) &&
+      case that: InvokerResourceMessage =>
         this.status == that.status &&
-        this.freeMemory == that.freeMemory &&
-        this.busyMemory == that.busyMemory &&
-        this.inProgressMemory == that.inProgressMemory &&
-        this.tags.toSet == that.tags.toSet &&
-        this.dedicatedNamespaces.toSet == that.dedicatedNamespaces.toSet
-      }
+          this.freeMemory == that.freeMemory &&
+          this.busyMemory == that.busyMemory &&
+          this.inProgressMemory == that.inProgressMemory &&
+          this.tags.toSet == that.tags.toSet &&
+          this.dedicatedNamespaces.toSet == that.dedicatedNamespaces.toSet
+
       case _ => false
     }
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/connector/Message.scala
@@ -495,6 +495,7 @@ case class InvokerResourceMessage(status: String,
     result = prime * result + busyMemory.hashCode()
     result = prime * result + inProgressMemory.hashCode()
     result = prime * result + tags.hashCode()
+    result = prime * result + dedicatedNamespaces.hashCode()
     result
   }
 }

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -404,7 +404,7 @@ case class SchedulerStates(sid: SchedulerInstanceId, queueSize: Int, endpoints: 
   override def hashCode: Int = {
     var result = 1
     val prime = 31
-    result = prime * 31 + queueSize.hashCode()
+    result = prime * result + queueSize.hashCode()
     result
   }
 }

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -389,6 +389,24 @@ case class SchedulerStates(sid: SchedulerInstanceId, queueSize: Int, endpoints: 
   def getSchedulerId(): SchedulerInstanceId = sid
 
   def serialize = SchedulerStates.serdes.write(this).compactPrint
+
+  def canEqual(a: Any) = a.isInstanceOf[SchedulerStates]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: SchedulerStates => {
+        that.canEqual(this) &&
+        this.queueSize == that.queueSize
+      }
+      case _ => false
+    }
+
+  override def hashCode: Int = {
+    var result = 1
+    val prime = 31
+    result = prime * 31 + queueSize.hashCode()
+    result
+  }
 }
 
 object SchedulerStates extends DefaultJsonProtocol {

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -390,12 +390,9 @@ case class SchedulerStates(sid: SchedulerInstanceId, queueSize: Int, endpoints: 
 
   def serialize = SchedulerStates.serdes.write(this).compactPrint
 
-  def canEqual(a: Any) = a.isInstanceOf[SchedulerStates]
-
   override def equals(that: Any): Boolean =
     that match {
       case that: SchedulerStates => {
-        that.canEqual(this) &&
         this.queueSize == that.queueSize
       }
       case _ => false

--- a/tests/src/test/scala/org/apache/openwhisk/core/connector/test/MessageTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/connector/test/MessageTests.scala
@@ -1,0 +1,87 @@
+package org.apache.openwhisk.core.connector.test
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.apache.openwhisk.common.InvokerState.{Healthy, Unhealthy}
+import org.apache.openwhisk.core.connector.InvokerResourceMessage
+import org.apache.openwhisk.core.entity.SchedulerInstanceId
+import org.apache.openwhisk.core.scheduler.{SchedulerEndpoints, SchedulerStates}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpecLike, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class MessageTests extends TestKit(ActorSystem("Message")) with FlatSpecLike with Matchers {
+  behavior of "Message"
+
+  it should "be able to compare the InvokerResourceMessage" in {
+    val msg1 = InvokerResourceMessage(Unhealthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+    val msg2 = InvokerResourceMessage(Unhealthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+
+    msg1 == msg2 shouldBe true
+  }
+
+  it should "be different when the state of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Unhealthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+    val msg2 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be different when the free memory of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+    val msg2 = InvokerResourceMessage(Healthy.asString, 2048L, 0, 0, Seq.empty, Seq.empty)
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be different when the busy memory of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+    val msg2 = InvokerResourceMessage(Healthy.asString, 1024L, 1024L, 0, Seq.empty, Seq.empty)
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be different when the in-progress memory of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq.empty)
+    val msg2 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 1024L, Seq.empty, Seq.empty)
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be different when the tags of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq("tag1"), Seq.empty)
+    val msg2 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq("tag1", "tag2"), Seq.empty)
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be different when the dedicated namespaces of InvokerResourceMessage is different" in {
+    val msg1 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq("ns1"))
+    val msg2 = InvokerResourceMessage(Healthy.asString, 1024L, 0, 0, Seq.empty, Seq("ns2"))
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be able to compare the SchedulerStates" in {
+    val msg1 = SchedulerStates(SchedulerInstanceId("0"), queueSize = 0, SchedulerEndpoints("10.10.10.10", 1234, 1234))
+    val msg2 = SchedulerStates(SchedulerInstanceId("0"), queueSize = 0, SchedulerEndpoints("10.10.10.10", 1234, 1234))
+
+    msg1 == msg2 shouldBe true
+  }
+
+  it should "be different when the queue size of SchedulerStates is different" in {
+    val msg1 = SchedulerStates(SchedulerInstanceId("0"), queueSize = 20, SchedulerEndpoints("10.10.10.10", 1234, 1234))
+    val msg2 = SchedulerStates(SchedulerInstanceId("0"), queueSize = 10, SchedulerEndpoints("10.10.10.10", 1234, 1234))
+
+    msg1 != msg2 shouldBe true
+  }
+
+  it should "be not different when other than the queue size of SchedulerStates is different" in {
+    // only the queue size matter
+    val msg1 = SchedulerStates(SchedulerInstanceId("0"), queueSize = 20, SchedulerEndpoints("10.10.10.10", 1234, 1234))
+    val msg2 = SchedulerStates(SchedulerInstanceId("1"), queueSize = 20, SchedulerEndpoints("10.10.10.20", 5678, 5678))
+
+    msg1 == msg2 shouldBe true
+  }
+}


### PR DESCRIPTION
## Description
Schedulers and invokers periodically publish their states to ETCD but when no data is changed, we don't need to keep sending the same request to ETCD.
This is not to put data to ETCD when no data is changed.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [x] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

