### PR TITLE
upgrade etcd java to latest version

### DIFF
--- a/common/scala/build.gradle
+++ b/common/scala/build.gradle
@@ -145,6 +145,51 @@ dependencies {
     api "io.netty:netty-transport-native-epoll:${gradle.netty.version}"
     api "io.netty:netty-transport-native-unix-common:${gradle.netty.version}"
     api "com.lightbend.akka.grpc:akka-grpc-runtime_${gradle.scala.depVersion}:${gradle.akka_gprc.version}"
+    constraints {
+        api("com.lightbend.akka.grpc:akka-grpc-runtime_${gradle.scala.depVersion}:${gradle.akka_gprc.version}")
+        api("io.grpc:grpc-api:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-core:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-netty:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-netty-shaded:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-stub:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-protobuf:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+        api("io.grpc:grpc-protobuf-lite:${gradle.grpc.version}") {
+            version {
+                strictly gradle.grpc.version
+            }
+            because "Akka gRPC runtime 1.0.2 requires gRPC 1.32.1"
+        }
+    }
     api "com.typesafe.akka:akka-stream_${gradle.scala.depVersion}:${gradle.akka.version}"
 
     // Constraints for transitive dependencies to address security vulnerabilities

--- a/settings.gradle
+++ b/settings.gradle
@@ -104,6 +104,8 @@ gradle.ext.akka_http = [version : '10.2.7']
 gradle.ext.akka_management = [version : '1.0.10']
 gradle.ext.akka_gprc = [version : '1.0.2']
 
+gradle.ext.grpc = [version : '1.32.1']
+
 gradle.ext.curator = [version : '4.3.0']
 gradle.ext.kube_client = [version: '4.10.3']
 


### PR DESCRIPTION
## Description
this works now by making sure all grpc related dependencies are pinned to the same version to match akka. this is another dependency preparation for the pekko migration.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [X] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [X] Scheduler
- [X] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

