### PR TITLE
Make action container tests resolve container IP on Docker Engine v29+

### DIFF
--- a/tests/src/test/scala/actionContainers/ActionContainer.scala
+++ b/tests/src/test/scala/actionContainers/ActionContainer.scala
@@ -220,7 +220,9 @@ object ActionContainer {
       } else {
         // not "mac" i.e., docker-for-mac, use direct container IP directly (this is OK for Ubuntu, and docker-machine)
         createContainer()
-        val ipOut = awaitDocker(s"""inspect --format '{{.NetworkSettings.IPAddress}}' $name""", 10.seconds)
+        val ipOut = awaitDocker(
+          s"""inspect --format '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $name""",
+          10.seconds)
         assert(ipOut._1 == 0, "'docker inspect did not exit with 0")
         (ipOut._2.replaceAll("""[^0-9.]""", ""), 8080)
       }


### PR DESCRIPTION
<!--- Provide a concise summary of your changes in the Title -->

## Description
<!--- Provide a detailed description of your changes. -->
<!--- Include details of what problem you are solving and how your changes are tested. -->

`ActionContainer.withContainer` discovers a freshly started action container's IP with
`docker inspect --format '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'`. Because the top-level network properties of `NetworkSettings` were removed in Docker Engine `v29.0.0` (API `v1.52`).

`range` is used rather than hard-coding `.Networks.bridge.IPAddress` so the lookup does not assume a
network name. Containers created by `createContainer()` are started without `--network` and therefore
join exactly one network, so the range yields a single address.


## Related issue and scope
<!--- Please include a link to a related issue if there is one. -->
- [x] I opened an issue to propose and discuss this change (#5582)

## My changes affect the following components
<!--- Select below all system components are affected by your change. -->
<!--- Enter an `x` in all applicable boxes. -->
- [ ] API
- [ ] Controller
- [ ] Message Bus (e.g., Kafka)
- [ ] Loadbalancer
- [ ] Scheduler
- [ ] Invoker
- [ ] Intrinsic actions (e.g., sequences, conductors)
- [ ] Data stores (e.g., CouchDB)
- [x] Tests
- [ ] Deployment
- [ ] CLI
- [ ] General tooling
- [ ] Documentation

## Types of changes
<!--- What types of changes does your code introduce? Use `x` in all the boxes that apply: -->
- [x] Bug fix (generally a non-breaking change which closes an issue).
- [ ] Enhancement or new feature (adds new functionality).
- [ ] Breaking change (a bug fix or enhancement which changes existing behavior).

## Checklist:
<!--- Please review the points below which help you make sure you've covered all aspects of the change you're making. -->

- [x] I signed an [Apache CLA](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [style guides](https://github.com/apache/openwhisk/blob/master/CONTRIBUTING.md#coding-standards) and followed the recommendations (Travis CI will check :).
- [ ] I added tests to cover my changes.
- [ ] My changes require further changes to the documentation.
- [ ] I updated the documentation where necessary.

