### PR TITLE
Normalize Kafka configuration units to bytes

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -59,7 +59,7 @@ object KafkaMessagingProvider extends MessagingProvider {
     val topicConfig = KafkaConfiguration.configMapToKafkaConfig(
       loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaTopics + "." + topicConfigKey)) ++
       (maxMessageBytes.map { max =>
-        Map(s"max.message.bytes" -> max.size.toString)
+        Map(s"max.message.bytes" -> max.toBytes.toString)
       } getOrElse Map.empty)
 
     val commonConfig = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon))

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaMessagingProvider.scala
@@ -59,7 +59,7 @@ object KafkaMessagingProvider extends MessagingProvider {
     val topicConfig = KafkaConfiguration.configMapToKafkaConfig(
       loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaTopics + "." + topicConfigKey)) ++
       (maxMessageBytes.map { max =>
-        Map(s"max.message.bytes" -> max.toBytes.toString)
+        Map("max.message.bytes" -> max.toBytes.toString)
       } getOrElse Map.empty)
 
     val commonConfig = configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon))

--- a/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/connector/kafka/KafkaProducerConnector.scala
@@ -108,7 +108,7 @@ class KafkaProducerConnector(
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaCommon)) ++
       configMapToKafkaConfig(loadConfigOrThrow[Map[String, String]](ConfigKeys.kafkaProducer)) ++
       (maxRequestSize map { max =>
-        Map("max.request.size" -> max.size.toString)
+        Map("max.request.size" -> max.toBytes.toString)
       } getOrElse Map.empty)
 
     verifyConfig(config, ProducerConfig.configNames().asScala.toSet)


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

Normalize Kafka configuration units to bytes for message and request size parameters.

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->


Kafka configuration units related to size are in bytes. However, ByteSize supports various units. I believe it's better to normalize the unit to bytes to help reduce human errors.

For example, if max-message-bytes is set with an MB unit, the topic configuration could mistakenly interpret it as 3 bytes instead of 3 MB:
```
// application.conf
whisk {
  kafka {
     ...
     events {
                segment-bytes   =  536870912
                retention-bytes = 1073741824
                retention-ms    = 3600000
                max-message-bytes = 3 m
            }
```

Currently, several topics set max.message.bytes as `${whisk.activation.kafka.payload.max} + ${whisk.activation.kafka.serdes-overhead}`. Fortunately, this ensures the unit remains in bytes when summing the two values.

Despite this, I believe normalizing the unit to bytes will help prevent unexpected bugs.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [x] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

