### PR TITLE
handle pekko deprecations

### DIFF
--- a/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/containerpool/logging/DockerToActivationFileLogStore.scala
@@ -174,7 +174,7 @@ object OwSink {
    */
   def combine[T, U, M1, M2](first: Sink[U, M1], second: Sink[U, M2])(
     strategy: Int => Graph[UniformFanOutShape[T, U], NotUsed]): Sink[T, (M1, M2)] = {
-    Sink.fromGraph(GraphDSL.create(first, second)((_, _)) { implicit b => (s1, s2) =>
+    Sink.fromGraph(GraphDSL.createGraph(first, second)((_, _)) { implicit b => (s1, s2) =>
       import GraphDSL.Implicits._
       val d = b.add(strategy(2))
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/Batcher.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/Batcher.scala
@@ -64,7 +64,7 @@ class Batcher[T, R](batchSize: Int, concurrency: Int, retry: Int)(operation: (Se
       completionMatcher = cm,
       failureMatcher = PartialFunction.empty[Any, Throwable],
       bufferSize = Int.MaxValue,
-      overflowStrategy = OverflowStrategy.dropNew)
+      overflowStrategy = OverflowStrategy.dropBuffer)
     .batch(batchSize, Queue(_))((queue, element) => queue :+ element)
     .mapAsyncUnordered(concurrency) { els =>
       val elements = els.map(_._1)

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/StoreUtils.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/StoreUtils.scala
@@ -84,7 +84,7 @@ private[database] object StoreUtils {
 
   def combinedSink[T](dest: Sink[ByteString, Future[T]])(
     implicit ec: ExecutionContext): Sink[ByteString, Future[AttachmentUploadResult[T]]] = {
-    Sink.fromGraph(GraphDSL.create(digestSink(), lengthSink(), dest)(combineResult) {
+    Sink.fromGraph(GraphDSL.createGraph(digestSink(), lengthSink(), dest)(combineResult) {
       implicit builder => (dgs, ls, dests) =>
         import GraphDSL.Implicits._
 

--- a/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
+++ b/common/scala/src/main/scala/org/apache/openwhisk/core/database/azblob/AzureBlobAttachmentStore.scala
@@ -299,7 +299,7 @@ class AzureBlobAttachmentStore(client: BlobContainerAsyncClient, prefix: String,
       case None =>
         blobClient.exists().toFuture.toScala.map { exists =>
           if (exists) {
-            val bbFlux = blobClient.download()
+            val bbFlux = blobClient.downloadStream()
             Some(Source.fromPublisher(bbFlux).map(ByteString.fromByteBuffer))
           } else {
             throw NoDocumentException("Not found on 'readAttachment'.")

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Actions.scala
@@ -316,7 +316,7 @@ trait WhiskActionsApi extends WhiskCollectionAPI with PostActionActivation with 
         }
       case Failure(t: RecordTooLargeException) =>
         logging.debug(this, s"[POST] action payload was too large")
-        terminate(PayloadTooLarge)
+        terminate(ContentTooLarge)
       case Failure(RejectRequest(code, message)) =>
         logging.debug(this, s"[POST] action rejected with code $code: $message")
         terminate(code, message)

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Entities.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Entities.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.Try
 import org.apache.pekko.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import org.apache.pekko.http.scaladsl.model.StatusCodes.PayloadTooLarge
+import org.apache.pekko.http.scaladsl.model.StatusCodes.ContentTooLarge
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
 import org.apache.pekko.http.scaladsl.server.Directive0
 import org.apache.pekko.http.scaladsl.server.Directives
@@ -45,7 +45,7 @@ protected[controller] trait ValidateRequestSize extends Directives {
     new Directive0 {
       override def tapply(f: Unit => Route) = {
         check map {
-          case e: SizeError => terminate(PayloadTooLarge, Messages.entityTooBig(e))
+          case e: SizeError => terminate(ContentTooLarge, Messages.entityTooBig(e))
         } getOrElse f(None)
       }
     }

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/controller/Packages.scala
@@ -336,7 +336,7 @@ trait WhiskPackagesApi extends WhiskCollectionAPI with ReferencedEntities {
         logging.debug(this, s"fetching package '$docid' for reference")
         if (docid == wp.docid) {
           logging.error(this, s"unexpected package binding refers to itself: $docid")
-          terminate(UnprocessableEntity, Messages.packageBindingCircularReference(b.fullyQualifiedName.toString))
+          terminate(UnprocessableContent, Messages.packageBindingCircularReference(b.fullyQualifiedName.toString))
         } else {
 
           /** Here's where I check package execute only case with package binding. */

--- a/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
+++ b/core/controller/src/main/scala/org/apache/openwhisk/core/entitlement/PackageCollection.scala
@@ -102,7 +102,7 @@ class PackageCollection(entityStore: EntityStore)(implicit logging: Logging) ext
             logging.error(this, s"unexpected package binding refers to itself: $doc")
             Future.failed(
               RejectRequest(
-                UnprocessableEntity,
+                UnprocessableContent,
                 Messages.packageBindingCircularReference(binding.fullyQualifiedName.toString)))
           } else {
             checkPackageReadPermission(namespaces, pkgOwner, pkgDocid)

--- a/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
+++ b/core/invoker/src/main/scala/org/apache/openwhisk/core/containerpool/v2/FunctionPullingContainerProxy.scala
@@ -20,7 +20,7 @@ package org.apache.openwhisk.core.containerpool.v2
 import java.net.InetSocketAddress
 import java.time.Instant
 import org.apache.pekko.actor.Status.{Failure => FailureMessage}
-import org.apache.pekko.actor.{actorRef2Scala, ActorRef, ActorRefFactory, ActorSystem, FSM, Props, Stash}
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, FSM, Props, Stash}
 import org.apache.pekko.event.Logging.InfoLevel
 import org.apache.pekko.io.{IO, Tcp}
 import org.apache.pekko.pattern.pipe

--- a/settings.gradle
+++ b/settings.gradle
@@ -78,9 +78,7 @@ if (scalaVersion == '2.12') {
             depVersion  : '2.12',
             scoverageScalaVersion : '2.12.15',
             scoverageVersion : '1.4.11',
-            // Temporarily disabled -Xfatal-warnings during Pekko migration to allow deprecated API usage
-            // BEFORE READY: Fix deprecation warnings and re-enable -Xfatal-warnings
-            compileFlags: ['-feature', '-unchecked', '-deprecation', '-Ywarn-unused-import']
+            compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
     ]
 } else {
     println("Build using Scala 2.13")

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/ActionsApiTests.scala
@@ -484,7 +484,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val exec: Exec = jsDefault(code)
     val content = JsObject("exec" -> exec.toJson)
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
       }
@@ -513,7 +513,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val content = JsObject("exec" -> exec.toJson)
     put(entityStore, action)
     Put(s"$collectionPath/${action.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskAction.execFieldName, exec.size, Exec.sizeLimit))
       }
@@ -529,7 +529,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     } reduce (_ ++ _)
     val content = s"""{"exec":{"kind":"nodejs:default","code":"??"},"parameters":$parameters}""".stripMargin
     Put(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
       }
@@ -558,7 +558,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     val content = s"""{"exec":{"kind":"nodejs:default","code":"??"},"parameters":$parameters}""".stripMargin
     Put(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(credsWithLimits)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, namespaceLimit))
       }
@@ -574,7 +574,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     } reduce (_ ++ _)
     val content = s"""{"exec":{"kind":"nodejs:default","code":"??"},"annotations":$annotations}""".stripMargin
     Put(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
       }
@@ -603,7 +603,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
 
     val content = s"""{"exec":{"kind":"nodejs:default","code":"??"},"annotations":$annotations}""".stripMargin
     Put(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(credsWithLimits)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, namespaceLimit))
       }
@@ -971,7 +971,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val code = "a" * (systemPayloadLimit.toBytes.toInt + 1)
     val content = s"""{"a":"$code"}""".stripMargin
     Post(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(fieldDescriptionForSizeError, (content.length).B, systemPayloadLimit.toBytes.B))
       }
@@ -983,7 +983,7 @@ class ActionsApiTests extends ControllerTestCommon with WhiskActionsApi {
     val code = "a" * (namespacePayloadLimit.toBytes.toInt + 1)
     val content = s"""{"a":"$code"}""".stripMargin
     Post(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(credsWithPayloadLimit)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(
           SizeError(fieldDescriptionForSizeError, (content.length).B, namespacePayloadLimit.toBytes.B))

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/PackagesApiTests.scala
@@ -591,7 +591,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     } reduce (_ ++ _)
     val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
       }
@@ -607,7 +607,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     } reduce (_ ++ _)
     val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
       }
@@ -625,7 +625,7 @@ class PackagesApiTests extends ControllerTestCommon with WhiskPackagesApi {
     val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
     put(entityStore, provider)
     Put(s"$collectionPath/${aname()}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/RulesApiTests.scala
@@ -526,7 +526,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       val t = get(entityStore, trigger.docid, WhiskTrigger)
       deleteTrigger(t.docid)
 
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
       }
@@ -556,7 +556,7 @@ class RulesApiTests extends ControllerTestCommon with WhiskRulesApi {
       val t = get(entityStore, trigger.docid, WhiskTrigger)
       deleteTrigger(t.docid)
 
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/TriggersApiTests.scala
@@ -273,7 +273,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val code = "a" * (systemPayloadLimit.toBytes.toInt + 1)
     val content = s"""{"a":"$code"}""".stripMargin
     Post(s"$collectionPath/${aname()}", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(fieldDescriptionForSizeError, (content.length).B, systemPayloadLimit.toBytes.B))
       }
@@ -289,7 +289,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     } reduce (_ ++ _)
     val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
       }
@@ -305,7 +305,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     } reduce (_ ++ _)
     val content = s"""{"annotations":$annotations}""".parseJson.asJsObject
     Put(s"$collectionPath/${aname()}", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.annotationsFieldName, annotations.size, Parameters.sizeLimit))
       }
@@ -323,7 +323,7 @@ class TriggersApiTests extends ControllerTestCommon with WhiskTriggersApi {
     val content = s"""{"parameters":$parameters}""".parseJson.asJsObject
     put(entityStore, trigger)
     Put(s"$collectionPath/${trigger.name}?overwrite=true", content) ~> Route.seal(routes(creds)) ~> check {
-      status should be(PayloadTooLarge)
+      status should be(ContentTooLarge)
       responseAs[String] should include {
         Messages.entityTooBig(SizeError(WhiskEntity.paramsFieldName, parameters.size, Parameters.sizeLimit))
       }

--- a/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/controller/test/WebActionsApiTests.scala
@@ -1524,7 +1524,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
 
         val content = s"""{"a":"$largeEntity"}"""
         Post(s"$testRoutePath/$path", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-          status should be(PayloadTooLarge)
+          status should be(ContentTooLarge)
           val expectedErrorMsg = Messages.entityTooBig(
             // must contains namespace's payload limit size in error message
             SizeError(fieldDescriptionForSizeError, (largeEntity.length + 8).B, namespacePayloadLimit.toBytes.B))
@@ -1533,7 +1533,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
 
         val form = FormData(Map("a" -> largeEntity))
         Post(s"$testRoutePath/$path", form) ~> Route.seal(routes(creds)) ~> check {
-          status should be(PayloadTooLarge)
+          status should be(ContentTooLarge)
           val expectedErrorMsg = Messages.entityTooBig(
             // must contains namespace's payload limit size in error message
             SizeError(fieldDescriptionForSizeError, (largeEntity.length + 2).B, namespacePayloadLimit.toBytes.B))
@@ -1568,7 +1568,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
 
         val content = s"""{"a":"$largeEntity"}"""
         Post(s"$testRoutePath/$path", content.parseJson.asJsObject) ~> Route.seal(routes(creds)) ~> check {
-          status should be(PayloadTooLarge)
+          status should be(ContentTooLarge)
           val expectedErrorMsg = Messages.entityTooBig(
             SizeError(fieldDescriptionForSizeError, (largeEntity.length + 8).B, namespacePayloadLimit.toBytes.B))
           confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))
@@ -1576,7 +1576,7 @@ trait WebActionsApiBaseTests extends ControllerTestCommon with BeforeAndAfterEac
 
         val form = FormData(Map("a" -> largeEntity))
         Post(s"$testRoutePath/$path", form) ~> Route.seal(routes(creds)) ~> check {
-          status should be(PayloadTooLarge)
+          status should be(ContentTooLarge)
           val expectedErrorMsg = Messages.entityTooBig(
             SizeError(fieldDescriptionForSizeError, (largeEntity.length + 2).B, namespacePayloadLimit.toBytes.B))
           confirmErrorWithTid(responseAs[JsObject], Some(expectedErrorMsg))

--- a/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
+++ b/tests/src/test/scala/org/apache/openwhisk/core/limits/ActionLimitsTests.scala
@@ -17,7 +17,7 @@
 
 package org.apache.openwhisk.core.limits
 
-import org.apache.pekko.http.scaladsl.model.StatusCodes.PayloadTooLarge
+import org.apache.pekko.http.scaladsl.model.StatusCodes.ContentTooLarge
 import org.apache.pekko.http.scaladsl.model.StatusCodes.BadGateway
 import java.io.File
 import java.io.PrintWriter
@@ -368,7 +368,7 @@ class ActionLimitsTests extends TestHelpers with WskTestHelpers with WskActorSys
     pw.close
 
     assetHelper.withCleaner(wsk.action, name, confirmDelete = false) { (action, _) =>
-      action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = PayloadTooLarge.intValue)
+      action.create(name, Some(actionCode.getAbsolutePath), expectedExitCode = ContentTooLarge.intValue)
     }
 
     actionCode.delete


### PR DESCRIPTION
## Description
handles deprecations going to pekko added in later akka 2.6 and pekko 1.1. changes are done such that there are no behavior changes.

The status code enum change is just in name, it still represents the same status code.

## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [ ] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:

- [X] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [X] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

