### PR TITLE
Missed config keys on Scala 2.13.x

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/common/Config.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/common/Config.scala
@@ -141,8 +141,9 @@ object Config {
    */
   def readPropertiesFromSystemAndEnv(properties: scala.collection.mutable.Map[String, String],
                                      env: Map[String, String])(implicit logging: Logging) = {
+    val keys: Seq[String] = properties.keys.toSeq
     readPropertiesFromSystem(properties)
-    for (p <- properties.keys) {
+    for (p <- keys) {
       val envp = p.replace('.', '_').toUpperCase
       val envv = env.get(envp)
       if (envv.isDefined) {
@@ -153,7 +154,8 @@ object Config {
   }
 
   def readPropertiesFromSystem(properties: scala.collection.mutable.Map[String, String])(implicit logging: Logging) = {
-    for (p <- properties.keys) {
+    val keys: Seq[String] = properties.keys.toSeq
+    for (p <- keys) {
       val sysv = Option(System.getProperty(prefix + p))
       if (sysv.isDefined) {
         logging.info(this, s"system set value for $p")


### PR DESCRIPTION
## Desscription 

The origin of issue is iteration through the config keys [here](https://github.com/apache/openwhisk/blob/master/common/scala/src/main/scala/org/apache/openwhisk/common/Config.scala#L145) and [here](https://github.com/apache/openwhisk/blob/master/common/scala/src/main/scala/org/apache/openwhisk/common/Config.scala#L156) and at the same time properties [change](https://github.com/apache/openwhisk/blob/master/common/scala/src/main/scala/org/apache/openwhisk/common/Config.scala#L150) in the loop which can lead to skipping some keys after `+=`.

- Fixed an issue with missed config keys while iterating through them on Scala 2.13.x

!Note: This issue reproduces only on Scala >= 2.13.x version and probably related to some internal changes in Scala. 

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] https://github.com/apache/openwhisk/issues/5447

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

