### PR TITLE
make scheduler consider action concurrency >1

### DIFF
--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/MemoryQueue.scala
@@ -943,6 +943,7 @@ class MemoryQueue(private val etcdClient: EtcdClient,
             namespaceContainerCount.inProgressContainerNumByNamespace,
             averageDuration,
             limit,
+            actionMetaData.limits.concurrency.maxConcurrent,
             stateName,
             self)
         case Failure(_: NoDocumentException) =>
@@ -1222,6 +1223,7 @@ case class QueueSnapshot(initialized: Boolean,
                          inProgressContainerCountInNamespace: Int,
                          averageDuration: Option[Double],
                          limit: Int,
+                         maxActionConcurrency: Int,
                          stateName: MemoryQueueState,
                          recipient: ActorRef)
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueFlowTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueFlowTests.scala
@@ -313,7 +313,7 @@ class MemoryQueueFlowTests
     // this is the case where there is no capacity in a namespace and no container can be created.
     decisionMaker.setAutoPilot((sender: ActorRef, msg) => {
       msg match {
-        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, Running, _) =>
+        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, Running, _) =>
           sender ! DecisionResults(EnableNamespaceThrottling(true), 0)
           TestActor.KeepRunning
 

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/MemoryQueueTests.scala
@@ -1534,7 +1534,7 @@ class MemoryQueueTests
     // This test pilot mimic the decision maker who disable the namespace throttling when there is enough capacity.
     decisionMaker.setAutoPilot((sender: ActorRef, msg) => {
       msg match {
-        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, NamespaceThrottled, _) =>
+        case QueueSnapshot(_, _, _, _, _, _, _, _, _, _, _, NamespaceThrottled, _) =>
           sender ! DisableNamespaceThrottling
 
         case _ =>

--- a/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/SchedulingDecisionMakerTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/scheduler/queue/test/SchedulingDecisionMakerTests.scala
@@ -63,7 +63,8 @@ class SchedulingDecisionMakerTests
       existingContainerCountInNamespace = 0,
       inProgressContainerCountInNamespace = 0,
       averageDuration = None,
-      limit = 0, // limit is 0
+      limit = 0, // limit is 0,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -87,6 +88,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = None,
       limit = 0, // limit is 0
+      maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
 
@@ -114,6 +116,7 @@ class SchedulingDecisionMakerTests
         inProgressContainerCountInNamespace = 2,
         averageDuration = None, // No average duration available
         limit = 10,
+        maxActionConcurrency = 1,
         stateName = state,
         recipient = testProbe.ref)
 
@@ -140,6 +143,7 @@ class SchedulingDecisionMakerTests
         inProgressContainerCountInNamespace = 8,
         averageDuration = Some(1.0), // Some average duration available
         limit = 20,
+        maxActionConcurrency = 1,
         stateName = state,
         recipient = testProbe.ref)
 
@@ -164,6 +168,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 2,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -188,6 +193,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 2, // this value includes the count of this action as well.
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -215,6 +221,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 2,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -242,6 +249,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 2,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -269,6 +277,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 2,
+      maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
 
@@ -296,6 +305,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 2,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -323,6 +333,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 2, // this value includes the count of this action as well.
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -347,6 +358,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -370,6 +382,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
 
@@ -393,6 +406,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = NamespaceThrottled,
       recipient = testProbe.ref)
 
@@ -417,6 +431,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -441,6 +456,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -465,6 +481,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
 
@@ -488,6 +505,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Flushing,
       recipient = testProbe.ref)
 
@@ -511,6 +529,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -534,6 +553,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -557,6 +577,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = None,
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -580,6 +601,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 6,
       averageDuration = None,
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -603,6 +625,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -628,6 +651,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -653,6 +677,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -680,6 +705,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -706,6 +732,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -733,6 +760,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -759,6 +787,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = None, // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -782,6 +811,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 1,
       averageDuration = Some(1000), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
 
@@ -808,6 +838,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 2,
       averageDuration = None, // the average duration does not exist
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
 
@@ -834,6 +865,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(1000), // the average duration exists
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -858,6 +890,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 0,
       averageDuration = Some(50), // the average duration gives container throughput of 2
       limit = 10,
