### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,14 +16,36 @@
  */
 
 plugins {
-    id "com.gradle.enterprise" version "3.10.2"
+    id 'com.gradle.enterprise' version '3.13.1'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
 }
 
+def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+def isJenkins = System.getenv('JENKINS_URL') != null
+def isCI = isGithubActions || isJenkins
+
 gradleEnterprise {
+    server = "https://ge.apache.org"
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-        publishAlwaysIf(System.getenv('CI') != null)
+        capture { taskInputFiles = true }
+        uploadInBackground = !isCI
+        publishAlways()
+        publishIfAuthenticated()
+        obfuscation {
+            // This obfuscates the IP addresses of the build machine in the build scan.
+            // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+        }
+    }
+}
+
+buildCache {
+    local {
+        enabled = !isCI
+    }
+
+    remote(gradleEnterprise.buildCache) {
+        enabled = false
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'com.gradle.enterprise' version '3.13.1'
+    id 'com.gradle.enterprise' version '3.13.2'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
 }
 


### PR DESCRIPTION
Capture build scans on ge.apache.org to benefit from deep build insights

## Description

This PR publishes a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache OpenWhisk project are published to the Gradle Enterprise instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by the Apache OpenWhisk project and all other Apache projects.

Currently, the Apache OpenWhisk build is configured to publish build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/). This pull request enhances that functionality by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Gradle Enterprise instance, Apache OpenWhisk will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

If interested in exploring a fully populated Gradle Enterprise instance, please explore the Maven builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Gradle Enterprise.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.
## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [x] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

