### PR TITLE
Revert etcd client version

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     api "io.kamon:kamon-datadog_${gradle.scala.depVersion}:2.1.12"
 
     // for etcd
-    api "com.ibm.etcd:etcd-java:0.0.21"
+    api "com.ibm.etcd:etcd-java:0.0.13"
 
     //tracing support
     api "io.opentracing:opentracing-api:0.31.0"


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
This is to fix https://github.com/apache/openwhisk/issues/5317 by reverting https://github.com/apache/openwhisk/commit/40077664ab3011e7a333b0197fa9a285502a1d81.
It seems the version of gprc-core module in the ETCD client conflicts with akka-grpc module.

I am curious how it passed all checks in the first place, but anyway it would be the easiest way to resolve it for now.

I think we need to upgrade both modules at once.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

