### PR TITLE
Add fake clock for test code

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/time/Clock.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/time/Clock.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.openwhisk.common.time
+
+import java.time.Instant
+
+trait Clock {
+  def now(): Instant
+}
+
+object SystemClock extends Clock {
+  def now() = Instant.now()
+}

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
@@ -33,6 +33,7 @@ import com.ibm.etcd.client.kv.WatchUpdate
 import com.ibm.etcd.client.{EtcdClient => Client}
 import com.sksamuel.elastic4s.http.ElasticClient
 import common.StreamLogging
+import org.apache.openwhisk.common.time.SystemClock
 import org.apache.openwhisk.common.{GracefulShutdown, TransactionId}
 import org.apache.openwhisk.core.ack.ActiveAck
 import org.apache.openwhisk.core.connector._
@@ -136,6 +137,7 @@ class MemoryQueueTests
   behavior of "MemoryQueue"
 
   it should "register the endpoint when initializing" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val prove = TestProbe()
     val watcher = TestProbe()
@@ -192,6 +194,7 @@ class MemoryQueueTests
   }
 
   it should "go to Flushing state if any error happens when the queue is depreacted" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val prove = TestProbe()
     val watcher = TestProbe()
@@ -252,6 +255,7 @@ class MemoryQueueTests
   }
 
   it should "go to the Running state without storing any data if it receives VersionUpdated" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val prove = TestProbe()
     val watcher = TestProbe()
@@ -308,6 +312,7 @@ class MemoryQueueTests
   }
 
   it should "remove the queue when timeout occurs" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val parent = TestProbe()
     val dataManagementService = TestProbe()
@@ -380,6 +385,7 @@ class MemoryQueueTests
   }
 
   it should "back to Running state when got new ActivationMessage when in Idle State" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val prove = TestProbe()
     val watcher = TestProbe()
@@ -459,6 +465,7 @@ class MemoryQueueTests
   }
 
   it should "back to Running state when got new ActivationMessage when in Removed State" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val prove = TestProbe()
     val watcher = TestProbe()
@@ -530,6 +537,7 @@ class MemoryQueueTests
   }
 
   it should "store the received ActivationMessage in the queue" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = new MockEtcdClient(client, isLeader = true)
     val prove = TestProbe()
 
@@ -571,6 +579,7 @@ class MemoryQueueTests
   }
 
   it should "send a ActivationMessage in response to GetActivation" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val tid = TransactionId(TransactionId.generateTid())
@@ -611,6 +620,7 @@ class MemoryQueueTests
   }
 
   it should "send NoActivationMessage in case there is no message in the queue" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val tid = TransactionId(TransactionId.generateTid())
@@ -650,6 +660,7 @@ class MemoryQueueTests
   }
 
   it should "poll for the ActivationMessage in case there is no message in the queue" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val tid = TransactionId(TransactionId.generateTid())
@@ -698,6 +709,7 @@ class MemoryQueueTests
   }
 
   it should "not send msg to a deleted container" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val tid = TransactionId(TransactionId.generateTid())
@@ -752,6 +764,7 @@ class MemoryQueueTests
   }
 
   it should "send response to request according to the order of container id and warmed flag" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val tid = TransactionId(TransactionId.generateTid())
@@ -819,6 +832,7 @@ class MemoryQueueTests
   }
 
   it should "send a container creation request to ContainerManager at initialization time" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val containerManger = TestProbe()
     val probe = TestProbe()
@@ -888,6 +902,7 @@ class MemoryQueueTests
   }
 
   it should "complete error activation while received FailedCreationJob and the error is not a whisk error(unrecoverable)" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val testProbe = TestProbe()
     val parent = TestProbe()
