### PR TITLE
Dedicated Invokers

### DIFF
--- a/ansible/roles/invoker/tasks/deploy.yml
+++ b/ansible/roles/invoker/tasks/deploy.yml
@@ -283,6 +283,7 @@
       "CONFIG_whisk_invoker_https_keystoreFlavor": "{{ invoker.ssl.storeFlavor }}"
       "CONFIG_whisk_invoker_https_clientAuth": "{{ invoker.ssl.clientAuth }}"
       "CONFIG_whisk_invoker_resource_tags": "{% if tags is defined %} '{{ tags | join(',') }}' {% else %} '' {% endif %}"
+      "CONFIG_whisk_invoker_dedicated_namespaces": "{% if dedicatedNamespaces is defined %} '{{ dedicatedNamespaces | join(',') }}' {% else %} '' {% endif %}"
       "CONFIG_whisk_containerProxy_timeouts_idleContainer": "{{ whisk.containerProxy.timeouts.idleContainer }}"
       "CONFIG_whisk_containerProxy_timeouts_pauseGrace": "{{ whisk.containerProxy.timeouts.pauseGrace  }}"
       "CONFIG_whisk_containerProxy_timeouts_keepingDuration": "{{ whisk.containerProxy.timeouts.keepingDuration }}"

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/WhiskConfig.scala
@@ -319,4 +319,5 @@ object ConfigKeys {
   val whiskInvokerPassword = "whisk.invoker.password"
 
   val invokerResourceTags = "whisk.invoker.resource.tags"
+  val invokerDedicatedNamespaces = "whisk.invoker.dedicated.namespaces"
 }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -114,6 +114,11 @@ object Invoker {
       .filter(_ != "")
       .map(_.split(",").toSeq)
       .getOrElse(Seq.empty[String])
+    val dedicatedNamespaces: Seq[String] = Some(loadConfigOrThrow[String](ConfigKeys.invokerDedicatedNamespaces))
+      .map(_.trim())
+      .filter(_ != "")
+      .map(_.split(",").toSeq)
+      .getOrElse(Seq.empty[String])
 
     logger.info(this, s"invoker tags: (${tags.mkString(", ")})")
     // Prepare Kamon shutdown
@@ -202,7 +207,8 @@ object Invoker {
         cmdLineArgs.displayedName,
         poolConfig.userMemory,
         None,
-        tags)
+        tags,
+        dedicatedNamespaces)
 
     val msgProvider = SpiLoader.get[MessagingProvider]
     if (msgProvider

--- a/docs/dedicated-invokers.md
+++ b/docs/dedicated-invokers.md
@@ -1,0 +1,40 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+# Dedicated Invokers
+
+Actions run on any invokers in OpenWhisk. But users may want to run their actions on a certain invoker(s) for some reason such as IP-based ACL.
+This is to provide dedicated invokers for a namespace. Operators can configure a dedicated namespace for invokers and all activations from the namespace will be delivered to the dedicated invokers only.
+
+## Tagging Invokers
+Operators can configure any tags for invokers.
+
+```bash
+invoker0 ansible_host=${INVOKER01} tags="['dedicated']" dedicatedNamespaces="['namespace1']"
+invoker1 ansible_host=${INVOKER02} tags="['dedicated']" dedicatedNamespaces="['namespace2']"
+```
+
+Users can add the following annotations to their actions.
+
+```
+wsk action update params tests/dat/actions/params.js -i -a invoker-resources '["dedicated"]'
+```
+
+So this feature is based on the [tag-based-scheduling](./tag-based-scheduling.md).
+The `dedicatedNamespaces` field is used to make sure the invokers are not used by other than allowed namespaces and users can decide whether to run their actions on dedicated invokers using the `dedicated` tag.


### PR DESCRIPTION

## Description
Actions run on any invokers in OpenWhisk. But users may want to run their actions on a certain invoker(s) for some reason such as IP-based ACL.
This is to provide dedicated invokers for a namespace. Operators can configure a dedicated namespace for invokers and all activations from the namespace will be delivered to the dedicated invokers only.

```
invoker0 ansible_host=${INVOKER01} tags="['dedicated']" dedicatedNamespaces="['namespace1']"
invoker1 ansible_host=${INVOKER02} tags="['dedicated']" dedicatedNamespaces="['namespace2']"
```

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

