### PR TITLE
Add ZOOKEEPER_HOSTS as an optional property

### DIFF
--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -93,6 +93,8 @@ object Invoker {
       kafkaHosts ++
       wskApiHost
 
+  def optionalProperties = zookeeperHosts.keys.toSet
+
   def initKamon(instance: Int): Unit = {
     // Replace the hostname of the invoker to the assigned id of the invoker.
     val newKamonConfig = Kamon.config
@@ -128,7 +130,7 @@ object Invoker {
     }
 
     // load values for the required properties from the environment
-    implicit val config = new WhiskConfig(requiredProperties)
+    implicit val config = new WhiskConfig(requiredProperties, optionalProperties)
 
     def abort(message: String) = {
       logger.error(this, message)(TransactionId.invoker)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -188,7 +188,7 @@ object Invoker {
 
       // --uniqueName is defined with a valid value, id is empty, assign an id via zookeeper
       case CmdLineArgs(Some(unique), None, _, overwriteId) =>
-        if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":")) {
+        if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":") || config.zookeeperHosts.equals("")) {
           abort(s"Must provide valid zookeeper host and port to use dynamicId assignment (${config.zookeeperHosts})")
         }
         new InstanceIdAssigner(config.zookeeperHosts).setAndGetId(unique, overwriteId)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/invoker/Invoker.scala
@@ -188,7 +188,8 @@ object Invoker {
 
       // --uniqueName is defined with a valid value, id is empty, assign an id via zookeeper
       case CmdLineArgs(Some(unique), None, _, overwriteId) =>
-        if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":") || config.zookeeperHosts.equals("")) {
+        if (config.zookeeperHosts.startsWith(":") || config.zookeeperHosts.endsWith(":") ||
+            config.zookeeperHosts.equals("")) {
           abort(s"Must provide valid zookeeper host and port to use dynamicId assignment (${config.zookeeperHosts})")
         }
         new InstanceIdAssigner(config.zookeeperHosts).setAndGetId(unique, overwriteId)


### PR DESCRIPTION
## Description
As [`ZOOKEEPER_HOSTS` is removed from the required properties](https://github.com/apache/openwhisk/pull/5375), it is no longer transformed into the whisk config from the environment variables.
But when the instance id assigned is used, the zookeeper host becomes a required property.
This change is to make it an optional property.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#5399 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [x] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

