### PR TITLE
add error handling to container manager when invoker query fails

### DIFF
--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/container/ContainerManager.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/container/ContainerManager.scala
@@ -144,6 +144,11 @@ class ContainerManager(jobManagerFactory: ActorRefFactory => ActorRef,
     logging.info(this, s"received ${msgs.size} creation message [${msgs.head.invocationNamespace}:${msgs.head.action}]")
     ContainerManager
       .getAvailableInvokers(etcdClient, memory, invocationNamespace)
+      .recover({
+        case t: Throwable =>
+          logging.error(this, s"Unable to get available invokers: ${t.getMessage}.")
+          List.empty[InvokerHealth]
+      })
       .foreach { invokers =>
         if (invokers.isEmpty) {
           logging.error(this, "there is no available invoker to schedule.")

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/container/test/ContainerManagerTests.scala
@@ -864,7 +864,7 @@ class ContainerManagerTests
       ScheduledPair(msg4, None, Some(NoAvailableInvokersError)))
   }
 
-  it should "send FailedCreationJob to queue manager when no invokers are available" in {
+  it should "send FailedCreationJob to memory queue when no invokers are available" in {
     val mockEtcd = mock[EtcdClient]
     val probe = TestProbe()
     (mockEtcd
@@ -910,13 +910,14 @@ class ContainerManagerTests
         NoAvailableInvokersError))
   }
 
-  it should "send FailedCreationJob to queue manager when available invoker query fails" in {
+  it should "send FailedCreationJob to memory queue when available invoker query fails" in {
     val mockEtcd = mock[EtcdClient]
     val probe = TestProbe()
     (mockEtcd
       .getPrefix(_: String))
       .expects(InvokerKeys.prefix)
       .returning(Future.failed(new Exception("etcd request failed.")))
+      .twice()
 
     val fqn = FullyQualifiedEntityName(EntityPath("ns1"), EntityName(testAction))
 


### PR DESCRIPTION
## Description
There is no failure handling if the query to etcd for list of healthy invokers fails. The container manager swallows the message and the memory queue will never hear back the status of the container creation.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

