### PR TITLE
bump java etcd client to 0.0.21

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     api "io.kamon:kamon-datadog_${gradle.scala.depVersion}:2.1.12"
 
     // for etcd
-    api "com.ibm.etcd:etcd-java:0.0.13"
+    api "com.ibm.etcd:etcd-java:0.0.21"
 
     //tracing support
     api "io.opentracing:opentracing-api:0.31.0"


### PR DESCRIPTION
## Description
Current etcd client version is from 2019. Bump to latest patch version.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

