### PR TITLE
add config to mask docker run args when logging

### DIFF
--- a/core/invoker/src/main/resources/application.conf
+++ b/core/invoker/src/main/resources/application.conf
@@ -33,6 +33,9 @@ whisk {
     # 0 means that there are infinite parallel runs.
     parallel-runs: 10
 
+    # hide args passed into docker run command when logging docker run command
+    mask-docker-run-args: false
+
     # Timeouts for docker commands. Set to "Inf" to disable timeout.
     timeouts {
       run: 1 minute

--- a/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
+++ b/core/standalone/src/main/scala/org/apache/openwhisk/standalone/StandaloneDockerSupport.scala
@@ -211,8 +211,9 @@ class StandaloneDockerClient(pullDisabled: Boolean)(implicit log: Logging, as: A
     if (pullDisabled) Future.successful(()) else super.pull(image)
   }
 
-  override def runCmd(args: Seq[String], timeout: Duration)(implicit transid: TransactionId): Future[String] =
-    super.runCmd(args, timeout)
+  override def runCmd(args: Seq[String], timeout: Duration, maskedArgs: Option[Seq[String]] = None)(
+    implicit transid: TransactionId): Future[String] =
+    super.runCmd(args, timeout, maskedArgs)
 
   val clientConfig: DockerClientConfig = loadConfigOrThrow[DockerClientConfig](ConfigKeys.dockerClient)
 


### PR DESCRIPTION
## Description
If additional args are added as the operator, you may not want those args exposed in logging. This gives the operator the option to just all up mask the args of the docker run command while still logging that the docker run occurred for the image.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

