### PR TITLE
WIP: add container pool state route to invoker

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
@@ -19,28 +19,14 @@ package org.apache.openwhisk.core.containerpool.v2
 
 import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Cancellable, Props}
-
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector.ContainerCreationError._
-import org.apache.openwhisk.core.connector.{
-  ContainerCreationAckMessage,
-  ContainerCreationMessage,
-  ContainerDeletionMessage,
-  ResultMetadata
-}
-import org.apache.openwhisk.core.containerpool.{
-  AdjustPrewarmedContainer,
-  BlackboxStartupError,
-  ColdStartKey,
-  ContainerPool,
-  ContainerPoolConfig,
-  ContainerRemoved,
-  PrewarmingConfig,
-  WhiskContainerStartupError
-}
+import org.apache.openwhisk.core.connector.{ContainerCreationAckMessage, ContainerCreationMessage, ContainerDeletionMessage, ResultMetadata}
+import org.apache.openwhisk.core.containerpool.{AdjustPrewarmedContainer, BlackboxStartupError, ColdStartKey, ContainerPool, ContainerPoolConfig, ContainerRemoved, PrewarmingConfig, WhiskContainerStartupError}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
+import spray.json.DefaultJsonProtocol
 
 import scala.annotation.tailrec
 import scala.collection.concurrent.TrieMap
@@ -50,11 +36,25 @@ import scala.concurrent.duration._
 import scala.util.{Random, Try}
 import scala.collection.immutable.Queue
 
+object  TotalContainerPoolState extends DefaultJsonProtocol {
+  implicit val prewarmedPoolSerdes = jsonFormat2(PrewarmedContainerPoolState.apply)
+  implicit val warmPoolSerdes = jsonFormat2(WarmContainerPoolState.apply)
+  implicit val totalPoolSerdes = jsonFormat5(TotalContainerPoolState.apply)
+}
+
+case class PrewarmedContainerPoolState(total: Int, countsByKind: Map[String, Int])
+case class WarmContainerPoolState(total: Int, containers: List[BasicContainerInfo])
+case class TotalContainerPoolState(totalContainers: Int, inProgressCount: Int, prewarmedPool: PrewarmedContainerPoolState,
+                                   busyPool: WarmContainerPoolState, pausedPool: WarmContainerPoolState) {
+  def serialize(): String = TotalContainerPoolState.totalPoolSerdes.write(this).compactPrint
+}
+
 case class CreationContainer(creationMessage: ContainerCreationMessage, action: WhiskAction)
 case class DeletionContainer(deletionMessage: ContainerDeletionMessage)
 case object Remove
 case class Keep(timeout: FiniteDuration)
 case class PrewarmContainer(maxConcurrent: Int)
+case object GetState
 
 /**
  * A pool managing containers to run actions on.
@@ -88,7 +88,7 @@ class FunctionPullingContainerPool(
 
   implicit val ec = context.system.dispatcher
 
-  protected[containerpool] var busyPool = immutable.Map.empty[ActorRef, Data]
+  protected[containerpool] var busyPool = immutable.Map.empty[ActorRef, ContainerAvailableData]
   protected[containerpool] var inProgressPool = immutable.Map.empty[ActorRef, Data]
   protected[containerpool] var warmedPool = immutable.Map.empty[ActorRef, WarmData]
   protected[containerpool] var prewarmedPool = immutable.Map.empty[ActorRef, PreWarmData]
@@ -413,6 +413,12 @@ class FunctionPullingContainerPool(
       // Reset the prewarmCreateCount value when do expiration check and backfill prewarm if possible
       prewarmCreateFailedCount.set(0)
       adjustPrewarmedContainer(false, true)
+    case GetState =>
+      val totalContainers = busyPool.size + inProgressPool.size + warmedPool.size + prewarmedPool.size
+      val prewarmedState = PrewarmedContainerPoolState(prewarmedPool.size, prewarmedPool.groupBy(_._2.kind).mapValues(_.size))
+      val busyState = WarmContainerPoolState(busyPool.size, busyPool.values.map(_.basicContainerInfo).toList)
+      val pausedState = WarmContainerPoolState(warmedPool.size, warmedPool.values.map(_.basicContainerInfo).toList)
+      sender() ! TotalContainerPoolState(totalContainers, inProgressPool.size, prewarmedState, busyState, pausedState)
   }
 
   /** Install prewarm containers up to the configured requirements for each kind/memory combination or specified kind/memory */

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerPool.scala
@@ -21,8 +21,22 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Cancellable, Props}
 import org.apache.openwhisk.common._
 import org.apache.openwhisk.core.connector.ContainerCreationError._
