### PR TITLE
optimize scheduling decision when there are stale activations

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -774,7 +774,6 @@ class FunctionPullingContainerProxy(
     case Event(Remove | GracefulShutdown, _) =>
       stay()
 
-
     case Event(DetermineKeepContainer(_), _) =>
       stay()
   }

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
@@ -135,41 +135,42 @@ class SchedulingDecisionMaker(
               staleActivationNum,
               0.0,
               Running)
-
-          case (Running, Some(duration)) if staleActivationNum > 0 =>
-            // we can safely get the value as we already checked the existence
-            val containerThroughput = staleThreshold / duration
-            val num = ceiling(staleActivationNum.toDouble / containerThroughput)
-            // if it tries to create more containers than existing messages, we just create shortage
-            val actualNum = (if (num > staleActivationNum) staleActivationNum else num) - inProgress
-            addServersIfPossible(
-              existing,
-              inProgress,
-              containerThroughput,
-              availableMsg,
-              capacity,
-              actualNum,
-              staleActivationNum,
-              duration,
-              Running)
-
           // need more containers and a message is already processed
           case (Running, Some(duration)) =>
             // we can safely get the value as we already checked the existence
             val containerThroughput = staleThreshold / duration
             val expectedTps = containerThroughput * (existing + inProgress)
+            val availableNonStaleActivations = availableMsg - staleActivationNum
 
-            if (availableMsg >= expectedTps && existing + inProgress < availableMsg) {
-              val num = ceiling((availableMsg / containerThroughput) - existing - inProgress)
+            var staleContainerProvision = 0
+            if (staleActivationNum > 0) {
+              val num = ceiling(staleActivationNum.toDouble / containerThroughput)
               // if it tries to create more containers than existing messages, we just create shortage
-              val actualNum = if (num + totalContainers > availableMsg) availableMsg - totalContainers else num
+              staleContainerProvision = (if (num > staleActivationNum) staleActivationNum else num) - inProgress
+            }
+
+            if (availableNonStaleActivations >= expectedTps && existing + inProgress < availableMsg) {
+              val num = ceiling((availableNonStaleActivations / containerThroughput) - existing - inProgress)
+              // if it tries to create more containers than existing messages, we just create shortage
+              val actualNum = if (num + totalContainers > availableNonStaleActivations) availableNonStaleActivations - totalContainers else num
               addServersIfPossible(
                 existing,
                 inProgress,
                 containerThroughput,
                 availableMsg,
                 capacity,
-                actualNum,
+                actualNum + staleContainerProvision,
+                staleActivationNum,
+                duration,
+                Running)
+            } else if (staleContainerProvision > 0) {
+              addServersIfPossible(
+                existing,
+                inProgress,
+                containerThroughput,
+                availableMsg,
+                capacity,
+                staleContainerProvision,
                 staleActivationNum,
                 duration,
                 Running)

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
@@ -139,9 +139,9 @@ class SchedulingDecisionMaker(
           case (Running, Some(duration)) if staleActivationNum > 0 =>
             // we can safely get the value as we already checked the existence
             val containerThroughput = staleThreshold / duration
-            val num = ceiling(availableMsg.toDouble / containerThroughput)
+            val num = ceiling(staleActivationNum.toDouble / containerThroughput)
             // if it tries to create more containers than existing messages, we just create shortage
-            val actualNum = (if (num > availableMsg) availableMsg else num) - inProgress
+            val actualNum = (if (num > staleActivationNum) staleActivationNum else num) - inProgress
             addServersIfPossible(
               existing,
               inProgress,
@@ -184,9 +184,9 @@ class SchedulingDecisionMaker(
           case (Removing, Some(duration)) if staleActivationNum > 0 =>
             // we can safely get the value as we already checked the existence
             val containerThroughput = staleThreshold / duration
-            val num = ceiling(availableMsg.toDouble / containerThroughput)
+            val num = ceiling(staleActivationNum.toDouble / containerThroughput)
             // if it tries to create more containers than existing messages, we just create shortage
-            val actualNum = (if (num > availableMsg) availableMsg else num) - inProgress
+            val actualNum = (if (num > staleActivationNum) staleActivationNum else num) - inProgress
             addServersIfPossible(
               existing,
               inProgress,

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
@@ -152,7 +152,9 @@ class SchedulingDecisionMaker(
             if (availableNonStaleActivations >= expectedTps && existing + inProgress < availableMsg) {
               val num = ceiling((availableNonStaleActivations / containerThroughput) - existing - inProgress)
               // if it tries to create more containers than existing messages, we just create shortage
-              val actualNum = if (num + totalContainers > availableNonStaleActivations) availableNonStaleActivations - totalContainers else num
+              val actualNum =
+                if (num + totalContainers > availableNonStaleActivations) availableNonStaleActivations - totalContainers
+                else num
               addServersIfPossible(
                 existing,
                 inProgress,

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
@@ -149,7 +149,7 @@ class SchedulingDecisionMaker(
               staleContainerProvision = (if (num > staleActivationNum) staleActivationNum else num) - inProgress
             }
 
-            if (availableNonStaleActivations >= expectedTps && existing + inProgress < availableMsg) {
+            if (availableNonStaleActivations >= expectedTps && existing + inProgress < availableNonStaleActivations) {
               val num = ceiling((availableNonStaleActivations / containerThroughput) - existing - inProgress)
               // if it tries to create more containers than existing messages, we just create shortage
               val actualNum =


### PR DESCRIPTION
## Description
I believe this optimizes scheduling decisions and reduces overprovisioning without sacrificing any performance. The reasoning here is if a queue has stale activations, you risk over-provisioning if you make the calculation based on all available messages,  not just stale ones. Here is an example:

t0ms: 5 activation arrives and for whatever reason it takes 100ms before the activation is processed even if there are containers existing (random network latency or whatever the brief blip may be). Let's say container throughput is 10 (10ms duration) and there's already 10 containers.
t50ms: 100 activations arrive and are available
t100ms: 5 activation is stale and enters the decision case when there is a stale activation. However it uses all 105 activations available to make a scheduling decision. 105 / 10 will create 11 containers. But it's not yet certain that the available messages can't be processed before going stale. You've therefore doubled containers for the action to 21 unnecessarily when 11 would be satisfactory. What this pr does is use the 5 stale activations at decision time to determine how much additional capacity is needed instead of total available activations, in this case it would be ceil(5 / 10) = 1. 


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