+      maxActionConcurrency = 1,
       stateName = Running,
       recipient = testProbe.ref)
 
@@ -882,6 +915,7 @@ class SchedulingDecisionMakerTests
       inProgressContainerCountInNamespace = 2,
       averageDuration = None, // the average duration does not exist
       limit = 4,
+      maxActionConcurrency = 1,
       stateName = Removing,
       recipient = testProbe.ref)
 
@@ -892,5 +926,114 @@ class SchedulingDecisionMakerTests
     // it should subtract the in-progress number so it is supposed to be 2
     // but there is not enough capacity, it becomes 1
     testProbe.expectMsg(DecisionResults(EnableNamespaceThrottling(false), 1))
+  }
+
+  it should "correctly calculate demand is met when action concurrency >1 w/ average duration and no stale activations" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 4,
+      existingContainerCount = 2,
+      inProgressContainerCount = 0,
+      staleActivationNum = 0,
+      existingContainerCountInNamespace = 2,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = Some(100.0),
+      limit = 4,
+      maxActionConcurrency = 2,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // available messages is 4 with duration equaling the stale threshold and action concurrency of 2 so needed containers
+    // should be exactly 2
+    testProbe.expectNoMessage()
+  }
+
+  it should "add containers when action concurrency >1 w/ average duration and demand is not met" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 20,
+      existingContainerCount = 2,
+      inProgressContainerCount = 0,
+      staleActivationNum = 0,
+      existingContainerCountInNamespace = 2,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = Some(50.0),
+      limit = 10,
+      maxActionConcurrency = 3,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // available messages is 20 and throughput should be 100.0 / 50.0 * 3 = 6
+    // existing container is 2 so can handle 12 messages, therefore need 2 more containers
+    testProbe.expectMsg(DecisionResults(AddContainer, 2))
+  }
+
+  it should "add containers when action concurrency >1 w/ average duration and demand is not met and has stale activations" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 30,
+      existingContainerCount = 2,
+      inProgressContainerCount = 0,
+      staleActivationNum = 10,
+      existingContainerCountInNamespace = 2,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = Some(50.0),
+      limit = 10,
+      maxActionConcurrency = 3,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // available messages is 30 and throughput should be 100.0 / 50.0 * 3 = 6
+    // existing container is 2 so can handle 12 messages, therefore need 2 more containers for non-stale
+    // stale has 10 activations so need another additional 2
+    testProbe.expectMsg(DecisionResults(AddContainer, 4))
+  }
+
+  it should "add containers when action concurrency >1 when no average duration and there are stale activations" in {
+    val decisionMaker = system.actorOf(SchedulingDecisionMaker.props(testNamespace, action, schedulingConfig))
+    val testProbe = TestProbe()
+
+    // container
+    val msg = QueueSnapshot(
+      initialized = true,
+      incomingMsgCount = new AtomicInteger(0),
+      currentMsgCount = 10,
+      existingContainerCount = 1,
+      inProgressContainerCount = 0,
+      staleActivationNum = 10,
+      existingContainerCountInNamespace = 2,
+      inProgressContainerCountInNamespace = 0,
+      averageDuration = None,
+      limit = 10,
+      maxActionConcurrency = 3,
+      stateName = Running,
+      recipient = testProbe.ref)
+
+    decisionMaker ! msg
+
+    // stale messages are 10. want stale to be handled by first pass of requests from containers so
+    // 10 / 3 = 4.0
+    testProbe.expectMsg(DecisionResults(AddContainer, 4))
   }
 }


### PR DESCRIPTION
## Description
Have the scheduling decision maker make container creation decisions using a throughput calculation that considers how many concurrent requests a container can take. This should exhibit the same throughput guarantees as is, but without unnecessary potential fan out of containers when an action has concurrency greater than one since the scheduler didn't consider it up until this point. **There is no semantic change to behavior from this commit if action concurrency == 1.**

Example: consider you have 100 incoming activations in the queue for an action with a concurrency of 10 with 1 existing container up currently processing 10 activations when the scheduling decision is made. The average duration is 10ms so the container throughput for this action due to the concurrency is really 100. So needed containers should already be met with just 1 container. However, currently the decision maker since it doesn't consider concurrency would create an additional 9 containers far exceeding the true needed number of containers.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [X] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [X] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

