### PR TITLE
Use separate dispatchers for MemoryQueue, QueueManager, and Akka heartbeat

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -41,6 +41,26 @@ akka.http {
         preview.enable-http2 = on
         parsing.illegal-header-warnings = off
     }
+
+    cluster {
+        use-dispatcher = "dispatchers.heartbeat-dispatcher"
+        failure-detector {
+            # How often keep-alive heartbeat messages should be sent to each connection.
+            heartbeat-interval = 1s
+
+            # Number of potentially lost/delayed heartbeats that will be
+            # accepted before considering it to be an anomaly.
+            # This margin is important to be able to survive sudden, occasional,
+            # pauses in heartbeat arrivals, due to for example garbage collect or
+            # network drop.
+            acceptable-heartbeat-pause = 5s
+
+            # After the heartbeat request has been sent the first failure detection
+            # will start after this period, even though no heartbeat message has
+            # been received.
+            expected-response-after = 1s
+        }
+    }
 }
 
 #kamon related configuration
@@ -72,7 +92,7 @@ kamon {
       service = "openwhisk-statsd"
     }
     metric {
-        tick-interval = 1 second
+        tick-interval = 10 second
     }
 
     statsd {

--- a/common/scala/src/main/resources/reference.conf
+++ b/common/scala/src/main/resources/reference.conf
@@ -86,4 +86,17 @@ dispatchers {
     type = PinnedDispatcher
     executor = "thread-pool-executor"
   }
+
+  # This is for akka-cluster heartbeat. Since heartbeat is a periodic light-weight message,
+  # fork-join executor should be enough
+  heartbeat-dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 2
+      parallelism-factor = 2.0
+      parallelism-max = 10
+    }
+    throughput = 100
+  }
 }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/loadBalancer/FPCPoolBalancer.scala
@@ -65,7 +65,7 @@ class FPCPoolBalancer(config: WhiskConfig,
 
   private implicit val executionContext: ExecutionContext = actorSystem.dispatcher
   // This value is given according to the total waiting time at QueueManager for a new queue to be created.
-  private implicit val requestTimeout: Timeout = Timeout(8.seconds)
+  private implicit val requestTimeout: Timeout = Timeout(1.seconds)
 
   private val entityStore = WhiskEntityStore.datastore()
 

--- a/core/scheduler/src/main/resources/reference.conf
+++ b/core/scheduler/src/main/resources/reference.conf
@@ -1,0 +1,37 @@
+dispatchers {
+  # A custom dispatcher for the queue manager
+  queue-manager-dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 1
+      parallelism-factor = 1
+      parallelism-max = 15
+    }
+    throughput = 5
+  }
+
+  # A custom dispatcher for memory queues.
+  memory-queue-dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 10
+      parallelism-factor = 2
+      parallelism-max = 60
+    }
+    throughput = 5
+  }
+
+  # A custom dispatcher for monitoring actors of memory queues.
+  monitoring-dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 10
+      parallelism-factor = 2
+      parallelism-max = 60
+    }
+    throughput = 5
+  }
+}

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/Scheduler.scala
@@ -47,7 +47,6 @@ import org.apache.openwhisk.core.{ConfigKeys, WhiskConfig}
 import org.apache.openwhisk.grpc.ActivationServiceHandler
 import org.apache.openwhisk.http.BasicHttpService
 import org.apache.openwhisk.spi.SpiLoader
-import org.apache.openwhisk.utils.ExecutionContextFactory
 import pureconfig.generic.auto._
 import pureconfig.loadConfigOrThrow
 import spray.json.{DefaultJsonProtocol, _}
@@ -287,9 +286,8 @@ object Scheduler {
   }
 
   def main(args: Array[String]): Unit = {
-    implicit val ec = ExecutionContextFactory.makeCachedThreadPoolExecutionContext()
-    implicit val actorSystem: ActorSystem =
-      ActorSystem(name = "scheduler-actor-system", defaultExecutionContext = Some(ec))
+    implicit val actorSystem: ActorSystem = ActorSystem("scheduler-actor-system")
+    implicit val ec = actorSystem.dispatcher
 
     implicit val logger = new AkkaLogging(akka.event.Logging.getLogger(actorSystem, this))
 

--- a/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/QueueManager.scala
+++ b/core/scheduler/src/main/scala/org/apache/openwhisk/core/scheduler/queue/QueueManager.scala
@@ -91,7 +91,7 @@ class QueueManager(
   private val leaderElectionCallbacks = TrieMap[String, (Either[EtcdFollower, EtcdLeader], Boolean) => Unit]()
 
   private implicit val askTimeout = Timeout(5.seconds)
-  private implicit val ec = context.dispatcher
+  private implicit val ec = context.system.dispatchers.lookup("dispatchers.queue-manager-dispatcher")
   private implicit val system = context.system
 
   private val watcherName = "queue-manager"


### PR DESCRIPTION
This is to make the system more stable. There are generally many numbers of queues running in a scheduler.
One queue will spawn multiple actors, and there will be a huge number of actors.
There are some critical actors to maintain the sanity of the system like akka-heartbeat.
This change will ensure isolating the performance impact of memory queues and guaranteeing the akka-heartbeat is not being starved.


## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [x] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [x] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

