### PR TITLE
schedule actions to run at least 3 times a week

### DIFF
--- a/.github/workflows/1-unit.yaml
+++ b/.github/workflows/1-unit.yaml
@@ -18,10 +18,13 @@
 name: Unit Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 1 * * 1,3,5'
 
 env:
   # openwhisk env

--- a/.github/workflows/2-system.yaml
+++ b/.github/workflows/2-system.yaml
@@ -18,10 +18,13 @@
 name: System Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 2 * * 1,3,5'
 
 env:
   # openwhisk env

--- a/.github/workflows/3-multi-runtime.yaml
+++ b/.github/workflows/3-multi-runtime.yaml
@@ -18,10 +18,13 @@
 name: MultiRuntime Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 3 * * 1,3,5'
 
 env:
   # openwhisk env

--- a/.github/workflows/4-standalone.yaml
+++ b/.github/workflows/4-standalone.yaml
@@ -18,10 +18,13 @@
 name: Standalone Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 4 * * 1,3,5'
 
 env:
   # openwhisk env

--- a/.github/workflows/5-scheduler.yaml
+++ b/.github/workflows/5-scheduler.yaml
@@ -18,10 +18,13 @@
 name: Scheduler Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 5 * * 1,3,5'
 
 env:
   # openwhisk env

--- a/.github/workflows/6-performance.yaml
+++ b/.github/workflows/6-performance.yaml
@@ -18,10 +18,13 @@
 name: Performance Tests
 
 on:
-  # build on push
   push:
-  # build on pull requests
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: '30 6 * * 1,3,5'
 
 env:
   # openwhisk env


### PR DESCRIPTION
Add schedule clause to GitHub actions to cause them to run 3 times a week.  Schedule is offset by 1 hour for each workflow file to avoid heavy spikes.