-import org.apache.openwhisk.core.connector.{ContainerCreationAckMessage, ContainerCreationMessage, ContainerDeletionMessage, ResultMetadata}
-import org.apache.openwhisk.core.containerpool.{AdjustPrewarmedContainer, BlackboxStartupError, ColdStartKey, ContainerPool, ContainerPoolConfig, ContainerRemoved, PrewarmingConfig, WhiskContainerStartupError}
+import org.apache.openwhisk.core.connector.{
+  ContainerCreationAckMessage,
+  ContainerCreationMessage,
+  ContainerDeletionMessage,
+  ResultMetadata
+}
+import org.apache.openwhisk.core.containerpool.{
+  AdjustPrewarmedContainer,
+  BlackboxStartupError,
+  ColdStartKey,
+  ContainerPool,
+  ContainerPoolConfig,
+  ContainerRemoved,
+  PrewarmingConfig,
+  WhiskContainerStartupError
+}
 import org.apache.openwhisk.core.entity._
 import org.apache.openwhisk.core.entity.size._
 import org.apache.openwhisk.http.Messages
@@ -36,7 +50,7 @@ import scala.concurrent.duration._
 import scala.util.{Random, Try}
 import scala.collection.immutable.Queue
 
-object  TotalContainerPoolState extends DefaultJsonProtocol {
+object TotalContainerPoolState extends DefaultJsonProtocol {
   implicit val prewarmedPoolSerdes = jsonFormat2(PrewarmedContainerPoolState.apply)
   implicit val warmPoolSerdes = jsonFormat2(WarmContainerPoolState.apply)
   implicit val totalPoolSerdes = jsonFormat5(TotalContainerPoolState.apply)
@@ -44,8 +58,11 @@ object  TotalContainerPoolState extends DefaultJsonProtocol {
 
 case class PrewarmedContainerPoolState(total: Int, countsByKind: Map[String, Int])
 case class WarmContainerPoolState(total: Int, containers: List[BasicContainerInfo])
-case class TotalContainerPoolState(totalContainers: Int, inProgressCount: Int, prewarmedPool: PrewarmedContainerPoolState,
-                                   busyPool: WarmContainerPoolState, pausedPool: WarmContainerPoolState) {
+case class TotalContainerPoolState(totalContainers: Int,
+                                   inProgressCount: Int,
+                                   prewarmedPool: PrewarmedContainerPoolState,
+                                   busyPool: WarmContainerPoolState,
+                                   pausedPool: WarmContainerPoolState) {
   def serialize(): String = TotalContainerPoolState.totalPoolSerdes.write(this).compactPrint
 }
 
@@ -415,7 +432,8 @@ class FunctionPullingContainerPool(
       adjustPrewarmedContainer(false, true)
     case GetState =>
       val totalContainers = busyPool.size + inProgressPool.size + warmedPool.size + prewarmedPool.size
-      val prewarmedState = PrewarmedContainerPoolState(prewarmedPool.size, prewarmedPool.groupBy(_._2.kind).mapValues(_.size))
+      val prewarmedState =
+        PrewarmedContainerPoolState(prewarmedPool.size, prewarmedPool.groupBy(_._2.kind).mapValues(_.size))
       val busyState = WarmContainerPoolState(busyPool.size, busyPool.values.map(_.basicContainerInfo).toList)
       val pausedState = WarmContainerPoolState(warmedPool.size, warmedPool.values.map(_.basicContainerInfo).toList)
       sender() ! TotalContainerPoolState(totalContainers, inProgressPool.size, prewarmedState, busyState, pausedState)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -127,18 +127,27 @@ case class PreWarmData(container: Container,
   def isExpired(): Boolean = expires.exists(_.isOverdue())
 }
 
-case class ContainerCreatedData(container: Container, invocationNamespace: String, action: ExecutableWhiskAction)
-    extends Data(action.limits.memory.megabytes.MB) {
-  override def getContainer = Some(container)
+object  BasicContainerInfo extends DefaultJsonProtocol {
+  implicit val prewarmedPoolSerdes = jsonFormat4(BasicContainerInfo.apply)
 }
+
+sealed case class BasicContainerInfo(containerId: String, namespace: String, action: String, kind: String)
+
+sealed abstract class ContainerAvailableData(container: Container, invocationNamespace: String, action: ExecutableWhiskAction) extends Data(action.limits.memory.megabytes.MB) {
+  override def getContainer = Some(container)
+
+  val basicContainerInfo = BasicContainerInfo(container.containerId.asString, invocationNamespace, action.name.asString, action.exec.kind)
+}
+
+case class ContainerCreatedData(container: Container, invocationNamespace: String, action: ExecutableWhiskAction)
+    extends ContainerAvailableData(container, invocationNamespace, action)
 
 case class InitializedData(container: Container,
                            invocationNamespace: String,
                            action: ExecutableWhiskAction,
                            override val clientProxy: ActorRef)
-    extends Data(action.limits.memory.megabytes.MB)
+    extends ContainerAvailableData(container, invocationNamespace, action)
     with WithClient {
-  override def getContainer = Some(container)
   def toReschedulingData(resumeRun: RunActivation) =
     ReschedulingData(container, invocationNamespace, action, clientProxy, resumeRun)
 }
@@ -149,9 +158,8 @@ case class WarmData(container: Container,
                     revision: DocRevision,
                     lastUsed: Instant,
                     override val clientProxy: ActorRef)
-    extends Data(action.limits.memory.megabytes.MB)
+    extends ContainerAvailableData(container, invocationNamespace, action)
     with WithClient {
-  override def getContainer = Some(container)
   def toReschedulingData(resumeRun: RunActivation) =
     ReschedulingData(container, invocationNamespace, action, clientProxy, resumeRun)
 }
@@ -159,12 +167,10 @@ case class WarmData(container: Container,
 case class ReschedulingData(container: Container,
                             invocationNamespace: String,
                             action: ExecutableWhiskAction,
-                            override val clientProxy: ActorRef,
+                            clientProxy: ActorRef,
                             resumeRun: RunActivation)
-    extends Data(action.limits.memory.megabytes.MB)
-    with WithClient {
-  override def getContainer = Some(container)
-}
+    extends ContainerAvailableData(container, invocationNamespace, action)
+    with WithClient
 
 class FunctionPullingContainerProxy(
   factory: (TransactionId,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -127,16 +127,20 @@ case class PreWarmData(container: Container,
   def isExpired(): Boolean = expires.exists(_.isOverdue())
 }
 
-object  BasicContainerInfo extends DefaultJsonProtocol {
+object BasicContainerInfo extends DefaultJsonProtocol {
   implicit val prewarmedPoolSerdes = jsonFormat4(BasicContainerInfo.apply)
 }
 
 sealed case class BasicContainerInfo(containerId: String, namespace: String, action: String, kind: String)
 
-sealed abstract class ContainerAvailableData(container: Container, invocationNamespace: String, action: ExecutableWhiskAction) extends Data(action.limits.memory.megabytes.MB) {
+sealed abstract class ContainerAvailableData(container: Container,
+                                             invocationNamespace: String,
+                                             action: ExecutableWhiskAction)
+    extends Data(action.limits.memory.megabytes.MB) {
   override def getContainer = Some(container)
 
-  val basicContainerInfo = BasicContainerInfo(container.containerId.asString, invocationNamespace, action.name.asString, action.exec.kind)
+  val basicContainerInfo =
+    BasicContainerInfo(container.containerId.asString, invocationNamespace, action.name.asString, action.exec.kind)
 }
 
 case class ContainerCreatedData(container: Container, invocationNamespace: String, action: ExecutableWhiskAction)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerReactive.scala
@@ -22,6 +22,8 @@ import akka.actor.{ActorRef, ActorRefFactory, ActorSystem, CoordinatedShutdown, 
 import akka.grpc.GrpcClientSettings
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.pattern.ask
+import akka.util.Timeout
 import com.ibm.etcd.api.Event.EventType
 import com.ibm.etcd.client.kv.KvClient.Watch
 import com.ibm.etcd.client.kv.WatchUpdate
@@ -390,6 +392,11 @@ class FPCInvokerReactive(config: WhiskConfig,
 
   override def isEnabled(): Route = {
     complete(InvokerEnabled(warmUpWatcher.nonEmpty).serialize())
+  }
+
+  override def getPoolState(): Route = {
+    implicit val timeout: Timeout = 5.seconds
+    complete((pool ? GetState).mapTo[TotalContainerPoolState].map(_.serialize()))
   }
 
   override def backfillPrewarm(): Route = {

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerServer.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/FPCInvokerServer.scala
@@ -51,6 +51,8 @@ class FPCInvokerServer(val invoker: InvokerCore, systemUsername: String, systemP
           invoker.disable()
         } ~ (path("isEnabled") & get) {
           invoker.isEnabled()
+        } ~ (path("pool") & get) {
+          invoker.getPoolState()
         }
       case _ => terminate(StatusCodes.Unauthorized)
     }

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -249,6 +249,7 @@ trait InvokerCore {
   def enable(): Route
   def disable(): Route
   def isEnabled(): Route
+  def getPoolState(): Route
   def backfillPrewarm(): Route
 }
 

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/InvokerReactive.scala
@@ -332,4 +332,8 @@ class InvokerReactive(
     complete("not supported")
   }
 
+  override def getPoolState(): Route = {
+    complete("not supported")
+  }
+
 }

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -291,8 +291,9 @@ class FunctionPullingContainerProxyTests
     Future.successful(count)
   }
 
-  def getLiveContainerCountFail(count: Long) = LoggedFunction { (_: String, _: FullyQualifiedEntityName, _: DocRevision) =>
-    Future.failed(new Exception("failure"))
+  def getLiveContainerCountFail(count: Long) = LoggedFunction {
+    (_: String, _: FullyQualifiedEntityName, _: DocRevision) =>
+      Future.failed(new Exception("failure"))
   }
 
   def getLiveContainerCountFailFirstCall(count: Long) = {
@@ -1137,7 +1138,8 @@ class FunctionPullingContainerProxyTests
     }
   }
 
-  it should "destroy container proxy when stopping due to timeout and getting live count fails permanently" in within(timeout) {
+  it should "destroy container proxy when stopping due to timeout and getting live count fails permanently" in within(
+    timeout) {
     val authStore = mock[ArtifactWhiskAuthStore]
     val namespaceBlacklist: NamespaceBlacklist = new NamespaceBlacklist(authStore)
     val get = getWhiskAction(Future(action.toWhiskAction))


### PR DESCRIPTION
## Description
Get state of invoker container pool over http route.

New GET route `/pool` returns a high level overview of the current state of its container pool. Useful for numerous things, one is being able to know when a disabled invoker has cleared out so it can be gracefully clear out. But also useful just for seeing a live state of things. We can leave it an experimental api for now subject to change.

Here is an example output:

```
{
  "busyPool": {
    "containers": [
         {
              "action": "test_action",
              "containerId": "1f485e8dbda91997e8e16b26c2e025b0cd453c9cc10a4cc678dd427abc614301",
              "kind": "nodejs:10",
              "namespace": "test_namespace"
         }
    ],
    "total": 1
  },
  "inProgressCount": 0,
  "pausedPool": {
    "containers": [
          {
              "action": "test_action",
              "containerId": "91cb46cee9b0893f47d7cd8aa5dd0e156a33a2f5ffc91f0a418d790de7895e50",
              "kind": "nodejs:10",
              "namespace": "test_namespace"
          }
     ],
    "total": 1
  },
  "prewarmedPool": {
    "countsByKind": {
      "java:8": 1,
      "nodejs:10": 1,
      "python:3": 1
    },
    "total": 3
  },
  "totalContainers": 5
}
```


## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

