### PR TITLE
Fix packages-public view function

### DIFF
--- a/ansible/files/whisks_design_document_for_entities_db_v2.1.0.json
+++ b/ansible/files/whisks_design_document_for_entities_db_v2.1.0.json
@@ -7,7 +7,7 @@
       "reduce": "_count"
     },
     "packages-public": {
-      "map": "function (doc) {\n  var isPublicPackage = function(doc) { \n    return Object.keys(doc.binding).length == 0 && doc.publish;\n  }\n  if (isPublicPackage(doc)) try {\n    var value = {\n      namespace: doc.namespace,\n      name: doc.name,\n      version: doc.version,\n      publish: doc.publish,\n      annotations: doc.annotations,\n      updated: doc.updated,\n      binding: false\n    };\n    emit([doc.namespace, doc.updated], value);\n  } catch (e) {}\n}",
+      "map": "function (doc) {\n  var isPublicPackage = function(doc) { \n    return doc.binding && doc.publish && Object.keys(doc.binding).length == 0;\n  }\n  if (isPublicPackage(doc)) try {\n    var value = {\n      namespace: doc.namespace,\n      name: doc.name,\n      version: doc.version,\n      publish: doc.publish,\n      annotations: doc.annotations,\n      updated: doc.updated,\n      binding: false\n    };\n    emit([doc.namespace, doc.updated], value);\n  } catch (e) {}\n}",
       "reduce": "_count"
     },
     "packages": {


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->
These changes make whisks.v.2.1/packges-public view function to check whether doc.binding is undfined before getting the length of it. It can prevent from CouchDB producing unnecessary logs.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

When 'packages-public' view builds the index, you can find these logs.

```
[info] 2024-09-07T02:25:38.312234Z nonode@nohost <0.1292.0> -------- OS Process #Port<0.8249> Log :: function raised exception (new TypeError("doc.binding is not an object", "undefined", 3)) with doc._id whisk.system/user25868/TEST
```


I modified 'isPublicPackage' function. I believe that use 'Falsy' because there's no need to check the length of doc.binding when it is not object type. And also, it's better to check Falsy or boolean before than the length of object.  
```javascript
// as-is
var isPublicPackage = functions(doc) {
    return Object.keys(doc.binding).length == 0 && doc.publish;
}

// to-be
var isPublicPackage = functions(doc) {
    return doc.binding && doc.publish && Object.keys(doc.binding).length == 0;
}
```


I confirmed that CouchDB 2.3.1 and 3.3.3 don't  print it out during re-building the index.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#5507 )

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [x] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.