### PR TITLE
Fix runtime return type backward compatibility

### DIFF
--- a/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
+++ b/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala
@@ -173,7 +173,9 @@ trait BasicActionRunnerTests extends ActionProxyContainerTestUtils {
         initCode should be(200)
         val (runCode, out) = c.run(JsObject.empty)
         runCode should not be (200)
-        out should be(Some(JsObject("error" -> JsString("The action did not return a dictionary or array."))))
+
+        out should (be(Some(JsObject("error" -> JsString("The action did not return a dictionary or array.")))) or be(
+          Some(JsObject("error" -> JsString("The action did not return a dictionary.")))))
       }
 
       checkStreams(out, err, {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
Some downstream runtimes may not support the array return type. 
(This also happens when using a legacy action loop base.)

In this case, test case will fail and you will be inconvenient for maintaining. 
I think it is should be preserved backward compatibility.

## Related issue and scope
https://github.com/apache/openwhisk/pull/5290

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [x] Tests

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [ ] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [ ] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

