### PR TITLE
rollback logback minor upgrade to latest patch

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     api "com.lightbend.akka:akka-stream-alpakka-file_${gradle.scala.depVersion}:1.1.2"
 
-    api "ch.qos.logback:logback-classic:1.4.5"
+    api "ch.qos.logback:logback-classic:1.2.11"
     api "org.slf4j:jcl-over-slf4j:1.7.25"
     api "org.slf4j:log4j-over-slf4j:1.7.25"
     api "commons-codec:commons-codec:1.9"


### PR DESCRIPTION
## Description
The dependency upgrade I merged in over the weekend has an issue with the logback minor upgrade. It seems the package is built past jdk8 and fails at runtime when trying to run with jdk8. I don't think a full revert is necessary since validated things look good now just going forward to the latest patch which I think still covers the cve.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

