### PR TITLE
Update FPC invoker health reporting logic

### DIFF
--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -627,7 +627,7 @@ class FPCPoolBalancer(config: WhiskConfig,
       val missingHealths =
         if (healthsFromEtcd.isEmpty) Set.empty[InvokerHealth]
         else
-          ((0 to healthsFromEtcd.maxBy(_.id.toInt).id.toInt).toSet -- healthsFromEtcd.map(_.id.toInt))
+          ((healthsFromEtcd.minBy(_.id.toInt).id.toInt to healthsFromEtcd.maxBy(_.id.toInt).id.toInt).toSet -- healthsFromEtcd.map(_.id.toInt))
             .map(id => new InvokerHealth(InvokerInstanceId(id, Some(id.toString), userMemory = 0 MB), Offline))
       (healthsFromEtcd ++ missingHealths) sortBy (_.id.toInt)
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -627,7 +627,10 @@ class FPCPoolBalancer(config: WhiskConfig,
       val missingHealths =
         if (healthsFromEtcd.isEmpty) Set.empty[InvokerHealth]
         else
-          ((healthsFromEtcd.minBy(_.id.toInt).id.toInt to healthsFromEtcd.maxBy(_.id.toInt).id.toInt).toSet -- healthsFromEtcd.map(_.id.toInt))
+          ((healthsFromEtcd
+            .minBy(_.id.toInt)
+            .id
+            .toInt to healthsFromEtcd.maxBy(_.id.toInt).id.toInt).toSet -- healthsFromEtcd.map(_.id.toInt))
             .map(id => new InvokerHealth(InvokerInstanceId(id, Some(id.toString), userMemory = 0 MB), Offline))
       (healthsFromEtcd ++ missingHealths) sortBy (_.id.toInt)
     }


### PR DESCRIPTION


## Description
With FPC, the list of managed invoker ids is determined by what's in etcd. However the metric reporting and invokers api still assume that 0...n invokers exist up to the max available id in etcd and will auto fill in any missing ids as offline. This is fine for a range to fill in by the current min starting point, but it's not providing any value to assume things start at 0. A cluster could have a monotonically increasing range of ids and potentially if original nodes are lost they shouldn't be assumed to be filled back in at 0.

Further, the current implementation already will not include invokers that are offline at the high end of the pool since the api / metrics just assumes that max id stored in etcd is the max id of the cluster. **Example ten node cluster of 0-9**:

- nodes 8 and 9 are down
- the api will then only return 0-7 as existing since 7 is the max remaining id in etcd once the lease expires for those nodes.

With this change, this applies the same functionality to the low end to account for clusters that don't always re-populate 0-x. 

- nodes 0 and 1 are down
- the api will now return 2-9 as existing since 2 is the min remaining id in etcd


- if node 5 is down in the middle between the min and max, that still will be auto-populated to be down.

**It's also important to note that this change only applies to FPC as the 0-n expectation of invoker ids is more important for the original load balancer algorithm with co-prime hashing.**

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [X] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

