### PR TITLE
fix missed etcd unregister data case for an existing container in container proxy

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -611,7 +611,12 @@ class FunctionPullingContainerProxy(
       if (runningActivations.isEmpty) {
         logging.info(this, s"The Client closed in state: $stateName, action: ${data.action}")
         // Stop ContainerProxy(ActivationClientProxy will stop also when send ClientClosed to ContainerProxy).
-        cleanUp(data.container, None, false)
+        cleanUp(
+          data.container,
+          data.invocationNamespace,
+          data.action.fullyQualifiedName(withVersion = true),
+          data.action.rev,
+          None)
       } else {
         logging.info(
           this,

--- a/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/containerpool/v2/test/FunctionPullingContainerProxyTests.scala
@@ -961,7 +961,7 @@ class FunctionPullingContainerProxyTests
     }
     client.send(machine, ClientClosed)
 
-    probe.expectMsgAllOf(ContainerRemoved(false), Transition(machine, Running, Removing))
+    probe.expectMsgAllOf(ContainerRemoved(true), Transition(machine, Running, Removing))
 
     awaitAssert {
       factory.calls should have size 1
@@ -1614,7 +1614,7 @@ class FunctionPullingContainerProxyTests
     client.expectMsg(GracefulShutdown)
     client.send(machine, ClientClosed)
 
-    probe.expectMsgAllOf(ContainerRemoved(false), Transition(machine, Running, Removing))
+    probe.expectMsgAllOf(ContainerRemoved(true), Transition(machine, Running, Removing))
 
     awaitAssert {
       factory.calls should have size 1


### PR DESCRIPTION
## Description
I think this may be an additional case that was missed where the container proxy can shutdown without removing the container data from etcd.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