@@ -968,6 +983,7 @@ class MemoryQueueTests
   }
 
   it should "complete error activation after timeout while received FailedCreationJob and the error is a whisk error(recoverable)" in {
+    implicit val clock = new FakeClock
     val mockEtcdClient = mock[EtcdClient]
     val testProbe = TestProbe()
     val decisionMaker = TestProbe()
@@ -1024,11 +1040,15 @@ class MemoryQueueTests
     parent.expectNoMessage(5.seconds)
 
     // Add 3 more messages.
+    clock.plusSeconds(5)
     (1 to expectedCount).foreach(_ => fsm ! message)
     parent.expectNoMessage(5.seconds)
 
     // After 10 seconds(action retention timeout), the first 3 messages are timed out.
     // It does not get removed as there are still 3 messages in the queue.
+    clock.plusSeconds(5)
+    fsm ! DropOld
+
     awaitAssert({
       ackedMessageCount shouldBe 3
       lastAckedActivationResult.response.result shouldBe Some(JsObject("error" -> JsString("no available invokers")))
@@ -1052,7 +1072,8 @@ class MemoryQueueTests
     parent.expectMsg(Transition(fsm, Running, Flushing))
 
     // wait for the flush grace, and then all existing activations will be flushed
-    Thread.sleep(queueConfig.maxBlackboxRetentionMs + queueConfig.flushGrace.toMillis)
+    clock.plusSeconds((queueConfig.maxBlackboxRetentionMs + queueConfig.flushGrace.toMillis) / 1000)
+    fsm ! DropOld
 
     // The error message is updated from the recent error message of the FailedCreationJob.
     awaitAssert({
@@ -1072,6 +1093,7 @@ class MemoryQueueTests
   }
 
   it should "send old version activation to queueManager when update action if doesn't exist old version container" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val queueManager = TestProbe()
@@ -1114,6 +1136,7 @@ class MemoryQueueTests
   }
 
   it should "fetch old version activation by old container when update action" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val probe = TestProbe()
     val queueManager = TestProbe()
@@ -1159,6 +1182,7 @@ class MemoryQueueTests
   }
 
   it should "complete error activation after blackbox timeout when the action is a blackbox action and received FailedCreationJob with a whisk error(recoverable)" in {
+    implicit val clock = new FakeClock
     val mockEtcdClient = mock[EtcdClient]
     val testProbe = TestProbe()
     val decisionMaker = TestProbe()
@@ -1246,7 +1270,8 @@ class MemoryQueueTests
     fsm ! message
 
     // wait for the flush grace, and then some existing activations will be flushed
-    Thread.sleep(queueConfig.maxBlackboxRetentionMs + queueConfig.flushGrace.toMillis)
+    clock.plusSeconds((queueConfig.maxBlackboxRetentionMs + queueConfig.flushGrace.toMillis) / 1000)
+    fsm ! DropOld
     (1 to expectedCount).foreach(_ => probe.expectMsg(ActivationResponse.whiskError("no available invokers")))
 
     val duration = FiniteDuration(queueConfig.maxBlackboxRetentionMs, MILLISECONDS) + queueConfig.flushGrace
@@ -1262,6 +1287,7 @@ class MemoryQueueTests
   }
 
   it should "stop scheduling if the namespace does not exist" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val getZeroLimit = (_: String) => { Future.failed(NoDocumentException("namespace does not exist")) }
     val testProbe = TestProbe()
@@ -1302,10 +1328,11 @@ class MemoryQueueTests
     parent.expectMsg(10 seconds, CurrentState(fsm, Uninitialized))
     parent.expectMsg(10 seconds, Transition(fsm, Uninitialized, Running))
 
-    Thread.sleep(idleGrace.toMillis)
-
-    parent expectMsg QueueRemoved(testInvocationNamespace, fqn.toDocId.asDocInfo(revision), None)
-    parent.expectMsg(10 seconds, Transition(fsm, Running, Removing))
+    fsm ! StopSchedulingAsOutdated
+    parent expectMsgAllOf (10 seconds, Transition(fsm, Running, Removing), QueueRemoved(
+      testInvocationNamespace,
+      fqn.toDocId.asDocInfo(revision),
+      None))
 
     fsm ! QueueRemovedCompleted
     parent.expectMsg(10 seconds, Transition(fsm, Removing, Removed))
@@ -1314,6 +1341,7 @@ class MemoryQueueTests
   }
 
   it should "throttle the namespace when the limit is already reached" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val dataManagementService = TestProbe()
     val probe = TestProbe()
@@ -1364,6 +1392,7 @@ class MemoryQueueTests
   }
 
   it should "disable namespace throttling when the capacity become available" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val dataManagementService = TestProbe()
     val probe = TestProbe()
@@ -1425,6 +1454,7 @@ class MemoryQueueTests
   }
 
   it should "throttle the action when the number of messages reaches the limit" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val dataManagementService = TestProbe()
     val probe = TestProbe()
@@ -1473,6 +1503,7 @@ class MemoryQueueTests
   }
 
   it should "disable action throttling when the number of messages is under throttling fraction" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
     val dataManagementService = TestProbe()
     val probe = TestProbe()
@@ -1531,6 +1562,7 @@ class MemoryQueueTests
   }
 
   it should "update the number of containers based on Watch event" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = new MockEtcdClient(client, true)
     val probe = TestProbe()
     val watcher = system.actorOf(WatcherService.props(mockEtcdClient))
@@ -1574,7 +1606,7 @@ class MemoryQueueTests
     val newRevision = DocRevision("2-testRev")
 
     memoryQueue.containers.size shouldBe 0
-    memoryQueue.creationIds.size shouldBe 0
+    memoryQueue.creationIds.count(_.startsWith("testId")) shouldBe 0
     memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 0
     memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 0
 
@@ -1611,13 +1643,12 @@ class MemoryQueueTests
         Some(ContainerId("test-containerId2"))),
       "test-value")
 
-    Thread.sleep(1000)
-    memoryQueue.containers.size shouldBe 1
-    // the monit actor in memoryQueue may decide to create a container
-    memoryQueue.creationIds.size should be >= 1
-    memoryQueue.creationIds.size should be <= 2
-    memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 2
-    memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 2
+    awaitAssert({
+      memoryQueue.containers.size shouldBe 1 // ['test-containerId1']
+      memoryQueue.creationIds.count(_.startsWith("testId")) shouldBe 1 // ['testId1']
+      memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 2
+      memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 2
+    }, 5.seconds)
 
     mockEtcdClient.publishEvents(
       EventType.PUT,
@@ -1650,12 +1681,12 @@ class MemoryQueueTests
         Some(ContainerId("test-containerId4"))),
       "test-value")
 
