### PR TITLE
Clean Up Etcd Worker Actor

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdClient.scala
@@ -25,10 +25,10 @@ import com.ibm.etcd.client.{EtcdClient => Client}
 import io.grpc.stub.StreamObserver
 import java.util.concurrent.Executors
 
-import org.apache.openwhisk.core.ConfigKeys
+//import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.etcd.EtcdType._
 import org.apache.openwhisk.core.service.Lease
-import pureconfig.loadConfigOrThrow
+//import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol
 
 import scala.language.implicitConversions
@@ -49,10 +49,10 @@ object RichListenableFuture {
 object EtcdClient {
   // hostAndPorts format: {HOST}:{PORT}[,{HOST}:{PORT},{HOST}:{PORT}, ...]
   def apply(config: EtcdConfig)(implicit ece: ExecutionContextExecutor): EtcdClient = {
-    require(config.hosts != null)
+    //require(config.hosts != null)
     require(
       (config.username.nonEmpty && config.password.nonEmpty) || (config.username.isEmpty && config.password.isEmpty))
-    val clientBuilder = Client.forEndpoints(config.hosts).withPlainText()
+    val clientBuilder = Client.forEndpoints("testHosts").withPlainText()
     if (config.username.nonEmpty && config.password.nonEmpty) {
       new EtcdClient(clientBuilder.withCredentials(config.username.get, config.password.get).build())
     } else {
@@ -183,7 +183,7 @@ trait EtcdLeaseApi {
 }
 
 trait EtcdWatchApi {
-  val nThreads = loadConfigOrThrow[Int](ConfigKeys.etcdPoolThreads)
+  val nThreads = 10
   val threadpool = Executors.newFixedThreadPool(nThreads);
   protected[etcd] val client: Client
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdClient.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdClient.scala
@@ -25,10 +25,10 @@ import com.ibm.etcd.client.{EtcdClient => Client}
 import io.grpc.stub.StreamObserver
 import java.util.concurrent.Executors
 
-//import org.apache.openwhisk.core.ConfigKeys
+import org.apache.openwhisk.core.ConfigKeys
 import org.apache.openwhisk.core.etcd.EtcdType._
 import org.apache.openwhisk.core.service.Lease
-//import pureconfig.loadConfigOrThrow
+import pureconfig.loadConfigOrThrow
 import spray.json.DefaultJsonProtocol
 
 import scala.language.implicitConversions
@@ -49,10 +49,10 @@ object RichListenableFuture {
 object EtcdClient {
   // hostAndPorts format: {HOST}:{PORT}[,{HOST}:{PORT},{HOST}:{PORT}, ...]
   def apply(config: EtcdConfig)(implicit ece: ExecutionContextExecutor): EtcdClient = {
-    //require(config.hosts != null)
+    require(config.hosts != null)
     require(
       (config.username.nonEmpty && config.password.nonEmpty) || (config.username.isEmpty && config.password.isEmpty))
-    val clientBuilder = Client.forEndpoints("testHosts").withPlainText()
+    val clientBuilder = Client.forEndpoints(config.hosts).withPlainText()
     if (config.username.nonEmpty && config.password.nonEmpty) {
       new EtcdClient(clientBuilder.withCredentials(config.username.get, config.password.get).build())
     } else {
@@ -183,7 +183,7 @@ trait EtcdLeaseApi {
 }
 
 trait EtcdWatchApi {
-  val nThreads = 10
+  val nThreads = loadConfigOrThrow[Int](ConfigKeys.etcdPoolThreads)
   val threadpool = Executors.newFixedThreadPool(nThreads);
   protected[etcd] val client: Client
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdWorker.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/etcd/EtcdWorker.scala
@@ -1,0 +1,166 @@
+package org.apache.openwhisk.core.etcd
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Timers}
+import io.grpc.StatusRuntimeException
+import org.apache.openwhisk.common.Logging
+import org.apache.openwhisk.core.etcd.EtcdWorker.GetLeaseAndRetry
+import org.apache.openwhisk.core.service.DataManagementService.retryInterval
+import org.apache.openwhisk.core.service.{
+  AlreadyExist,
+  Done,
+  ElectLeader,
+  ElectionResult,
+  FinishWork,
+  GetLease,
+  InitialDataStorageResults,
+  Lease,
+  RegisterData,
+  RegisterInitialData,
+  WatcherClosed
+}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Success
+
+class EtcdWorker(etcdClient: EtcdClient, leaseService: ActorRef)(implicit val ec: ExecutionContext,
+                                                                 actorSystem: ActorSystem,
+                                                                 logging: Logging)
+    extends Actor
+    with Timers {
+
+  private val dataManagementService = context.parent
+  private var lease: Option[Lease] = None
+  leaseService ! GetLease
+
+  override def receive: Receive = {
+    case msg: Lease =>
+      lease = Some(msg)
+    case msg: GetLeaseAndRetry =>
+      logging.warn(this, msg.log)
+      if (!msg.skipLeaseRefresh) {
+        if (msg.clearLease) {
+          lease = None
+        }
+        leaseService ! GetLease
+      }
+      sendMessageToSelfAfter(msg.request, retryInterval)
+    // leader election + endpoint management
+    case request: ElectLeader =>
+      lease match {
+        case Some(l) =>
+          etcdClient
+            .electLeader(request.key, request.value, l)
+            .andThen {
+              case Success(msg) =>
+                request.recipient ! ElectionResult(msg)
+                dataManagementService ! FinishWork(request.key)
+            }
+            .recover {
+              // if there is no lease, reissue it and retry immediately
+              case t: StatusRuntimeException =>
+                self ! GetLeaseAndRetry(request, s"a lease is expired while leader election, reissue it: $t")
+              // it should retry forever until the data is stored
+              case t: Throwable =>
+                self ! GetLeaseAndRetry(
+                  request,
+                  s"unexpected error happened: $t, retry storing data",
+                  skipLeaseRefresh = true)
+            }
+        case None =>
+          self ! GetLeaseAndRetry(request, s"lease not found, retry storing data ${request.key}", clearLease = false)
+      }
+
+    // only endpoint management
+    case request: RegisterData =>
+      lease match {
+        case Some(l) =>
+          etcdClient
+            .put(request.key, request.value, l.id)
+            .andThen {
+              case Success(_) =>
+                dataManagementService ! FinishWork(request.key)
+            }
+            .recover {
+              // if there is no lease, reissue it and retry immediately
+              case t: StatusRuntimeException =>
+                self ! GetLeaseAndRetry(
+                  request,
+                  s"a lease is expired while registering data ${request.key}, reissue it: $t")
+              // it should retry forever until the data is stored
+              case t: Throwable =>
+                self ! GetLeaseAndRetry(
+                  request,
+                  s"unexpected error happened: $t, retry storing data ${request.key}",
+                  skipLeaseRefresh = true)
+            }
+        case None =>
+          self ! GetLeaseAndRetry(request, s"lease not found, retry storing data ${request.key}", clearLease = false)
+      }
+    // it stores the data iif there is no such one
+    case request: RegisterInitialData =>
+      lease match {
+        case Some(l) =>
+          etcdClient
+            .putTxn(request.key, request.value, 0, l.id)
+            .map { res =>
+              dataManagementService ! FinishWork(request.key)
+              if (res.getSucceeded) {
+                logging.info(this, s"initial data storing succeeds for ${request.key}")
+                request.recipient.map(_ ! InitialDataStorageResults(request.key, Right(Done())))
+              } else {
+                logging.info(this, s"data is already stored for: $request, cancel the initial data storing")
+                request.recipient.map(_ ! InitialDataStorageResults(request.key, Left(AlreadyExist())))
+              }
+            }
+            .recover {
+              // if there is no lease, reissue it and retry immediately
+              case t: StatusRuntimeException =>
+                self ! GetLeaseAndRetry(
+                  request,
+                  s"a lease is expired while registering an initial data ${request.key}, reissue it: $t")
+              // it should retry forever until the data is stored
+              case t: Throwable =>
+                self ! GetLeaseAndRetry(
+                  request,
+                  s"unexpected error happened: $t, retry storing data ${request.key}",
+                  skipLeaseRefresh = true)
+            }
+        case None =>
+          self ! GetLeaseAndRetry(request, s"lease not found, retry storing data ${request.key}", clearLease = false)
+      }
+
+    case msg: WatcherClosed =>
+      etcdClient
+        .del(msg.key)
+        .andThen {
+          case Success(_) =>
+            dataManagementService ! FinishWork(msg.key)
+        }
+        .recover {
+          // if there is no lease, reissue it and retry immediately
+          case t: StatusRuntimeException =>
+            self ! GetLeaseAndRetry(msg, s"a lease is expired while deleting data ${msg.key}, reissue it: $t")
+          // it should retry forever until the data is stored
+          case t: Throwable =>
+            self ! GetLeaseAndRetry(
+              msg,
+              s"unexpected error happened: $t, retry storing data for ${msg.key}",
+              skipLeaseRefresh = true)
+        }
+  }
+
+  private def sendMessageToSelfAfter(msg: Any, retryInterval: FiniteDuration) = {
+    timers.startSingleTimer(msg, msg, retryInterval)
+  }
+}
+
+object EtcdWorker {
+  case class GetLeaseAndRetry(request: Any, log: String, clearLease: Boolean = true, skipLeaseRefresh: Boolean = false)
+
+  def props(etcdClient: EtcdClient, leaseService: ActorRef)(implicit ec: ExecutionContext,
+                                                            actorSystem: ActorSystem,
+                                                            logging: Logging): Props = {
+    Props(new EtcdWorker(etcdClient, leaseService))
+  }
+}

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -37,10 +37,10 @@ import org.apache.openwhisk.core.etcd.EtcdKV.ContainerKeys.containerPrefix
 import org.apache.openwhisk.core.etcd.EtcdKV.QueueKeys.queue
 import org.apache.openwhisk.core.etcd.EtcdKV.{ContainerKeys, SchedulerKeys}
 import org.apache.openwhisk.core.etcd.EtcdType._
-import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig}
+import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig, EtcdWorker}
 import org.apache.openwhisk.core.invoker.Invoker.InvokerEnabled
 import org.apache.openwhisk.core.scheduler.{SchedulerEndpoints, SchedulerStates}
-import org.apache.openwhisk.core.service.{DataManagementService, EtcdWorker, LeaseKeepAliveService, WatcherService}
+import org.apache.openwhisk.core.service.{DataManagementService, LeaseKeepAliveService, WatcherService}
 import org.apache.openwhisk.core.{ConfigKeys, WarmUp, WhiskConfig}
 import org.apache.openwhisk.grpc.{ActivationServiceClient, FetchRequest}
 import org.apache.openwhisk.spi.SpiLoader

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -34,11 +34,11 @@ import org.apache.openwhisk.core.database.{ActivationStoreProvider, NoDocumentEx
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.etcd.EtcdKV.{QueueKeys, SchedulerKeys}
 import org.apache.openwhisk.core.etcd.EtcdType.ByteStringToString
-import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig}
+import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdConfig, EtcdWorker}
 import org.apache.openwhisk.core.scheduler.container.{ContainerManager, CreationJobManager}
 import org.apache.openwhisk.core.scheduler.grpc.ActivationServiceImpl
 import org.apache.openwhisk.core.scheduler.queue._
-import org.apache.openwhisk.core.service.{DataManagementService, EtcdWorker, LeaseKeepAliveService, WatcherService}
+import org.apache.openwhisk.core.service.{DataManagementService, LeaseKeepAliveService, WatcherService}
 import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.grpc.ActivationServiceHandler
 import org.apache.openwhisk.http.BasicHttpService

--- a/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdWorkerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdWorkerTests.scala
@@ -159,7 +159,7 @@ class EtcdWorkerTests
     (mockEtcd
       .del(_: String))
       .expects(key)
-      .onCall(_ => {
+      .onCall((_: String) => {
         if (firstAttempt) {
           firstAttempt = false
           Future.failed(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED))

--- a/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdWorkerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/common/etcd/EtcdWorkerTests.scala
@@ -1,0 +1,176 @@
+package org.apache.openwhisk.common.etcd
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{ImplicitSender, TestActor, TestActorRef, TestKit, TestProbe}
+import akka.util.Timeout
+import com.ibm.etcd.api.{DeleteRangeResponse, PutResponse, TxnResponse}
+import common.StreamLogging
+import io.grpc.{Status, StatusRuntimeException}
+import org.apache.openwhisk.core.entity.SchedulerInstanceId
+import org.apache.openwhisk.core.etcd.{EtcdClient, EtcdLeader, EtcdWorker}
+import org.apache.openwhisk.core.service.{
+  AlreadyExist,
+  Done,
+  ElectLeader,
+  ElectionResult,
+  FinishWork,
+  GetLease,
+  InitialDataStorageResults,
+  Lease,
+  RegisterData,
+  RegisterInitialData,
+  WatcherClosed
+}
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+@RunWith(classOf[JUnitRunner])
+class EtcdWorkerTests
+    extends TestKit(ActorSystem("EtcdWorker"))
+    with ImplicitSender
+    with FlatSpecLike
+    with ScalaFutures
+    with Matchers
+    with MockFactory
+    with BeforeAndAfterAll
+    with StreamLogging {
+
+  implicit val timeout: Timeout = Timeout(5.seconds)
+  implicit val ec: ExecutionContext = system.dispatcher
+  val leaseService = TestProbe()
+  val leaseId = 10
+  val leaseTtl = 10
+  leaseService.setAutoPilot((sender: ActorRef, msg: Any) =>
+    msg match {
+      case GetLease =>
+        sender ! Lease(leaseId, leaseTtl)
+        TestActor.KeepRunning
+
+      case _ =>
+        TestActor.KeepRunning
+  })
+
+  //val dataManagementService = TestProbe()
+  val schedulerId = SchedulerInstanceId("scheduler0")
+  val instanceId = schedulerId
+
+  behavior of "EtcdWorker"
+
+  it should "elect leader and send completion ack to parent" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val leader = Right(EtcdLeader(key, value, leaseId))
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+
+    (mockEtcd
+      .electLeader(_: String, _: String, _: Lease))
+      .expects(key, value, *)
+      .returns(Future.successful(leader))
+
+    etcdWorker ! ElectLeader(key, value, recipient = self)
+
+    expectMsg(ElectionResult(leader))
+    expectMsg(FinishWork(key))
+  }
+
+  it should "register initial data when doesn't exit and send completion ack to parent" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+
+    (mockEtcd
+      .putTxn(_: String, _: String, _: Long, _: Long))
+      .expects(key, value, *, *)
+      .returns(Future.successful(TxnResponse.newBuilder().setSucceeded(true).build()))
+
+    etcdWorker ! RegisterInitialData(key, value, recipient = Some(self))
+
+    expectMsg(FinishWork(key))
+    expectMsg(InitialDataStorageResults(key, Right(Done())))
+  }
+
+  it should "attempt to register initial data when exists and send completion ack to parent" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+
+    (mockEtcd
+      .putTxn(_: String, _: String, _: Long, _: Long))
+      .expects(key, value, *, *)
+      .returns(Future.successful(TxnResponse.newBuilder().setSucceeded(false).build()))
+
+    etcdWorker ! RegisterInitialData(key, value, recipient = Some(self))
+
+    expectMsg(FinishWork(key))
+    expectMsg(InitialDataStorageResults(key, Left(AlreadyExist())))
+  }
+
+  it should "register data and send completion ack to parent" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val value = "testValue"
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+
+    (mockEtcd
+      .put(_: String, _: String, _: Long))
+      .expects(key, value, leaseId)
+      .returns(Future.successful(PutResponse.newBuilder().build()))
+
+    etcdWorker ! RegisterData(key, value)
+
+    expectMsg(FinishWork(key))
+  }
+
+  it should "delete data when watcher closed" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+
+    (mockEtcd
+      .del(_: String))
+      .expects(key)
+      .returns(Future.successful(DeleteRangeResponse.newBuilder().build()))
+
+    etcdWorker ! WatcherClosed(key, false)
+
+    expectMsg(FinishWork(key))
+  }
+
+  it should "retry request after failure if lease does not exist" in {
+    val mockEtcd = mock[EtcdClient]
+
+    val key = "testKey"
+    val etcdWorker = TestActorRef(EtcdWorker.props(mockEtcd, leaseService.ref), self)
+    var firstAttempt = true
+    (mockEtcd
+      .del(_: String))
+      .expects(key)
+      .onCall(_ => {
+        if (firstAttempt) {
+          firstAttempt = false
+          Future.failed(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED))
+        } else {
+          Future.successful(DeleteRangeResponse.newBuilder().build())
+        }
+      })
+      .twice()
+
+    etcdWorker ! WatcherClosed(key, false)
+
+    expectMsg(FinishWork(key))
+  }
+}


### PR DESCRIPTION
## Description
I don't think this is the root of my issue with the scheduler not learning that a container has been removed, but nevertheless this is a valuable refactor to make sure everything is thread safe in this actor.

There should be no behavior change to the actor at all, should be 100% refactor.

This pr does a couple things:

1. Move etcd worker to its own file under the etcd folder in commons
2. Clean up the error handling to remove duplicate code
3. Make the retry handling more thread safe by first forwarding the retry message and using the actor's internal timers scheduler rather than the system scheduler
4. Fix non-thread safe access to actor member variable `lease` from future callbacks through 3.
5. Add unit tests for EtcdWorker which previously wasn't covered.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

