### PR TITLE
Maximize build spaces of all workflows by manually removing unnecessary resources

### DIFF
--- a/.github/workflows/0-on-demand.yaml
+++ b/.github/workflows/0-on-demand.yaml
@@ -73,6 +73,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/1-unit.yaml
+++ b/.github/workflows/1-unit.yaml
@@ -63,6 +63,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/2-system.yaml
+++ b/.github/workflows/2-system.yaml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/3-multi-runtime.yaml
+++ b/.github/workflows/3-multi-runtime.yaml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/4-standalone.yaml
+++ b/.github/workflows/4-standalone.yaml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/5-scheduler.yaml
+++ b/.github/workflows/5-scheduler.yaml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - id: tests
         name: Run Tests
         run: "./tools/github/run${{ env.TEST_SUITE }}Tests.sh"

--- a/.github/workflows/6-performance.yaml
+++ b/.github/workflows/6-performance.yaml
@@ -58,6 +58,13 @@ jobs:
         uses: actions/checkout@v3
       - name: "Setup"
         run: ./tools/github/setup.sh
+      - name: Maximize free space
+        run: >
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Check free space
+        run: df -h
       - run: ./tests/performance/preparation/deploy.sh
       - run: TERM=dumb ./tests/performance/wrk_tests/latency.sh "https://172.17.0.1:10001" "$(cat ansible/files/auth.guest)" ./tests/performance/preparation/actions/noop.js 2m
         continue-on-error: true


### PR DESCRIPTION
## Description
While running tests, all indices of elasticsearch become read-only because of limited disk space.
This change maximize the build disk space by removing unnecessary built-in tools.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#5433)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

