### PR TITLE
update coreos/etcd version to 3.4.33 to unblock build

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -464,7 +464,7 @@ zeroDowntimeDeployment:
   enabled: "{{ zerodowntime_deployment_switch | default(false) }}"
 
 etcd:
-  version: "{{ etcd_version | default('v3.4.0') }}"
+  version: "{{ etcd_version | default('v3.4.33') }}"
   client:
     port: 2379
   server:


### PR DESCRIPTION
quay.io/coreos/etcd:v3.4.0 is 5 years old and is using a deprecated Docker image format.  