-    Thread.sleep(1000)
-    memoryQueue.containers.size shouldBe 2
-    memoryQueue.creationIds.size should be >= 2
-    memoryQueue.creationIds.size should be <= 3
-    memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 4
-    memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 4
+    awaitAssert({
+      memoryQueue.containers.size shouldBe 2 // ['test-containerId1', 'test-containerId3']
+      memoryQueue.creationIds.count(_.startsWith("testId")) shouldBe 2 // ['testId1', 'testId3']
+      memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 4
+      memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 4
+    }, 5.seconds)
 
     mockEtcdClient.publishEvents(
       EventType.DELETE,
@@ -1678,12 +1709,12 @@ class MemoryQueueTests
       inProgressContainer(testInvocationNamespace, newFqn, newRevision, schedulerId, CreationId("testId4")),
       "test-value")
 
-    Thread.sleep(1000)
-    memoryQueue.containers.size shouldBe 2
-    memoryQueue.creationIds.size should be >= 0
-    memoryQueue.creationIds.size should be <= 1
-    memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 0
-    memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 4
+    awaitAssert({
+      memoryQueue.containers.size shouldBe 2 // ['test-containerId1', 'test-containerId3']
+      memoryQueue.creationIds.count(_.startsWith("testId")) shouldBe 0
+      memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 0
+      memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 4
+    }, 5.seconds)
 
     mockEtcdClient.publishEvents(
       EventType.DELETE,
@@ -1726,15 +1757,12 @@ class MemoryQueueTests
         Some(ContainerId("test-containerId4"))),
       "test-value")
 
-    memoryQueue.creationIds.size should be >= 0
-    memoryQueue.creationIds.size should be <= 1
-
-    Thread.sleep(1000)
-    memoryQueue.containers.size shouldBe 0
-    memoryQueue.creationIds.size should be >= 1 // if there is no container, the queue tries to create one container
-    memoryQueue.creationIds.size should be <= 2
-    memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 0
-    memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 0
+    awaitAssert({
+      memoryQueue.containers.size shouldBe 0
+      memoryQueue.creationIds.count(_.startsWith("testId")) shouldBe 0
+      memoryQueue.namespaceContainerCount.inProgressContainerNumByNamespace shouldBe 0
+      memoryQueue.namespaceContainerCount.existingContainerNumByNamespace shouldBe 0
+    }, 5.seconds)
   }
 
   private def getData(states: List[MemoryQueueState]) = {
@@ -1749,6 +1777,7 @@ class MemoryQueueTests
     (schedulingActors, droppingActors, data)
   }
   it should "clean up throttling data when it stops gracefully" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
 
     val dataManagementService = TestProbe()
@@ -1815,7 +1844,8 @@ class MemoryQueueTests
   it should "drop the old activation from the queue" in {
     var queue = Queue.empty[TimeSeriesActivationEntry]
 
-    val now = Instant.now
+    val clock = new FakeClock
+    val now = clock.now()
     val records = List(
       TimeSeriesActivationEntry(Instant.ofEpochMilli(now.toEpochMilli + 1000), message),
       TimeSeriesActivationEntry(Instant.ofEpochMilli(now.toEpochMilli + 2000), message),
@@ -1826,10 +1856,10 @@ class MemoryQueueTests
     )
 
     records.foreach(record => queue = queue.enqueue(record))
-
-    Thread.sleep(5000)
+    clock.plusSeconds(5)
 
     queue = MemoryQueue.dropOld(
+      clock,
       queue,
       java.time.Duration.ofMillis(1000),
       "activation processing is not initiated for 1000 ms",
@@ -1843,6 +1873,7 @@ class MemoryQueueTests
 
     noException should be thrownBy {
       queue = MemoryQueue.dropOld(
+        SystemClock,
         queue,
         java.time.Duration.ofMillis(1000),
         "activation processing is not initiated for 1000 ms",
@@ -1853,6 +1884,7 @@ class MemoryQueueTests
   behavior of "duration checker"
 
   it should "check the duration once" in {
+    implicit val clock = SystemClock
     val mockEtcdClient = mock[EtcdClient]
 
     val dataManagementService = TestProbe()


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
There is an issue that the test results are different depending on the performance of the build machine because the test code is written in a time-dependent. This PR improves memory queue test code that fails like heisenbug.

- Use fake clock to improve time-dependent test code execution time.
  - The memory queue test execution time was reduced from 7m3s -> 1m34s in downstream environment.
- Remove thread sleep and explicitly calls StateTimeout.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] Scheduler
- [x] Tests

## Types of changes
- [x] Enhancement or new feature (adds new functionality).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

