### PR TITLE
dependency updates for cve patches (part 2)

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -105,7 +105,6 @@ dependencies {
         exclude group: "com.azure", module: "azure-core-test"
     }
 
-    // https://nvd.nist.gov/vuln/detail/CVE-2020-11612
     compile "io.netty:netty-buffer:${gradle.netty.version}"
     compile "io.netty:netty-handler:${gradle.netty.version}"
     compile "io.netty:netty-handler-proxy:${gradle.netty.version}"

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "commons-codec:commons-codec:1.9"
     api "commons-io:commons-io:2.11.0"
     api "commons-collections:commons-collections:3.2.2"
-    api "org.apache.kafka:kafka-clients:2.4.0"
+    api "org.apache.kafka:kafka-clients:2.8.2"
     api "org.apache.httpcomponents:httpclient:4.5.5"
     api "com.fasterxml.uuid:java-uuid-generator:3.1.3"
     api "com.github.ben-manes.caffeine:caffeine:2.6.2"
@@ -92,7 +92,7 @@ dependencies {
 
     api "com.sksamuel.elastic4s:elastic4s-http_${gradle.scala.depVersion}:6.7.4"
     //for mongo
-    api "org.mongodb.scala:mongo-scala-driver_${gradle.scala.depVersion}:2.7.0"
+    api "org.mongodb.scala:mongo-scala-driver_${gradle.scala.depVersion}:2.9.0"
 
     api ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.1.2") {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http
@@ -104,6 +104,16 @@ dependencies {
     api ("com.azure:azure-storage-blob:12.7.0") {
         exclude group: "com.azure", module: "azure-core-test"
     }
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2020-11612
+    compile "io.netty:netty-buffer:${gradle.netty.version}"
+    compile "io.netty:netty-handler:${gradle.netty.version}"
+    compile "io.netty:netty-handler-proxy:${gradle.netty.version}"
+    compile "io.netty:netty-codec-socks:${gradle.netty.version}"
+    compile "io.netty:netty-codec-http:${gradle.netty.version}"
+    compile "io.netty:netty-codec-http2:${gradle.netty.version}"
+    compile "io.netty:netty-transport-native-epoll:${gradle.netty.version}"
+    compile "io.netty:netty-transport-native-unix-common:${gradle.netty.version}"
 }
 
 configurations {

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     api "com.sksamuel.elastic4s:elastic4s-http_${gradle.scala.depVersion}:6.7.4"
     //for mongo
-    api "org.mongodb.scala:mongo-scala-driver_${gradle.scala.depVersion}:2.9.0"
+    api "org.mongodb.scala:mongo-scala-driver_${gradle.scala.depVersion}:2.7.0"
 
     api ("com.lightbend.akka:akka-stream-alpakka-s3_${gradle.scala.depVersion}:1.1.2") {
         exclude group: 'org.apache.httpcomponents' //Not used as alpakka uses akka-http

--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     api "commons-codec:commons-codec:1.9"
     api "commons-io:commons-io:2.11.0"
     api "commons-collections:commons-collections:3.2.2"
-    api "org.apache.kafka:kafka-clients:2.8.2"
+    api "org.apache.kafka:kafka-clients:2.4.0"
     api "org.apache.httpcomponents:httpclient:4.5.5"
     api "com.fasterxml.uuid:java-uuid-generator:3.1.3"
     api "com.github.ben-manes.caffeine:caffeine:2.6.2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -79,4 +79,6 @@ gradle.ext.akka_http = [version : '10.2.4']
 gradle.ext.akka_management = [version : '1.0.5']
 
 gradle.ext.curator = [version : '4.3.0']
-gradle.ext.kube_client = [version: '4.10.3']
+gradle.ext.kube_client = [version: '4.13.3']
+
+gradle.ext.netty = [version : '4.1.87.Final']

--- a/settings.gradle
+++ b/settings.gradle
@@ -79,6 +79,6 @@ gradle.ext.akka_http = [version : '10.2.4']
 gradle.ext.akka_management = [version : '1.0.5']
 
 gradle.ext.curator = [version : '4.3.0']
-gradle.ext.kube_client = [version: '4.13.3']
+gradle.ext.kube_client = [version: '4.10.3']
 
 gradle.ext.netty = [version : '4.1.87.Final']

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -226,7 +226,7 @@ dependencies {
     implementation "io.opentracing:opentracing-mock:0.31.0"
     implementation "org.apache.curator:curator-test:${gradle.curator.version}"
     implementation "com.atlassian.oai:swagger-request-validator-core:1.4.5"
-    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1"
+    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
     implementation "com.typesafe.akka:akka-stream-kafka-testkit_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
     implementation "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     implementation "io.fabric8:kubernetes-server-mock:${gradle.kube_client.version}"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -218,7 +218,7 @@ dependencies {
     implementation "io.rest-assured:rest-assured:4.5.1"
     implementation "org.scalatest:scalatest_${gradle.scala.depVersion}:3.0.8"
     implementation "com.typesafe.akka:akka-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
-    implementation "com.google.code.gson:gson:2.3.1"
+    implementation "com.google.code.gson:gson:2.10.1"
     implementation "org.scalamock:scalamock_${gradle.scala.depVersion}:4.4.0"
     implementation "com.typesafe.akka:akka-http-testkit_${gradle.scala.depVersion}:${gradle.akka_http.version}"
     implementation "com.github.java-json-tools:json-schema-validator:2.2.8"
@@ -226,7 +226,7 @@ dependencies {
     implementation "io.opentracing:opentracing-mock:0.31.0"
     implementation "org.apache.curator:curator-test:${gradle.curator.version}"
     implementation "com.atlassian.oai:swagger-request-validator-core:1.4.5"
-    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.4.0"
+    implementation "io.github.embeddedkafka:embedded-kafka_${gradle.scala.depVersion}:2.8.1"
     implementation "com.typesafe.akka:akka-stream-kafka-testkit_${gradle.scala.depVersion}:${gradle.akka_kafka.version}"
     implementation "com.typesafe.akka:akka-stream-testkit_${gradle.scala.depVersion}:${gradle.akka.version}"
     implementation "io.fabric8:kubernetes-server-mock:${gradle.kube_client.version}"
@@ -234,7 +234,7 @@ dependencies {
 
     implementation "com.amazonaws:aws-java-sdk-s3:1.12.395"
     implementation "com.microsoft.azure:azure-cosmos:3.7.6"
-    implementation 'org.testcontainers:elasticsearch:1.17.1'
+    implementation 'org.testcontainers:elasticsearch:1.17.6'
     implementation 'org.testcontainers:mongodb:1.17.1'
 
     implementation project(':common:scala')
@@ -245,7 +245,7 @@ dependencies {
     implementation project(':core:monitoring:user-events')
     implementation project(':tools:admin')
 
-    swaggerCodegen 'io.swagger:swagger-codegen-cli:2.4.9'
+    swaggerCodegen 'io.swagger:swagger-codegen-cli:2.4.29'
 }
 
 def keystorePath = new File(sourceSets.test.scala.outputDir, 'keystore')

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
@@ -22,7 +22,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import com.typesafe.config.ConfigFactory
-import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.openwhisk.common.{AkkaLogging, TransactionId}

--- a/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/database/cosmosdb/cache/CacheInvalidatorTests.scala
@@ -22,7 +22,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import com.typesafe.config.ConfigFactory
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import io.github.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.openwhisk.common.{AkkaLogging, TransactionId}


### PR DESCRIPTION
## Description
More dependency upgrades to deal with cve patches.

Have to pin the netty version. There's too many dependencies that pull it in that have breaking changes that it's not worth dealing with if pinning the latest patch works fine.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [X] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

