### PR TITLE
Fix typo in application.conf comment

### DIFF
--- a/common/scala/src/main/resources/application.conf
+++ b/common/scala/src/main/resources/application.conf
@@ -321,7 +321,7 @@ whisk {
                 # Sets the maximum number of retries in the case where the request fails
                 # because the service has applied rate limiting on the client.
 
-                # If this value is changed then adjust the buckets under `kamon.prometehus`
+                # If this value is changed then adjust the buckets under `kamon.prometheus`
                 max-retry-attempts-on-throttled-requests = 9
 
                 # Sets the maximum retry time


### PR DESCRIPTION
## Description
Fixes a single-character typo in a HOCON comment in `common/scala/src/main/resources/application.conf`: `kamon.prometehus` -> `kamon.prometheus`. The actual config block (line 96) is named `prometheus`, so the comment reference is now consistent with the real path. Comment-only change, no behavior impact.

## Related issue and scope
- [ ] I opened an issue to propose and discuss this change (#????)

## My changes affect the following components
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [ ] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.