### PR TITLE
Handle container cleanup from ActivationClient shutdown gracefully

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/ActivationClientProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/ActivationClientProxy.scala
@@ -18,7 +18,7 @@
 package org.apache.openwhisk.core.containerpool.v2
 
 import akka.actor.Status.{Failure => FailureMessage}
-import akka.actor.{ActorRef, ActorSystem, FSM, Props, Stash}
+import akka.actor.{ActorSystem, FSM, Props, Stash}
 import akka.grpc.internal.ClientClosedException
 import akka.pattern.pipe
 import io.grpc.StatusRuntimeException
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 import scala.util.{Success, Try}
 
 // Event send by the actor
-case class ClientCreationCompleted(client: Option[ActorRef] = None)
+case object ClientCreationCompleted
 case object ClientClosed
 
 // Event received by the actor
@@ -91,12 +91,14 @@ class ActivationClientProxy(
       stay using r
 
     case Event(client: ActivationClient, _) =>
-      context.parent ! ClientCreationCompleted()
+      context.parent ! ClientCreationCompleted
 
       goto(ClientProxyReady) using Client(client.client, client.rpcHost, client.rpcPort)
 
     case Event(f: FailureMessage, _) =>
       logging.error(this, s"failed to create grpc client for ${action} caused by: $f")
+      context.parent ! f
+
       self ! ClientClosed
 
       goto(ClientProxyRemoving)
@@ -164,9 +166,12 @@ class ActivationClientProxy(
           stay()
 
         case _: ActionMismatch =>
-          logging.error(this, s"[${containerId.asString}] action version does not match: $action")
+          val errorMsg = s"[${containerId.asString}] action version does not match: $action"
+          logging.error(this, errorMsg)
           c.activationClient.close().andThen {
-            case _ => self ! ClientClosed
+            case _ =>
+              context.parent ! FailureMessage(new RuntimeException(errorMsg))
+              self ! ClientClosed
           }
 
           goto(ClientProxyRemoving)
@@ -194,6 +199,7 @@ class ActivationClientProxy(
         // it would print huge log due to create another grpcClient to fetch activation again.
         case t: StatusRuntimeException if t.getMessage.contains(ActivationClientProxy.hostResolveError) =>
           logging.error(this, s"[${containerId.asString}] akka grpc server connection failed: $t")
+          context.parent ! FailureMessage(t)
           self ! ClientClosed
 
           goto(ClientProxyRemoving)
@@ -208,14 +214,18 @@ class ActivationClientProxy(
 
           stay()
 
-        case _: ClientClosedException =>
+        case t: ClientClosedException =>
           logging.error(this, s"[${containerId.asString}] grpc client is already closed for $action")
+          context.parent ! FailureMessage(t)
+
           self ! ClientClosed
 
           goto(ClientProxyRemoving)
 
         case t: Throwable =>
           logging.error(this, s"[${containerId.asString}] get activation from remote server error: $t")
+          context.parent ! FailureMessage(t)
+
           safelyCloseClient(c)
           goto(ClientProxyRemoving)
       }
@@ -372,7 +382,7 @@ class ActivationClientProxy(
           logging.debug(this, s"grpc client is closed for $fqn in the Try closure")
           Future.successful(ClientClosed)
       }
-      .getOrElse(Future.failed(new Exception(s"error to get $fqn activation from grpc server")))
+      .getOrElse(Future.failed(new RuntimeException(s"error to get $fqn activation from grpc server")))
   }
 
   private def createActivationClient(invocationNamespace: String,

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/InvokerHealthManager.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/InvokerHealthManager.scala
@@ -247,7 +247,7 @@ case class HealthActivationServiceClient() extends Actor {
   private var closed: Boolean = false
 
   override def receive: Receive = {
-    case StartClient => sender() ! ClientCreationCompleted()
+    case StartClient => sender() ! ClientCreationCompleted
     case _: RequestActivation =>
       InvokerHealthManager.healthActivation match {
         case Some(activation) if !closed =>

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/SchedulingDecisionMaker.scala
@@ -96,7 +96,9 @@ class SchedulingDecisionMaker(
               this,
               s"there is no capacity activations will be dropped or throttled, (availableMsg: $availableMsg totalContainers: $totalContainers, limit: $limit, namespaceContainers: ${existingContainerCountInNs}, namespaceInProgressContainer: ${inProgressContainerCountInNs}) [$invocationNamespace:$action]")
             Future.successful(DecisionResults(EnableNamespaceThrottling(dropMsg = totalContainers == 0), 0))
-          case NamespaceThrottled if schedulingConfig.allowOverProvisionBeforeThrottle && ceiling(limit * schedulingConfig.namespaceOverProvisionBeforeThrottleRatio) - existingContainerCountInNs - inProgressContainerCountInNs > 0 =>
+          case NamespaceThrottled
+              if schedulingConfig.allowOverProvisionBeforeThrottle && ceiling(
+                limit * schedulingConfig.namespaceOverProvisionBeforeThrottleRatio) - existingContainerCountInNs - inProgressContainerCountInNs > 0 =>
             Future.successful(DecisionResults(DisableNamespaceThrottling, 0))
           // do nothing
           case _ =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
@@ -213,9 +213,11 @@ class ActivationClientProxyTests
 
     machine ! RequestActivation()
 
-    probe.expectMsg(Transition(machine, ClientProxyReady, ClientProxyRemoving))
-    probe.expectMsgPF() {
-      case Failure(t) => t.getMessage.contains(s"action version does not match") shouldBe true
+    inAnyOrder {
+      probe.expectMsg(Transition(machine, ClientProxyReady, ClientProxyRemoving))
+      probe.expectMsgPF() {
+        case Failure(t) => t.getMessage.contains(s"action version does not match") shouldBe true
+      }
     }
 
     probe.expectMsg(ClientClosed)

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
@@ -103,7 +103,7 @@ class ActivationClientProxyTests
 
     machine ! StartClient
 
-    probe.expectMsg(ClientCreationCompleted())
+    probe.expectMsg(ClientCreationCompleted)
     probe.expectMsg(Transition(machine, ClientProxyUninitialized, ClientProxyReady))
   }
 
@@ -426,7 +426,7 @@ class ActivationClientProxyTests
 
   def ready(machine: ActorRef, probe: TestProbe) = {
     machine ! StartClient
-    probe.expectMsg(ClientCreationCompleted())
+    probe.expectMsg(ClientCreationCompleted)
     probe.expectMsg(Transition(machine, ClientProxyUninitialized, ClientProxyReady))
   }
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/ActivationClientProxyTests.scala
@@ -19,6 +19,7 @@ package org.apache.openwhisk.core.containerpool.v2.test
 
 import akka.Done
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
+import akka.actor.Status.Failure
 import akka.actor.{ActorRef, ActorSystem}
 import akka.grpc.internal.ClientClosedException
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
@@ -124,6 +125,9 @@ class ActivationClientProxyTests
 
     machine ! StartClient
 
+    probe.expectMsgPF() {
+      case Failure(t) => t.getMessage shouldBe "The number of client creation retries has been exceeded."
+    }
     probe.expectMsg(Transition(machine, ClientProxyUninitialized, ClientProxyRemoving))
     probe.expectMsg(ClientClosed)
 
@@ -208,7 +212,12 @@ class ActivationClientProxyTests
     ready(machine, probe)
 
     machine ! RequestActivation()
+
     probe.expectMsg(Transition(machine, ClientProxyReady, ClientProxyRemoving))
+    probe.expectMsgPF() {
+      case Failure(t) => t.getMessage.contains(s"action version does not match") shouldBe true
+    }
+
     probe.expectMsg(ClientClosed)
 
     probe expectTerminated machine
@@ -319,7 +328,11 @@ class ActivationClientProxyTests
     ready(machine, probe)
 
     machine ! RequestActivation()
+    probe.expectMsgPF() {
+      case Failure(t) => t.isInstanceOf[ClientClosedException] shouldBe true
+    }
     probe.expectMsg(Transition(machine, ClientProxyReady, ClientProxyRemoving))
+
     probe.expectMsg(ClientClosed)
 
     probe expectTerminated machine
@@ -343,6 +356,9 @@ class ActivationClientProxyTests
     ready(machine, probe)
 
     machine ! RequestActivation()
+    probe.expectMsgPF() {
+      case Failure(t) => t.getMessage.contains("Unknown exception") shouldBe true
+    }
     probe.expectMsg(Transition(machine, ClientProxyReady, ClientProxyRemoving))
     probe.expectMsg(ClientClosed)
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -444,7 +444,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, transid)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -509,7 +509,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -573,7 +573,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -642,7 +642,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -883,7 +883,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -943,7 +943,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1015,7 +1015,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1094,7 +1094,7 @@ class FunctionPullingContainerProxyTests
 
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1180,7 +1180,7 @@ class FunctionPullingContainerProxyTests
 
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1265,7 +1265,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1342,7 +1342,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1423,7 +1423,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1500,7 +1500,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1576,7 +1576,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     awaitAssert {
       machine.underlyingActor.stateData.getContainer should not be None
@@ -1670,7 +1670,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
     dataManagementService.expectMsg(
       RegisterData(
         ContainerKeys.existingContainers(
@@ -1779,7 +1779,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, noLogsAction, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1910,7 +1910,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -1984,7 +1984,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2061,7 +2061,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2140,7 +2140,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2230,7 +2230,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2293,7 +2293,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2359,7 +2359,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2429,7 +2429,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2512,7 +2512,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, Uninitialized, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2589,7 +2589,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2656,7 +2656,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2742,7 +2742,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2822,7 +2822,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, transid)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2893,7 +2893,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -2955,7 +2955,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)
@@ -3021,7 +3021,7 @@ class FunctionPullingContainerProxyTests
     machine ! Initialize(invocationNamespace.asString, fqn, action, schedulerHost, rpcPort, messageTransId)
     probe.expectMsg(Transition(machine, ContainerCreated, CreatingClient))
     client.expectMsg(StartClient)
-    client.send(machine, ClientCreationCompleted(Some(client.ref)))
+    client.send(machine, ClientCreationCompleted)
 
     probe.expectMsg(Transition(machine, CreatingClient, ClientCreated))
     expectInitialized(probe)

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
@@ -1470,7 +1470,7 @@ class MemoryQueueTests
     fsm ! QueueRemovedCompleted
     parent.expectMsg(10 seconds, Transition(fsm, Removing, Removed))
 
-    probe.expectTerminated(fsm)
+    probe.expectTerminated(fsm, 10 seconds)
   }
 
   it should "throttle the namespace when the limit is already reached" in {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
This is to fix the regression introduced from https://github.com/apache/openwhisk/pull/5338

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [x] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

