### PR TITLE
fix bug in average ring buffer and add negative duration protection to scheduler decision maker

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/AverageRingBuffer.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/AverageRingBuffer.scala
@@ -32,18 +32,12 @@ object AverageRingBuffer {
 class AverageRingBuffer(private val maxSize: Int) {
   private var elements = Vector.empty[Double]
   private var sum = 0.0
-  private var max = 0.0
-  private var min = 0.0
 
   def nonEmpty: Boolean = elements.nonEmpty
 
   def average: Double = {
     val size = elements.size
-    if (size > 2) {
-      (sum - max - min) / (size - 2)
-    } else {
-      sum / size
-    }
+    sum / size
   }
 
   def add(el: Double): Unit = synchronized {
@@ -53,12 +47,6 @@ class AverageRingBuffer(private val maxSize: Int) {
     } else {
       sum += el
       elements = elements :+ el
-    }
-    if (el > max) {
-      max = el
-    }
-    if (el < min) {
-      min = el
     }
   }
 


### PR DESCRIPTION
## Description
The average ring buffer has an edge case where discarding the max and min outliers from the average calculation can result in the average being negative due to the max and min not ever being reset even when the max and min value is ultimately discarded from the ongoing buffer. So the way it's set up it keeps the absolute max and absolute min duration for this function that has ever occurred. I just got rid of the max and min outlier discarding for now because I don't think it's adding much value and to appropriately update the max and min would require a performance hit to the ring buffer. I've also added negative duration buffer protection to the scheduling decision maker so that if such a case were introduced again in the future, the scheduling decision maker can more gracefully handle it and still fallback to scheduling containers when there are stale activations rather than thinking the amount of containers to schedule is negative.

Here is a raw example of how things can go wrong.

There is an edge case on the (sum - max - min) / (size - 2) calculation. The max never gets reset even if the element leaves the buffer. So say you have a random activation that takes 60s to run. The normal case is that all other activations take 50ms. If the buffer size is 10, then the sum should = 500 assuming the 60000 activation has left the buffer. however the max value will still be set to 60000.

(500 - 60000 - 50) / (10 - 2) = -7443ms

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

