### PR TITLE
remove zookeeper config requirement

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -91,7 +91,6 @@ object Invoker {
     Map(servicePort -> 8080.toString) ++
       ExecManifest.requiredProperties ++
       kafkaHosts ++
-      zookeeperHosts ++
       wskApiHost
 
   def initKamon(instance: Int): Unit = {

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -275,7 +275,6 @@ object Scheduler {
       schedulerRpcPort -> null,
       WhiskConfig.actionInvokeConcurrentLimit -> null) ++
       kafkaHosts ++
-      zookeeperHosts ++
       ExecManifest.requiredProperties
 
   def initKamon(instance: SchedulerInstanceId): Unit = {


### PR DESCRIPTION
## Description
First step to getting rid of the zookeeper dependency on the invokers. Invokers currently can already be started without the zookeeper config if `--id` flag is set which is already the case in ansible. The only case that needs to be covered still before removing the dependency is adding support for kubernetes deployment. If started without config and need to connect to zookeeper still, the invoker will fail and shut down anyways from failing to connect to zookeeper in the instance id assigner on startup so this shouldn't be a breaking change.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

